### PR TITLE
docs: Codex CLI 최소 문서 기반 호환 가이드 추가

### DIFF
--- a/.codex-plugin.md
+++ b/.codex-plugin.md
@@ -34,6 +34,15 @@ opencode와 동일한 env var를 그대로 사용한다.
 - `AGENT_TOOLKIT_CACHE_DIR`
 - `AGENT_TOOLKIT_CACHE_TTL`
 
+## Context7 MCP 설정
+
+Codex에서 context7 MCP를 바로 붙일 수 있게 `.codex/mcp.json`을 추가했다.
+
+- 파일: `.codex/mcp.json`
+- 서버: `context7` (`https://mcp.context7.com/mcp`)
+
+호스트별 MCP 로딩 방식이 다를 수 있으므로, Codex 실행 환경에서 이 파일을 MCP 설정으로 참조하도록 연결해 사용한다.
+
 ## 제한
 
 - Codex 호스트에 대한 자동 plugin 등록(`config` 훅 등)은 제공하지 않는다.

--- a/.codex-plugin.md
+++ b/.codex-plugin.md
@@ -1,6 +1,6 @@
 # Codex plugin (experimental)
 
-이 저장소는 기본적으로 opencode plugin 구조를 따르지만, Codex CLI에서도 동일한 Notion 컨텍스트 흐름을 **작게** 재사용할 수 있게 최소 가이드를 제공한다.
+이 저장소는 기본적으로 opencode plugin 구조를 따르지만, Codex CLI/데스크탑에서도 동일한 Notion 컨텍스트 흐름을 **작게** 재사용할 수 있게 최소 가이드를 제공한다.
 
 ## 목표
 
@@ -12,9 +12,18 @@
 1. Codex가 읽는 작업 디렉터리에서 아래 파일들을 참조(복사/심볼릭 링크)한다.
    - `skills/notion-context/SKILL.md`
    - `agents/rocky.md`
-2. 세션 시작 시 다음 규칙을 명시한다.
+2. 세션 시작 시(또는 프로젝트 기본 지침 파일에) 다음 규칙을 명시한다.
    - Notion 조회는 `notion_get`, `notion_refresh`, `notion_status` 도구 계약을 따른다.
    - 스펙 정리는 `skills/notion-context/SKILL.md`의 출력 포맷을 따른다.
+
+
+## Codex 데스크탑 사용 가능 여부
+
+가능하다. 다만 CLI와 동일하게 **자동 plugin 로딩은 없고 수동 연결 방식**이다.
+
+- 데스크탑에서 이 저장소를 워크스페이스(프로젝트)로 연다.
+- 프로젝트 지침(예: AGENTS.md 또는 세션 지시)에 `notion_get`/`notion_refresh`/`notion_status` 계약과 `skills/notion-context/SKILL.md` 출력 규칙을 명시한다.
+- 필요 시 `agents/rocky.md`를 함께 참조해 라우팅 힌트를 준다.
 
 ## 환경변수
 

--- a/.codex-plugin.md
+++ b/.codex-plugin.md
@@ -1,0 +1,31 @@
+# Codex plugin (experimental)
+
+이 저장소는 기본적으로 opencode plugin 구조를 따르지만, Codex CLI에서도 동일한 Notion 컨텍스트 흐름을 **작게** 재사용할 수 있게 최소 가이드를 제공한다.
+
+## 목표
+
+- opencode 전용 런타임/코드는 유지한다.
+- Codex에서는 플러그인 자동 로딩 대신, 기존 자산(`skills/notion-context/SKILL.md`, `agents/rocky.md`)을 수동 연결해 사용한다.
+
+## 빠른 연결 방법
+
+1. Codex가 읽는 작업 디렉터리에서 아래 파일들을 참조(복사/심볼릭 링크)한다.
+   - `skills/notion-context/SKILL.md`
+   - `agents/rocky.md`
+2. 세션 시작 시 다음 규칙을 명시한다.
+   - Notion 조회는 `notion_get`, `notion_refresh`, `notion_status` 도구 계약을 따른다.
+   - 스펙 정리는 `skills/notion-context/SKILL.md`의 출력 포맷을 따른다.
+
+## 환경변수
+
+opencode와 동일한 env var를 그대로 사용한다.
+
+- `AGENT_TOOLKIT_NOTION_MCP_URL`
+- `AGENT_TOOLKIT_NOTION_MCP_TIMEOUT_MS`
+- `AGENT_TOOLKIT_CACHE_DIR`
+- `AGENT_TOOLKIT_CACHE_TTL`
+
+## 제한
+
+- Codex 호스트에 대한 자동 plugin 등록(`config` 훅 등)은 제공하지 않는다.
+- 즉, 이 지원은 "문서 기반 최소 호환"이다.

--- a/.codex/mcp.json
+++ b/.codex/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -67,3 +67,11 @@ opencode 를 띄운 뒤:
 OmO 같이 자체 primary agent (Sisyphus 등) 를 쓰는 환경에선, primary 가 turn 시작 시 받는 subagent 목록에서 `rocky` 의 description 을 보고 Notion 관련 요청을 자동으로 위임한다 (보장은 안 됨 — primary 가 직접 처리하기로 결정할 수도 있음). Rocky 의 존재를 OmO 측 system prompt 에 박을 필요는 없다.
 
 plugin 이 미등록이거나 `agents.paths` 가 인식되지 않는 opencode 버전이면, 프로젝트의 `.opencode/agents/rocky.md` 로 직접 심볼릭 링크하거나 복사해서 쓴다.
+
+## Codex CLI 최소 호환 (선택)
+
+opencode 외 환경에서도 같은 Notion 컨텍스트 자산을 쓰고 싶다면, 문서 기반 최소 호환 가이드를 따른다.
+
+- [`.codex-plugin.md`](../.codex-plugin.md)
+
+주의: Codex는 현재 이 저장소의 opencode `config` 훅을 자동 실행하지 않으므로, skill/agent 연결은 수동으로 해야 한다.

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -68,7 +68,7 @@ OmO 같이 자체 primary agent (Sisyphus 등) 를 쓰는 환경에선, primary 
 
 plugin 이 미등록이거나 `agents.paths` 가 인식되지 않는 opencode 버전이면, 프로젝트의 `.opencode/agents/rocky.md` 로 직접 심볼릭 링크하거나 복사해서 쓴다.
 
-## Codex CLI 최소 호환 (선택)
+## Codex CLI/데스크탑 최소 호환 (선택)
 
 opencode 외 환경에서도 같은 Notion 컨텍스트 자산을 쓰고 싶다면, 문서 기반 최소 호환 가이드를 따른다.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 └── README.md
 ```
 
-> 다른 host 호환은 기본적으로 후속 작업이지만, **Codex CLI는 최소 문서 기반 호환**을 추가했다. 자세한 내용은 [`.codex-plugin.md`](./.codex-plugin.md) 참고. (자동 plugin 로딩은 아직 미지원)
+> 다른 host 호환은 기본적으로 후속 작업이지만, **Codex CLI/데스크탑은 최소 문서 기반 호환**을 추가했다. 자세한 내용은 [`.codex-plugin.md`](./.codex-plugin.md) 참고. (자동 plugin 로딩은 아직 미지원)
 
 ## 설치 / 사용
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 └── README.md
 ```
 
-> 다른 host (Claude Code, Cursor, Codex CLI) 호환은 후속 작업 — 필요 시 Superpowers 처럼 `.claude-plugin/`, `.cursor-plugin/` 디렉터리를 추가하면 된다. 지금은 opencode 전용.
+> 다른 host 호환은 기본적으로 후속 작업이지만, **Codex CLI는 최소 문서 기반 호환**을 추가했다. 자세한 내용은 [`.codex-plugin.md`](./.codex-plugin.md) 참고. (자동 plugin 로딩은 아직 미지원)
 
 ## 설치 / 사용
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 └── README.md
 ```
 
-> 다른 host 호환은 기본적으로 후속 작업이지만, **Codex CLI/데스크탑은 최소 문서 기반 호환**을 추가했다. 자세한 내용은 [`.codex-plugin.md`](./.codex-plugin.md) 참고. (자동 plugin 로딩은 아직 미지원)
+> 다른 host 호환은 기본적으로 후속 작업이지만, **Codex CLI/데스크탑은 최소 문서 기반 호환**을 추가했다. 자세한 내용은 [`.codex-plugin.md`](./.codex-plugin.md) 참고. (`.codex/mcp.json`에 context7 MCP 예시 포함, 자동 plugin 로딩은 아직 미지원)
 
 ## 설치 / 사용
 


### PR DESCRIPTION
### Motivation

- Codex CLI 환경에서도 기존 Notion 컨텍스트 자산을 작게 재사용할 수 있도록 문서 기반 최소 호환 가이드를 제공하기 위함입니다.

### Description

- 새 파일 `./.codex-plugin.md`를 추가해 Codex에서 `skills/notion-context/SKILL.md`와 `agents/rocky.md`를 수동으로 연결하는 사용법과 제한사항을 정리했습니다.
- `README.md`의 호스트 호환 설명을 업데이트해 Codex 최소 지원을 명시하고 관련 가이드를 링크하도록 변경했습니다.
- `.opencode/INSTALL.md`에 `Codex CLI 최소 호환` 섹션을 추가해 설치/사용 안내와 주의사항을 연결했습니다.

### Testing

- `bun test`를 실행해 단위 테스트가 통과했으며 결과는 `12 pass`입니다.
- `bun run typecheck`는 의존성(타입 정의) 설치 전제로 실패했고, 로컬에서의 `bun install`은 외부 레지스트리 접근(`403`)으로 인해 진행되지 않아 타입체크를 완료하지 못했습니다.
- 문서 변경만으로 코드 동작에는 영향이 없으므로 단위 테스트는 성공 상태입니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f23c524483299f8f8c35fb01389f)