### PR TITLE
feat(phase4): OpenAPI cache + endpoint search + openapi-client skill (closes #6)

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -25,9 +25,12 @@
 | 변수 | 기본값 | 설명 |
 | --- | --- | --- |
 | `AGENT_TOOLKIT_NOTION_MCP_URL` | `https://mcp.notion.com/mcp` | remote Notion MCP base URL. 인증은 OAuth 가 처리하므로 토큰 변수는 없다. |
-| `AGENT_TOOLKIT_NOTION_MCP_TIMEOUT_MS` | `15000` | remote 호출 timeout (ms) |
-| `AGENT_TOOLKIT_CACHE_DIR` | `~/.cache/notion-context/pages` | 페이지 캐시 디렉터리 |
-| `AGENT_TOOLKIT_CACHE_TTL` | `86400` | 캐시 TTL (초) |
+| `AGENT_TOOLKIT_NOTION_MCP_TIMEOUT_MS` | `15000` | remote Notion 호출 timeout (ms) |
+| `AGENT_TOOLKIT_CACHE_DIR` | `~/.config/opencode/agent-toolkit/notion-pages` | Notion 페이지 캐시 디렉터리 |
+| `AGENT_TOOLKIT_CACHE_TTL` | `86400` | Notion 캐시 TTL (초) |
+| `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` | `~/.config/opencode/agent-toolkit/openapi-specs` | OpenAPI / Swagger spec 캐시 디렉터리 |
+| `AGENT_TOOLKIT_OPENAPI_CACHE_TTL` | `86400` | OpenAPI 캐시 TTL (초) |
+| `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS` | `30000` | OpenAPI spec 다운로드 timeout (ms) |
 
 ## 동작 확인
 
@@ -37,16 +40,18 @@ opencode 를 띄운 뒤:
 > use skill tool to list skills
 ```
 
-목록에 `notion-context` 가 보이면 skill 로딩 OK.
+목록에 `notion-context` / `openapi-client` 가 둘 다 보이면 skill 로딩 OK.
 
 도구 등록도 확인:
 
 ```
 > use notion_status tool with input "<pageId or url>"
 > use notion_get tool with input "<pageId or url>"
+> use swagger_status tool with input "<spec URL>"
+> use swagger_get tool with input "<spec URL>"
 ```
 
-첫 호출은 `fromCache: false` 로 remote 가 한 번 불리고, 두 번째 호출은 `fromCache: true` 가 되어야 한다.
+첫 호출은 `fromCache: false` 로 remote 가 한 번 불리고, 두 번째 호출은 `fromCache: true` 가 되어야 한다 (`notion_*` / `swagger_*` 둘 다 동일 정책).
 
 ## Agent (`rocky`)
 

--- a/.opencode/plugins/agent-toolkit.test.ts
+++ b/.opencode/plugins/agent-toolkit.test.ts
@@ -3,10 +3,15 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { NotionCache } from "../../lib/notion-context";
+import { OpenapiCache } from "../../lib/openapi-context";
 import agentToolkitPlugin, {
   handleNotionGet,
   handleNotionRefresh,
   handleNotionStatus,
+  handleSwaggerGet,
+  handleSwaggerRefresh,
+  handleSwaggerSearch,
+  handleSwaggerStatus,
 } from "./agent-toolkit";
 
 const PAGE = "1234abcd1234abcd1234abcd1234abcd";
@@ -85,6 +90,130 @@ describe("plugin handlers", () => {
     await expect(handleNotionGet(cache, PAGE)).rejects.toThrow(/wrong page/i);
     const s = await handleNotionStatus(cache, PAGE);
     expect(s.exists).toBe(false);
+  });
+});
+
+describe("swagger handlers", () => {
+  let oaDir: string;
+  let oaCache: OpenapiCache;
+  let oaServer: ReturnType<typeof Bun.serve>;
+  let oaCalls: number;
+  let respondMalformed: boolean;
+
+  const SAMPLE_SPEC = {
+    openapi: "3.0.0",
+    info: { title: "Sample", version: "1.0.0" },
+    paths: {
+      "/pets": {
+        get: { operationId: "listPets", summary: "List pets", tags: ["pet"] },
+        post: { operationId: "createPet", summary: "Create pet", tags: ["pet"] },
+      },
+      "/users/{id}": {
+        get: { operationId: "getUser", summary: "Fetch user", tags: ["user"] },
+      },
+    },
+  };
+
+  let baseUrl: string;
+
+  beforeEach(() => {
+    oaDir = mkdtempSync(join(tmpdir(), "plugin-oa-"));
+    oaCache = new OpenapiCache({ baseDir: oaDir, defaultTtlSeconds: 60 });
+    oaCalls = 0;
+    respondMalformed = false;
+    oaServer = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/spec.json" && req.method === "GET") {
+          oaCalls += 1;
+          if (respondMalformed) {
+            return Response.json({ info: {}, paths: {} });
+          }
+          return Response.json(SAMPLE_SPEC);
+        }
+        if (url.pathname === "/other.json" && req.method === "GET") {
+          oaCalls += 1;
+          return Response.json({
+            openapi: "3.0.0",
+            info: { title: "Other", version: "0.1.0" },
+            paths: { "/health": { get: { operationId: "health" } } },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    baseUrl = `http://${oaServer.hostname}:${oaServer.port}`;
+  });
+
+  afterEach(() => {
+    oaServer.stop(true);
+  });
+
+  it("swagger_get: cache miss → write → second call hits cache", async () => {
+    const url = `${baseUrl}/spec.json`;
+    const first = await handleSwaggerGet(oaCache, url);
+    expect(first.fromCache).toBe(false);
+    expect(first.entry.title).toBe("Sample");
+    expect(first.entry.endpointCount).toBe(3);
+
+    const second = await handleSwaggerGet(oaCache, url);
+    expect(second.fromCache).toBe(true);
+    expect(oaCalls).toBe(1);
+  });
+
+  it("swagger_refresh: ignores cache and re-fetches", async () => {
+    const url = `${baseUrl}/spec.json`;
+    await handleSwaggerGet(oaCache, url);
+    expect(oaCalls).toBe(1);
+
+    const r = await handleSwaggerRefresh(oaCache, url);
+    expect(r.fromCache).toBe(false);
+    expect(oaCalls).toBe(2);
+  });
+
+  it("swagger_status: reflects cache state", async () => {
+    const url = `${baseUrl}/spec.json`;
+    const before = await handleSwaggerStatus(oaCache, url);
+    expect(before.exists).toBe(false);
+
+    await handleSwaggerGet(oaCache, url);
+    const after = await handleSwaggerStatus(oaCache, url);
+    expect(after.exists).toBe(true);
+    expect(after.expired).toBe(false);
+    expect(after.title).toBe("Sample");
+  });
+
+  it("rejects spec missing both openapi and swagger fields", async () => {
+    respondMalformed = true;
+    const url = `${baseUrl}/spec.json`;
+    await expect(handleSwaggerGet(oaCache, url)).rejects.toThrow(
+      /openapi.*swagger/i,
+    );
+    const s = await handleSwaggerStatus(oaCache, url);
+    expect(s.exists).toBe(false);
+  });
+
+  it("swagger_search spans every cached spec", async () => {
+    await handleSwaggerGet(oaCache, `${baseUrl}/spec.json`);
+    await handleSwaggerGet(oaCache, `${baseUrl}/other.json`);
+
+    const pets = await handleSwaggerSearch(oaCache, "pet");
+    expect(pets.length).toBe(2);
+    expect(pets.every((p) => p.path === "/pets")).toBe(true);
+    expect(pets.map((p) => p.method).sort()).toEqual(["GET", "POST"]);
+
+    const health = await handleSwaggerSearch(oaCache, "health");
+    expect(health.length).toBe(1);
+    expect(health[0]?.specTitle).toBe("Other");
+    expect(health[0]?.path).toBe("/health");
+
+    const all = await handleSwaggerSearch(oaCache, "");
+    expect(all.length).toBe(4);
+
+    const limited = await handleSwaggerSearch(oaCache, "", 2);
+    expect(limited.length).toBe(2);
   });
 });
 

--- a/.opencode/plugins/agent-toolkit.test.ts
+++ b/.opencode/plugins/agent-toolkit.test.ts
@@ -195,6 +195,42 @@ describe("swagger handlers", () => {
     expect(s.exists).toBe(false);
   });
 
+  it("swagger_get with a 16-hex key recovers the spec URL via meta and refetches", async () => {
+    const url = `${baseUrl}/spec.json`;
+    const first = await handleSwaggerGet(oaCache, url);
+    expect(first.fromCache).toBe(false);
+
+    // 본문만 날리고 메타 유지 → 캐시 miss 지만 specUrl 은 복구 가능.
+    const { rmSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    rmSync(join(oaDir, `${first.entry.key}.spec.json`));
+
+    const recovered = await handleSwaggerGet(oaCache, first.entry.key);
+    expect(recovered.fromCache).toBe(false);
+    expect(recovered.entry.specUrl).toBe(url);
+    expect(oaCalls).toBe(2);
+  });
+
+  it("swagger_get with a 16-hex key throws clearly when meta is also gone", async () => {
+    const url = `${baseUrl}/spec.json`;
+    const first = await handleSwaggerGet(oaCache, url);
+    const { rmSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    rmSync(join(oaDir, `${first.entry.key}.spec.json`));
+    rmSync(join(oaDir, `${first.entry.key}.json`));
+
+    await expect(handleSwaggerGet(oaCache, first.entry.key)).rejects.toThrow(
+      /no recoverable spec URL/i,
+    );
+  });
+
+  it("swagger_status returns endpointCount on cache hit", async () => {
+    const url = `${baseUrl}/spec.json`;
+    await handleSwaggerGet(oaCache, url);
+    const s = await handleSwaggerStatus(oaCache, url);
+    expect(s.endpointCount).toBe(3);
+  });
+
   it("swagger_search spans every cached spec", async () => {
     await handleSwaggerGet(oaCache, `${baseUrl}/spec.json`);
     await handleSwaggerGet(oaCache, `${baseUrl}/other.json`);

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -12,6 +12,7 @@ import {
 import {
   OpenapiCache,
   createOpenapiCacheFromEnv,
+  resolveSpecKey,
   searchEndpoints,
   assertOpenapiShape,
   type OpenapiCacheStatus,
@@ -223,13 +224,28 @@ export async function downloadOpenapiSpec(
 /**
  * 다운로드 → 검증 → 캐시에 기록.
  * Notion 의 `fetchAndCache` 와 같은 모양이지만 id 검증 단은 없다 (URL 자체가 키).
+ *
+ * 16-hex 키 입력 (`swagger_status` / search 결과로 얻은 디스크 key) 으로 들어왔을 때는
+ * 캐시 메타에서 원본 URL 을 복구한다 — 메타까지 사라진 경우엔 키를 fetch URL 로 쓰면
+ * `ERR_INVALID_URL` 이 나므로 명확한 에러로 거부한다.
  */
 async function fetchAndCacheSpec(
   cache: OpenapiCache,
   input: string,
 ): Promise<OpenapiSpecResult> {
-  const spec = await downloadOpenapiSpec(input);
-  const written = await cache.write(input, spec);
+  const { isKeyInput } = resolveSpecKey(input);
+  let specUrl = input;
+  if (isKeyInput) {
+    const recovered = await cache.peekSpecUrl(input);
+    if (!recovered) {
+      throw new Error(
+        `Cached key "${input}" has no recoverable spec URL — pass the original spec URL or use swagger_search to find one.`,
+      );
+    }
+    specUrl = recovered;
+  }
+  const spec = await downloadOpenapiSpec(specUrl);
+  const written = await cache.write(specUrl, spec);
   return { ...written, fromCache: false };
 }
 

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -9,6 +9,16 @@ import {
   type NotionPageResult,
   type NotionCacheStatus,
 } from "../../lib/notion-context";
+import {
+  OpenapiCache,
+  createOpenapiCacheFromEnv,
+  searchEndpoints,
+  assertOpenapiShape,
+  type OpenapiCacheStatus,
+  type OpenapiEndpointMatch,
+  type OpenapiSpec,
+  type OpenapiSpecResult,
+} from "../../lib/openapi-context";
 
 /**
  * opencode plugin entrypoint (Superpowers 형식).
@@ -36,6 +46,13 @@ const AGENTS_DIR = resolve(REPO_ROOT, "agents");
  */
 export const DEFAULT_NOTION_MCP_URL = "https://mcp.notion.com/mcp";
 
+/**
+ * OpenAPI / Swagger spec 다운로드 timeout 기본값.
+ * Notion 호출보다 spec 본문이 큰 경우가 많아 더 길게 잡는다.
+ * `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS` 로 덮어쓴다.
+ */
+export const DEFAULT_OPENAPI_DOWNLOAD_TIMEOUT_MS = 30_000;
+
 function readEnv() {
   const url = process.env.AGENT_TOOLKIT_NOTION_MCP_URL ?? DEFAULT_NOTION_MCP_URL;
   const timeoutMs = Number.parseInt(
@@ -45,6 +62,23 @@ function readEnv() {
   return {
     url: url.replace(/\/$/, ""),
     timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 15_000,
+  };
+}
+
+/**
+ * OpenAPI 다운로드용 env 만 읽는다 — cache dir / TTL 은 cache 모듈이 직접 읽으므로 여기선 timeout 만.
+ */
+function readOpenapiEnv() {
+  const timeoutMs = Number.parseInt(
+    process.env.AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS ??
+      String(DEFAULT_OPENAPI_DOWNLOAD_TIMEOUT_MS),
+    10,
+  );
+  return {
+    timeoutMs:
+      Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? timeoutMs
+        : DEFAULT_OPENAPI_DOWNLOAD_TIMEOUT_MS,
   };
 }
 
@@ -139,12 +173,132 @@ export async function handleNotionStatus(
 }
 
 /**
+ * 공유된 OpenAPI / Swagger JSON spec 을 한 번 다운로드한다.
+ * wire format: GET `${specUrl}` -> JSON OpenAPI document.
+ *
+ * YAML 은 MVP 에서 미지원 — content-type 무관하게 JSON parse 만 시도한다 (parse 실패 → throw).
+ * timeout / 빈 응답 / 잘못된 shape 는 모두 메시지에 URL 과 함께 throw.
+ */
+export async function downloadOpenapiSpec(
+  specUrl: string,
+): Promise<OpenapiSpec> {
+  const { timeoutMs } = readOpenapiEnv();
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(specUrl, {
+      method: "GET",
+      headers: { accept: "application/json" },
+      signal: ac.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(
+        `OpenAPI download error ${res.status} ${res.statusText} (url=${specUrl}): ${body.slice(0, 200)}`,
+      );
+    }
+    const text = await res.text();
+    let data: unknown;
+    try {
+      data = JSON.parse(text);
+    } catch (parseErr) {
+      throw new Error(
+        `OpenAPI download from ${specUrl} returned non-JSON body (first 120 chars: ${text.slice(0, 120)})`,
+      );
+    }
+    assertOpenapiShape(data);
+    return data;
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(
+        `OpenAPI download timed out after ${timeoutMs}ms (url=${specUrl})`,
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * 다운로드 → 검증 → 캐시에 기록.
+ * Notion 의 `fetchAndCache` 와 같은 모양이지만 id 검증 단은 없다 (URL 자체가 키).
+ */
+async function fetchAndCacheSpec(
+  cache: OpenapiCache,
+  input: string,
+): Promise<OpenapiSpecResult> {
+  const spec = await downloadOpenapiSpec(input);
+  const written = await cache.write(input, spec);
+  return { ...written, fromCache: false };
+}
+
+/** 도구 핸들러: 캐시 우선. 단위 테스트에서 직접 호출 가능하도록 export. */
+export async function handleSwaggerGet(
+  cache: OpenapiCache,
+  input: string,
+): Promise<OpenapiSpecResult> {
+  const cached = await cache.read(input);
+  if (cached) return { ...cached, fromCache: true };
+  return fetchAndCacheSpec(cache, input);
+}
+
+export async function handleSwaggerRefresh(
+  cache: OpenapiCache,
+  input: string,
+): Promise<OpenapiSpecResult> {
+  return fetchAndCacheSpec(cache, input);
+}
+
+export async function handleSwaggerStatus(
+  cache: OpenapiCache,
+  input: string,
+): Promise<OpenapiCacheStatus> {
+  return cache.status(input);
+}
+
+/**
+ * 캐시된 모든 spec 을 가로질러 endpoint substring 검색.
+ * - 결과는 caller 가 입력한 `limit` 까지 (기본 20).
+ * - 빈 query 는 캐시된 모든 endpoint 를 limit 까지 나열.
+ */
+export async function handleSwaggerSearch(
+  cache: OpenapiCache,
+  query: string,
+  limit?: number,
+): Promise<OpenapiEndpointMatch[]> {
+  const cap = Number.isFinite(limit) && (limit as number) > 0 ? (limit as number) : 20;
+  const all = await cache.list();
+  const out: OpenapiEndpointMatch[] = [];
+  for (const { entry, spec } of all) {
+    const remaining = cap - out.length;
+    if (remaining <= 0) break;
+    const matches = searchEndpoints(spec, query, remaining);
+    for (const m of matches) {
+      out.push({
+        specKey: entry.key,
+        specUrl: entry.specUrl,
+        specTitle: entry.title,
+        method: m.method,
+        path: m.path,
+        operationId: m.operationId,
+        summary: m.summary,
+        tags: m.tags,
+      });
+      if (out.length >= cap) break;
+    }
+  }
+  return out;
+}
+
+/**
  * opencode plugin default export.
  * `directory` 는 opencode 가 plugin 을 로드한 cwd. 우리는 import.meta 기반으로
  * 자기 저장소의 skills/ 를 절대 경로로 잡는다.
  */
 export default async function agentToolkitPlugin(_input: unknown) {
   const cache = createCacheFromEnv();
+  const openapi = createOpenapiCacheFromEnv();
 
   return {
     /**
@@ -188,6 +342,41 @@ export default async function agentToolkitPlugin(_input: unknown) {
         parameters: { input: { type: "string", required: true } },
         async handler({ input }: { input: string }) {
           return handleNotionStatus(cache, input);
+        },
+      },
+      swagger_get: {
+        description:
+          "OpenAPI / Swagger JSON spec 을 캐시 우선 정책으로 가져온다. 캐시 hit 이면 remote 호출 없음. miss 면 spec URL 을 GET 으로 받아 형식 검증 후 캐시에 저장. (input: spec URL 또는 이미 캐시된 16-hex key)",
+        parameters: { input: { type: "string", required: true } },
+        async handler({ input }: { input: string }) {
+          return handleSwaggerGet(openapi, input);
+        },
+      },
+      swagger_refresh: {
+        description:
+          "캐시를 무시하고 OpenAPI spec URL 에서 강제로 다시 가져와 캐시를 갱신한다. (input: spec URL)",
+        parameters: { input: { type: "string", required: true } },
+        async handler({ input }: { input: string }) {
+          return handleSwaggerRefresh(openapi, input);
+        },
+      },
+      swagger_status: {
+        description:
+          "캐시된 OpenAPI spec 의 메타(저장 시각, TTL, 만료 여부, title, endpoint 수)만 조회. remote 호출 없음. (input: spec URL 또는 16-hex key)",
+        parameters: { input: { type: "string", required: true } },
+        async handler({ input }: { input: string }) {
+          return handleSwaggerStatus(openapi, input);
+        },
+      },
+      swagger_search: {
+        description:
+          "캐시된 모든 OpenAPI spec 을 가로질러 path / method / tag / operationId / summary 를 substring 으로 검색한다. remote 호출 없음. (query: 검색어, limit?: 결과 최대 개수, 기본 20)",
+        parameters: {
+          query: { type: "string", required: true },
+          limit: { type: "number", required: false },
+        },
+        async handler({ query, limit }: { query: string; limit?: number }) {
+          return handleSwaggerSearch(openapi, query, limit);
         },
       },
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,15 @@ Shared guide for AI coding agents (Claude Code, opencode, codex, etc.) working i
 
 ## Project in one line
 
-opencode-only plugin. Three Notion cache tools + one cache-first context / spec-extraction skill + one thin gateway agent (`rocky`, naming convention borrowed from [OmO](https://github.com/code-yeongyu/oh-my-openagent)'s named-specialist pattern). **Runtime is Bun (>=1.0). No Node. No build step (Bun runs TS directly).** Layout follows the [obra/superpowers](https://github.com/obra/superpowers) shape.
+opencode-only plugin. Three Notion cache tools + four OpenAPI cache & search tools + two cache-first skills (`notion-context` for context / Korean specs, `openapi-client` for `fetch`/`axios` snippets) + one thin gateway agent (`rocky`, naming convention borrowed from [OmO](https://github.com/code-yeongyu/oh-my-openagent)'s named-specialist pattern). **Runtime is Bun (>=1.0). No Node. No build step (Bun runs TS directly).** Layout follows the [obra/superpowers](https://github.com/obra/superpowers) shape.
 
 ## Layout
 
-- `.opencode/plugins/agent-toolkit.ts` — plugin entrypoint. `config` hook registers `skills/` and `agents/`, and exposes the three tools (`notion_get` / `notion_refresh` / `notion_status`).
-- `lib/notion-context.ts` — single-file TTL filesystem cache + `resolveCacheKey` + `notionToMarkdown`.
+- `.opencode/plugins/agent-toolkit.ts` — plugin entrypoint. `config` hook registers `skills/` and `agents/`, and exposes seven tools: `notion_get` / `notion_refresh` / `notion_status` plus `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search`.
+- `lib/notion-context.ts` — single-file TTL filesystem cache for Notion pages + `resolveCacheKey` + `notionToMarkdown`.
+- `lib/openapi-context.ts` — single-file TTL filesystem cache for OpenAPI / Swagger JSON specs + `resolveSpecKey` + `searchEndpoints` + shape validation.
 - `skills/notion-context/SKILL.md` — Notion cache-first read + Korean-language spec extraction skill.
+- `skills/openapi-client/SKILL.md` — cached OpenAPI spec → `fetch` or `axios` call snippet skill.
 - `agents/rocky.md` — thin gateway agent (`mode: all`) that exposes the toolkit's Notion flow to users and to other primary agents (e.g. OmO Sisyphus).
 - `.opencode/INSTALL.md` — install guide for opencode users.
 
@@ -36,9 +38,9 @@ Only `AGENT_TOOLKIT_NOTION_MCP_URL` is required. See the README env-var table fo
 
 ## MVP scope (hold the line)
 
-**In**: single-page Notion read + cache + expiry, one skill, one gateway agent (`rocky`), opencode-only.
+**In**: single-page Notion read + cache + expiry, single OpenAPI / Swagger JSON spec cache + cross-spec endpoint search, two skills (`notion-context`, `openapi-client`), one gateway agent (`rocky`), opencode-only.
 
-**Out**: database queries, OAuth, child pages, multi-host plugin layouts (`.claude-plugin/`, etc.), UI, codex integration, agent-side workflow orchestration (that lives in the caller, not in `rocky`). Anything beyond this scope ships as a separate PR proposal.
+**Out**: database queries, OAuth, Notion child pages, OpenAPI YAML parsing, full SDK code generation, multi-spec merge, mock servers, multi-host plugin layouts (`.claude-plugin/`, etc.), UI, codex integration, agent-side workflow orchestration (that lives in the caller, not in `rocky`). Anything beyond this scope ships as a separate PR proposal.
 
 The longer-term capability targets (auto memory, GitHub-issue tracking, OpenAPI client generation, …) live in [`ROADMAP.md`](./ROADMAP.md) — phase-by-phase, one PR at a time. Do not pull roadmap items into MVP unless the user explicitly asks.
 
@@ -48,7 +50,7 @@ The longer-term capability targets (auto memory, GitHub-issue tracking, OpenAPI 
 2. `bun test` passes
 3. If the user-facing surface (tools / env vars) changes, sync `README.md` and `.opencode/INSTALL.md`
 4. If a new env var is added, also update the plugin's `readEnv()`
-5. If the plugin's tool contract changes, update the tool-usage rules in `skills/notion-context/SKILL.md` and the corresponding tool description/rules in `agents/rocky.md`
+5. If the plugin's tool contract changes, update the tool-usage rules in the relevant skill (`skills/notion-context/SKILL.md` for `notion_*`, `skills/openapi-client/SKILL.md` for `swagger_*`) and the corresponding tool description/rules in `agents/rocky.md` when Notion-side
 
 ## MCP servers
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Toolkit
 
-opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 개와, 그 도구로 페이지를 컨텍스트로 가져오거나 한국어 스펙으로 정리하는 skill 1 개, 그리고 회사 컨텍스트를 들고 있는 업무 파트너 agent 1 개(`rocky`) 를 제공한다. Notion 은 시작 소스이고, 회사 지식 표면은 이후 더 넓혀질 수 있다. 런타임은 **Bun (>=1.0)** 만 사용하며, 별도 빌드 단계는 없다 (Bun 이 TS 직접 실행).
+opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 개, OpenAPI / Swagger JSON 을 캐시 우선으로 가져와 endpoint 검색까지 해 주는 도구 4 개, 그 도구들을 묶어 컨텍스트 / 한국어 스펙 / `fetch`·`axios` 호출 코드로 정리하는 skill 2 개, 그리고 회사 컨텍스트를 들고 있는 업무 파트너 agent 1 개(`rocky`) 를 제공한다. Notion 은 시작 소스이고, 회사 지식 표면은 이후 더 넓혀질 수 있다. 런타임은 **Bun (>=1.0)** 만 사용하며, 별도 빌드 단계는 없다 (Bun 이 TS 직접 실행).
 
 구조는 [obra/superpowers](https://github.com/obra/superpowers) 형식을 따른다 — 단일 plugin 파일이 `skills/` / `agents/` 디렉터리를 opencode 탐색 경로에 등록하고 도구를 노출한다. `rocky` 의 캐릭터/네이밍 컨벤션은 [code-yeongyu/oh-my-openagent (OmO)](https://github.com/code-yeongyu/oh-my-openagent) 의 named-specialist 패턴에서 빌렸지만, 책임은 회사 컨텍스트 파트너 한 줄로 한정한다.
 
@@ -11,13 +11,16 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 ├── .opencode/
 │   ├── INSTALL.md                  # opencode 사용자용 설치 안내
 │   └── plugins/
-│       ├── agent-toolkit.ts        # plugin entrypoint + 도구 3 개
+│       ├── agent-toolkit.ts        # plugin entrypoint + 도구 7 개 (notion 3 + swagger 4)
 │       └── agent-toolkit.test.ts
 ├── lib/
-│   ├── notion-context.ts           # TTL 파일 캐시 + key 정규화 + normalize
-│   └── notion-context.test.ts
+│   ├── notion-context.ts           # Notion TTL 파일 캐시 + key 정규화 + normalize
+│   ├── notion-context.test.ts
+│   ├── openapi-context.ts          # OpenAPI TTL 파일 캐시 + endpoint 검색
+│   └── openapi-context.test.ts
 ├── skills/
-│   └── notion-context/SKILL.md     # Notion 캐시 우선 읽기 + 한국어 스펙 정리 skill
+│   ├── notion-context/SKILL.md     # Notion 캐시 우선 읽기 + 한국어 스펙 정리 skill
+│   └── openapi-client/SKILL.md     # 캐시된 OpenAPI spec → fetch / axios 호출 코드 skill
 ├── agents/
 │   └── rocky.md                    # 회사 컨텍스트 업무 파트너 (mode: all, Notion 시작)
 ├── .mcp.json                        # context7 MCP 등록 (개발 보조용)
@@ -45,13 +48,18 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 | 변수 | 기본값 | 설명 |
 | --- | --- | --- |
 | `AGENT_TOOLKIT_NOTION_MCP_URL` | `https://mcp.notion.com/mcp` | remote Notion MCP base URL. 인증은 OAuth 가 처리하므로 토큰 변수는 없다. |
-| `AGENT_TOOLKIT_NOTION_MCP_TIMEOUT_MS` | `15000` | remote 호출 timeout (ms) |
-| `AGENT_TOOLKIT_CACHE_DIR` | `~/.cache/notion-context/pages` | 페이지 캐시 디렉터리 |
-| `AGENT_TOOLKIT_CACHE_TTL` | `86400` | 캐시 TTL (초) |
+| `AGENT_TOOLKIT_NOTION_MCP_TIMEOUT_MS` | `15000` | remote Notion 호출 timeout (ms) |
+| `AGENT_TOOLKIT_CACHE_DIR` | `~/.config/opencode/agent-toolkit/notion-pages` | Notion 페이지 캐시 디렉터리 |
+| `AGENT_TOOLKIT_CACHE_TTL` | `86400` | Notion 캐시 TTL (초) |
+| `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` | `~/.config/opencode/agent-toolkit/openapi-specs` | OpenAPI / Swagger spec 캐시 디렉터리 |
+| `AGENT_TOOLKIT_OPENAPI_CACHE_TTL` | `86400` | OpenAPI 캐시 TTL (초) |
+| `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS` | `30000` | OpenAPI spec 다운로드 timeout (ms) |
 
 ## 도구
 
-plugin 이 opencode 에 다음 3 개를 등록한다:
+plugin 이 opencode 에 다음 7 개를 등록한다.
+
+### Notion (`notion_*`)
 
 | 도구 | 동작 |
 | --- | --- |
@@ -60,6 +68,17 @@ plugin 이 opencode 에 다음 3 개를 등록한다:
 | `notion_status` | 캐시 메타(저장 시각, TTL, 만료 여부) 만 조회. remote 호출 없음 |
 
 `input` 파라미터는 page id 또는 Notion URL 모두 허용.
+
+### OpenAPI / Swagger (`swagger_*`)
+
+| 도구 | 동작 |
+| --- | --- |
+| `swagger_get` | 캐시 우선. hit 면 즉시 반환, miss 면 spec URL 을 GET 으로 다운로드 → JSON / shape 검증 → 캐시 저장 |
+| `swagger_refresh` | 캐시 무시하고 spec URL 에서 강제 다운로드 → 검증 → 캐시 갱신 |
+| `swagger_status` | 캐시 메타(저장 시각, TTL, 만료 여부, title, endpointCount) 만 조회. remote 호출 없음 |
+| `swagger_search` | 캐시된 모든 spec 을 가로질러 path / method / tag / operationId / summary 를 substring 으로 검색. remote 호출 없음 |
+
+`swagger_get` / `swagger_refresh` / `swagger_status` 의 `input` 은 spec URL 또는 이미 캐시된 16-hex key. `swagger_search` 는 `query: string`, `limit?: number` (기본 20). YAML spec 은 MVP 에서 미지원 — JSON 만 받는다.
 
 ## Agent
 
@@ -71,6 +90,8 @@ plugin 이 opencode 에 다음 3 개를 등록한다:
 
 ## 캐시 구조
 
+### Notion (`AGENT_TOOLKIT_CACHE_DIR`)
+
 ```
 <AGENT_TOOLKIT_CACHE_DIR>/
   <pageId>.json   # 메타데이터: pageId, url, cachedAt, ttlSeconds, contentHash, title
@@ -78,6 +99,16 @@ plugin 이 opencode 에 다음 3 개를 등록한다:
 ```
 
 `.json` 또는 `.md` 한쪽이 누락되면 `notion_status` 와 `notion_get` 모두 cache miss 로 본다.
+
+### OpenAPI (`AGENT_TOOLKIT_OPENAPI_CACHE_DIR`)
+
+```
+<AGENT_TOOLKIT_OPENAPI_CACHE_DIR>/
+  <key>.json        # 메타데이터: key, specUrl, cachedAt, ttlSeconds, specHash, title, version, openapi, endpointCount
+  <key>.spec.json   # 다운로드한 OpenAPI document (parsed → re-stringified)
+```
+
+`<key>` 는 `sha256(specUrl)` 의 앞 16자 hex. `.json` 또는 `.spec.json` 한쪽이 누락되면 `swagger_status` / `swagger_get` 모두 cache miss 로 본다.
 
 ## 개발
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 | 4 | Notion 캐싱 + TTL | ✅ MVP | — | `notion_get` / `notion_status` / `notion_refresh`, `lib/notion-context.ts` |
 | 5 | Notion → 개발 스펙 분해 | ✅ MVP | — | `skills/notion-context/SKILL.md` spec mode |
 | 6 | 스펙 → GitHub Issue 추적 | 📋 planned | [#4](https://github.com/minjun0219/coding-agent-toolkit/issues/4) | GitHub MCP / 자체 도구 어느 쪽으로 갈지 미정 |
-| 7 | OpenAPI 캐시 + client 작성 | 📋 planned | [#6](https://github.com/minjun0219/coding-agent-toolkit/issues/6) | `lib/openapi-context.ts` 형식 후보 |
+| 7 | OpenAPI 캐시 + client 작성 | ✅ MVP | [#6](https://github.com/minjun0219/coding-agent-toolkit/issues/6) | `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search`, `lib/openapi-context.ts`, `skills/openapi-client/SKILL.md` (JSON-only, 단일 endpoint 단위 snippet) |
 
 ## 제안 단계
 
@@ -42,9 +42,9 @@
 - **Phase 3 — 에이전트 자동 기억 / 기록** *(memo #1, issue [#5](https://github.com/minjun0219/coding-agent-toolkit/issues/5))*
   - turn 단위 결정 / blocker / 사용자 답변을 캐시 디렉터리 옆에 append-only 로 저장
   - Rocky 가 "이전 turn 에 X 로 결정했음" 같은 기억을 인용 가능하게
-- **Phase 4 — OpenAPI 캐시 + client 작성** *(memo #7, issue [#6](https://github.com/minjun0219/coding-agent-toolkit/issues/6))*
-  - `swagger_get` / `swagger_status` / `swagger_search` 같은 도구
-  - skill: 한 endpoint → `fetch` / `axios` 호출 코드 한 덩어리
+- **Phase 4 — OpenAPI 캐시 + client 작성 — 완료** *(memo #7, issue [#6](https://github.com/minjun0219/coding-agent-toolkit/issues/6))*
+  - `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` 4 도구 + `lib/openapi-context.ts` TTL 파일 캐시 + `skills/openapi-client/SKILL.md`
+  - JSON-only (YAML 미지원), 단일 endpoint → `fetch` / `axios` snippet 한 덩어리
 - **횡단 — 코드 품질 정책 강화** *(memo #2, #3, issue [#7](https://github.com/minjun0219/coding-agent-toolkit/issues/7))*
   - 한글 주석 / JSDoc 정책의 lint 단 검증 (필요해지면)
 

--- a/lib/notion-context.ts
+++ b/lib/notion-context.ts
@@ -11,11 +11,18 @@ import { createHash } from "node:crypto";
  *   <baseDir>/<pageId>.json   메타데이터 (NotionCacheEntry)
  *   <baseDir>/<pageId>.md     normalize 된 markdown 본문
  *
- * baseDir 기본값은 `~/.cache/notion-context/pages` — 사용자 단위 캐시 위치.
+ * baseDir 기본값은 `~/.config/opencode/agent-toolkit/notion-pages` —
+ * 다른 opencode plugin 들이 자기 데이터를 두는 위치 컨벤션을 따른다.
  * 프로젝트별로 격리하고 싶으면 `AGENT_TOOLKIT_CACHE_DIR` 로 덮어쓴다.
  */
 
-export const DEFAULT_CACHE_DIR = join(homedir(), ".cache", "notion-context", "pages");
+export const DEFAULT_CACHE_DIR = join(
+  homedir(),
+  ".config",
+  "opencode",
+  "agent-toolkit",
+  "notion-pages",
+);
 export const DEFAULT_TTL_SECONDS = 60 * 60 * 24; // 24h
 
 export interface NotionCacheEntry {

--- a/lib/openapi-context.test.ts
+++ b/lib/openapi-context.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  OpenapiCache,
+  resolveSpecKey,
+  searchEndpoints,
+  countEndpoints,
+  assertOpenapiShape,
+  specHash,
+  type OpenapiSpec,
+} from "./openapi-context";
+
+const SPEC_URL = "https://example.com/openapi.json";
+
+/** 최소 OpenAPI 3 doc — paths 두 개, method 세 개, tag/operationId 다양. */
+const SAMPLE_SPEC: OpenapiSpec = {
+  openapi: "3.0.0",
+  info: { title: "Sample", version: "1.0.0" },
+  paths: {
+    "/pets": {
+      get: {
+        operationId: "listPets",
+        summary: "List all pets",
+        tags: ["pet"],
+      },
+      post: {
+        operationId: "createPet",
+        summary: "Create a pet",
+        tags: ["pet"],
+      },
+    },
+    "/users/{id}": {
+      get: {
+        operationId: "getUser",
+        summary: "Fetch user by id",
+        tags: ["user"],
+      },
+    },
+  },
+};
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agent-toolkit-openapi-"));
+});
+
+describe("resolveSpecKey", () => {
+  it("hashes a URL to a 16-hex key", () => {
+    const r = resolveSpecKey(SPEC_URL);
+    expect(r.key).toMatch(/^[0-9a-f]{16}$/);
+    expect(r.specUrl).toBe(SPEC_URL);
+  });
+
+  it("treats an already-normalized 16-hex input as the key itself", () => {
+    const { key } = resolveSpecKey(SPEC_URL);
+    const r = resolveSpecKey(key);
+    expect(r.key).toBe(key);
+  });
+
+  it("rejects empty / whitespace input", () => {
+    expect(() => resolveSpecKey("")).toThrow();
+    expect(() => resolveSpecKey("   ")).toThrow();
+  });
+});
+
+describe("countEndpoints", () => {
+  it("counts (path × method) pairs", () => {
+    expect(countEndpoints(SAMPLE_SPEC)).toBe(3);
+  });
+
+  it("returns 0 for malformed spec", () => {
+    expect(countEndpoints({} as OpenapiSpec)).toBe(0);
+    expect(countEndpoints({ paths: null } as unknown as OpenapiSpec)).toBe(0);
+  });
+});
+
+describe("searchEndpoints", () => {
+  it("matches by path substring", () => {
+    const r = searchEndpoints(SAMPLE_SPEC, "/pets");
+    expect(r.length).toBe(2);
+    expect(r.map((e) => e.method).sort()).toEqual(["GET", "POST"]);
+  });
+
+  it("matches by tag", () => {
+    const r = searchEndpoints(SAMPLE_SPEC, "user");
+    expect(r.length).toBe(1);
+    expect(r[0]?.path).toBe("/users/{id}");
+  });
+
+  it("matches by operationId", () => {
+    const r = searchEndpoints(SAMPLE_SPEC, "createPet");
+    expect(r.length).toBe(1);
+    expect(r[0]?.method).toBe("POST");
+  });
+
+  it("matches by summary substring", () => {
+    const r = searchEndpoints(SAMPLE_SPEC, "fetch user");
+    expect(r.length).toBe(1);
+    expect(r[0]?.operationId).toBe("getUser");
+  });
+
+  it("empty query returns all up to limit", () => {
+    expect(searchEndpoints(SAMPLE_SPEC, "").length).toBe(3);
+    expect(searchEndpoints(SAMPLE_SPEC, "", 2).length).toBe(2);
+  });
+});
+
+describe("assertOpenapiShape", () => {
+  it("accepts OpenAPI 3.x", () => {
+    expect(() =>
+      assertOpenapiShape({ openapi: "3.0.0", info: {}, paths: {} }),
+    ).not.toThrow();
+  });
+  it("accepts swagger 2.x", () => {
+    expect(() =>
+      assertOpenapiShape({ swagger: "2.0", info: {}, paths: {} }),
+    ).not.toThrow();
+  });
+  it("rejects payload missing both fields", () => {
+    expect(() => assertOpenapiShape({ info: {}, paths: {} })).toThrow(
+      /openapi.*swagger/i,
+    );
+  });
+  it("rejects non-object payload", () => {
+    expect(() => assertOpenapiShape("string")).toThrow();
+    expect(() => assertOpenapiShape(null)).toThrow();
+  });
+});
+
+describe("OpenapiCache", () => {
+  it("returns null for missing specs", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    expect(await cache.read(SPEC_URL)).toBeNull();
+  });
+
+  it("writes and reads back, with stable specHash and derived metadata", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
+    expect(w.entry.title).toBe("Sample");
+    expect(w.entry.version).toBe("1.0.0");
+    expect(w.entry.openapi).toBe("3.0.0");
+    expect(w.entry.endpointCount).toBe(3);
+
+    const r = await cache.read(SPEC_URL);
+    expect(r?.entry.specHash).toBe(w.entry.specHash);
+    expect(r?.spec.paths?.["/pets"]?.get?.operationId).toBe("listPets");
+
+    // 같은 본문을 다시 쓰면 specHash 가 같아야 한다.
+    const reHash = specHash(`${JSON.stringify(SAMPLE_SPEC, null, 2)}\n`);
+    expect(r?.entry.specHash).toBe(reHash);
+  });
+
+  it("treats expired entries as miss but still reports them via status", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    await cache.write(SPEC_URL, SAMPLE_SPEC);
+    expect(await cache.invalidate(SPEC_URL)).toBe(true);
+    expect(await cache.read(SPEC_URL)).toBeNull();
+    const s = await cache.status(SPEC_URL);
+    expect(s.exists).toBe(true);
+    expect(s.expired).toBe(true);
+  });
+
+  it("status reports exists=false when only meta exists (missing .spec.json)", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
+    rmSync(join(dir, `${w.entry.key}.spec.json`));
+    const s = await cache.status(SPEC_URL);
+    expect(s.exists).toBe(false);
+    expect(await cache.read(SPEC_URL)).toBeNull();
+  });
+
+  it("status reports exists=false when only .spec.json exists (missing meta)", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
+    rmSync(join(dir, `${w.entry.key}.json`));
+    const s = await cache.status(SPEC_URL);
+    expect(s.exists).toBe(false);
+  });
+
+  it("treats corrupt meta as miss without throwing", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
+    writeFileSync(join(dir, `${w.entry.key}.json`), "{ not json", "utf8");
+    expect(await cache.read(SPEC_URL)).toBeNull();
+    const s = await cache.status(SPEC_URL);
+    expect(s.exists).toBe(false);
+  });
+
+  it("write rejects payload missing both openapi and swagger fields", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    await expect(
+      cache.write(SPEC_URL, { info: {}, paths: {} } as OpenapiSpec),
+    ).rejects.toThrow(/openapi.*swagger/i);
+  });
+
+  it("list returns all unexpired (entry, spec) pairs across the cache dir", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    await cache.write("https://a.example.com/spec.json", SAMPLE_SPEC);
+    await cache.write("https://b.example.com/spec.json", {
+      openapi: "3.0.0",
+      info: { title: "B", version: "2.0.0" },
+      paths: { "/health": { get: { operationId: "health" } } },
+    });
+    const all = await cache.list();
+    expect(all.length).toBe(2);
+    const titles = all.map((r) => r.entry.title).sort();
+    expect(titles).toEqual(["B", "Sample"]);
+  });
+
+  it("list skips entries whose .spec.json is missing", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
+    rmSync(join(dir, `${w.entry.key}.spec.json`));
+    const all = await cache.list();
+    expect(all.length).toBe(0);
+  });
+});

--- a/lib/openapi-context.test.ts
+++ b/lib/openapi-context.test.ts
@@ -47,16 +47,17 @@ beforeEach(() => {
 });
 
 describe("resolveSpecKey", () => {
-  it("hashes a URL to a 16-hex key", () => {
+  it("hashes a URL to a 16-hex key and reports isKeyInput=false", () => {
     const r = resolveSpecKey(SPEC_URL);
     expect(r.key).toMatch(/^[0-9a-f]{16}$/);
-    expect(r.specUrl).toBe(SPEC_URL);
+    expect(r.isKeyInput).toBe(false);
   });
 
-  it("treats an already-normalized 16-hex input as the key itself", () => {
+  it("treats an already-normalized 16-hex input as the key itself with isKeyInput=true", () => {
     const { key } = resolveSpecKey(SPEC_URL);
     const r = resolveSpecKey(key);
     expect(r.key).toBe(key);
+    expect(r.isKeyInput).toBe(true);
   });
 
   it("rejects empty / whitespace input", () => {
@@ -193,6 +194,46 @@ describe("OpenapiCache", () => {
     await expect(
       cache.write(SPEC_URL, { info: {}, paths: {} } as OpenapiSpec),
     ).rejects.toThrow(/openapi.*swagger/i);
+  });
+
+  it("write rejects 16-hex cache key input (URL required)", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
+    await expect(cache.write(w.entry.key, SAMPLE_SPEC)).rejects.toThrow(
+      /requires a spec URL/i,
+    );
+  });
+
+  it("status includes endpointCount for cache hits", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    await cache.write(SPEC_URL, SAMPLE_SPEC);
+    const s = await cache.status(SPEC_URL);
+    expect(s.exists).toBe(true);
+    expect(s.endpointCount).toBe(3);
+  });
+
+  it("status omits endpointCount for cache miss", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const s = await cache.status(SPEC_URL);
+    expect(s.exists).toBe(false);
+    expect(s.endpointCount).toBeUndefined();
+  });
+
+  it("peekSpecUrl recovers original URL even after .spec.json is removed", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
+    rmSync(join(dir, `${w.entry.key}.spec.json`));
+    // status now reports miss, but the meta is still on disk.
+    expect((await cache.status(SPEC_URL)).exists).toBe(false);
+    expect(await cache.peekSpecUrl(SPEC_URL)).toBe(SPEC_URL);
+    expect(await cache.peekSpecUrl(w.entry.key)).toBe(SPEC_URL);
+  });
+
+  it("peekSpecUrl returns null when the meta file is gone", async () => {
+    const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
+    const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
+    rmSync(join(dir, `${w.entry.key}.json`));
+    expect(await cache.peekSpecUrl(SPEC_URL)).toBeNull();
   });
 
   it("list returns all unexpired (entry, spec) pairs across the cache dir", async () => {

--- a/lib/openapi-context.ts
+++ b/lib/openapi-context.ts
@@ -1,0 +1,420 @@
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { createHash } from "node:crypto";
+
+/**
+ * OpenAPI / Swagger spec 캐시 + endpoint 검색을 한 파일에 모은다.
+ *
+ * 디스크 레이아웃 (한 spec 당 두 파일):
+ *   <baseDir>/<key>.json        메타데이터 (OpenapiCacheEntry)
+ *   <baseDir>/<key>.spec.json   다운로드한 OpenAPI document 그대로 (parsed → re-stringified)
+ *
+ * baseDir 기본값은 `~/.config/opencode/agent-toolkit/openapi-specs` — Notion 캐시
+ * (`agent-toolkit/notion-pages`) 와 같은 부모 아래에 두되 디렉터리는 분리.
+ * 환경변수는 `AGENT_TOOLKIT_OPENAPI_CACHE_*` 로 Notion 쪽과 분리되어 있다.
+ *
+ * 키 정규화: spec URL 자체는 길이/문자가 다양하므로 sha256 의 앞 16자(hex) 를 디스크 키로
+ * 쓰고, 원본 URL 은 entry 의 `specUrl` 에 보관한다. `resolveSpecKey` 는 URL / 짧은 키
+ * (32-hex 부분) 둘 다 받아 key 만 통일.
+ */
+
+/** 캐시 파일 디렉터리 기본값 — 사용자 단위. `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` 로 덮어쓴다. */
+export const DEFAULT_OPENAPI_CACHE_DIR = join(
+  homedir(),
+  ".config",
+  "opencode",
+  "agent-toolkit",
+  "openapi-specs",
+);
+/** 기본 TTL 24h — Notion 캐시와 동일. `AGENT_TOOLKIT_OPENAPI_CACHE_TTL` 로 덮어쓴다. */
+export const DEFAULT_OPENAPI_TTL_SECONDS = 60 * 60 * 24;
+
+/**
+ * OpenAPI document 의 우리가 실제로 읽는 부분만 정의한 최소 인터페이스.
+ * 전체 스펙 타입을 들고 가지 않는다 — 검색 / 메타 추출에 필요한 필드만.
+ */
+export interface OpenapiSpec {
+  /** OpenAPI 3.x 의 버전 필드. swagger 2.0 이면 비어 있음. */
+  openapi?: string;
+  /** swagger 2.0 의 버전 필드. OpenAPI 3.x 이면 비어 있음. */
+  swagger?: string;
+  info?: {
+    title?: string;
+    version?: string;
+  };
+  paths?: Record<string, OpenapiPathItem>;
+  /** 그 외 필드는 그대로 보존. */
+  [key: string]: unknown;
+}
+
+/**
+ * 한 path 아래의 method → operation 매핑.
+ * 표준 외 필드(`parameters`, `summary`, `description`, `$ref` 등) 는 unknown 으로 흘려 둔다.
+ */
+export interface OpenapiPathItem {
+  get?: OpenapiOperation;
+  put?: OpenapiOperation;
+  post?: OpenapiOperation;
+  delete?: OpenapiOperation;
+  patch?: OpenapiOperation;
+  head?: OpenapiOperation;
+  options?: OpenapiOperation;
+  trace?: OpenapiOperation;
+  [key: string]: unknown;
+}
+
+export interface OpenapiOperation {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  [key: string]: unknown;
+}
+
+export interface OpenapiCacheEntry {
+  /** 디스크 키 (sha256(specUrl) 앞 16자). */
+  key: string;
+  /** 사용자가 입력한 spec URL (또는 마지막으로 캐시한 URL). */
+  specUrl: string;
+  cachedAt: string;
+  ttlSeconds: number;
+  /** spec 본문의 sha256 앞 16자 — 같은 본문 재캐시 판정용. */
+  specHash: string;
+  title: string;
+  version: string;
+  /** OpenAPI 버전 문자열 (`3.0.x` 또는 `2.0`). */
+  openapi: string;
+  /** spec.paths 안의 (path × method) 합 — 빠른 sanity check. */
+  endpointCount: number;
+}
+
+export interface OpenapiCacheStatus {
+  key: string;
+  exists: boolean;
+  expired: boolean;
+  cachedAt?: string;
+  ttlSeconds?: number;
+  ageSeconds?: number;
+  title?: string;
+  specUrl?: string;
+}
+
+export interface OpenapiSpecResult {
+  entry: OpenapiCacheEntry;
+  spec: OpenapiSpec;
+  fromCache: boolean;
+}
+
+export interface OpenapiCacheOptions {
+  baseDir?: string;
+  defaultTtlSeconds?: number;
+}
+
+/** 검색 결과 한 행 — 어느 spec 의 어느 endpoint 인지 + 매칭에 쓰인 핵심 필드. */
+export interface OpenapiEndpointMatch {
+  /** 매칭된 spec 의 디스크 key. */
+  specKey: string;
+  /** 매칭된 spec 의 원본 URL. */
+  specUrl: string;
+  /** 매칭된 spec 의 info.title. */
+  specTitle: string;
+  /** HTTP method 대문자 (`GET` / `POST` / …). */
+  method: string;
+  /** spec.paths 의 path 그대로. */
+  path: string;
+  operationId?: string;
+  summary?: string;
+  tags?: string[];
+}
+
+/**
+ * spec URL / 디스크 key 양쪽을 받아 정규화된 key 를 반환.
+ *
+ * - 입력이 16자 hex 면 그대로 key 로 사용 (이미 정규화된 상태).
+ * - 그 외에는 sha256(input) 의 앞 16자를 key 로 사용.
+ *
+ * 이 함수는 URL 검증을 하지 않는다 — 호출 측이 fetch 단계에서 처리한다.
+ */
+export function resolveSpecKey(input: string): { key: string; specUrl: string } {
+  if (!input || typeof input !== "string") {
+    throw new Error("resolveSpecKey: input must be a non-empty string");
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error("resolveSpecKey: input must be a non-empty string");
+  }
+  // 16자 hex (이미 정규화된 디스크 key) 면 그대로.
+  if (/^[0-9a-f]{16}$/.test(trimmed)) {
+    return { key: trimmed, specUrl: trimmed };
+  }
+  const key = createHash("sha256").update(trimmed, "utf8").digest("hex").slice(0, 16);
+  return { key, specUrl: trimmed };
+}
+
+/** 짧은(앞 16자) sha256 — spec 본문 동일성 비교용. */
+export function specHash(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex").slice(0, 16);
+}
+
+/**
+ * spec 의 path × method 합을 센다. malformed 입력은 0.
+ * 표준 HTTP method 7 종만 카운트 (`get`/`put`/`post`/`delete`/`patch`/`head`/`options`/`trace`).
+ */
+const HTTP_METHODS = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "patch",
+  "head",
+  "options",
+  "trace",
+] as const;
+
+export function countEndpoints(spec: OpenapiSpec): number {
+  if (!spec.paths || typeof spec.paths !== "object") return 0;
+  let total = 0;
+  for (const item of Object.values(spec.paths)) {
+    if (!item || typeof item !== "object") continue;
+    for (const m of HTTP_METHODS) {
+      if (item[m] && typeof item[m] === "object") total += 1;
+    }
+  }
+  return total;
+}
+
+/**
+ * 한 spec 안에서 endpoint 를 substring 검색 (case-insensitive).
+ * 매칭 대상: path / method / operationId / summary / tags.
+ *
+ * 빈 query 는 모든 endpoint 를 limit 까지 반환 — "이 spec 에 뭐 있는지 일단 보여줘" 용도.
+ */
+export function searchEndpoints(
+  spec: OpenapiSpec,
+  query: string,
+  limit = 20,
+): Array<{
+  method: string;
+  path: string;
+  operationId?: string;
+  summary?: string;
+  tags?: string[];
+}> {
+  if (!spec.paths || typeof spec.paths !== "object") return [];
+  const needle = (query ?? "").trim().toLowerCase();
+  const out: Array<{
+    method: string;
+    path: string;
+    operationId?: string;
+    summary?: string;
+    tags?: string[];
+  }> = [];
+  for (const [path, item] of Object.entries(spec.paths)) {
+    if (!item || typeof item !== "object") continue;
+    for (const m of HTTP_METHODS) {
+      const op = (item as OpenapiPathItem)[m];
+      if (!op || typeof op !== "object") continue;
+      // 빈 query 면 무조건 hit, 그 외에는 한 필드라도 substring 매칭되어야 한다.
+      const hit =
+        needle.length === 0 ||
+        path.toLowerCase().includes(needle) ||
+        m.includes(needle) ||
+        (op.operationId ?? "").toLowerCase().includes(needle) ||
+        (op.summary ?? "").toLowerCase().includes(needle) ||
+        (op.tags ?? []).some((t) => t.toLowerCase().includes(needle));
+      if (!hit) continue;
+      out.push({
+        method: m.toUpperCase(),
+        path,
+        operationId: op.operationId,
+        summary: op.summary,
+        tags: op.tags,
+      });
+      if (out.length >= limit) return out;
+    }
+  }
+  return out;
+}
+
+/**
+ * raw 응답이 OpenAPI 3.x 또는 swagger 2.x 인지 검증.
+ * 둘 다 아니면 throw — 호출 측이 캐시에 잘못된 페이로드를 박지 못하게 한다.
+ */
+export function assertOpenapiShape(payload: unknown): asserts payload is OpenapiSpec {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("OpenAPI payload must be a JSON object");
+  }
+  const obj = payload as Record<string, unknown>;
+  const hasOpenapi = typeof obj.openapi === "string" && obj.openapi.length > 0;
+  const hasSwagger = typeof obj.swagger === "string" && obj.swagger.length > 0;
+  if (!hasOpenapi && !hasSwagger) {
+    throw new Error(
+      "OpenAPI payload missing both `openapi` and `swagger` version fields — refusing to cache",
+    );
+  }
+}
+
+/**
+ * 파일시스템 기반 OpenAPI spec 캐시.
+ *
+ * 외부에 노출되는 메서드는 read / write / status / invalidate / list 5가지.
+ * `read` 와 `status` 는 `.json` 과 `.spec.json` 모두 존재해야 hit 으로 간주 — 한 쪽만
+ * 남아있으면 손상 상태로 보고 cache miss 처리.
+ */
+export class OpenapiCache {
+  private readonly dir: string;
+  private readonly defaultTtl: number;
+
+  constructor(options: OpenapiCacheOptions = {}) {
+    this.dir = resolve(options.baseDir ?? DEFAULT_OPENAPI_CACHE_DIR);
+    this.defaultTtl = options.defaultTtlSeconds ?? DEFAULT_OPENAPI_TTL_SECONDS;
+  }
+
+  getDir(): string {
+    return this.dir;
+  }
+
+  /** hit 이면 entry+spec, miss/만료/손상이면 null. */
+  async read(
+    input: string,
+  ): Promise<{ entry: OpenapiCacheEntry; spec: OpenapiSpec } | null> {
+    const { key } = resolveSpecKey(input);
+    const metaPath = join(this.dir, `${key}.json`);
+    const specPath = join(this.dir, `${key}.spec.json`);
+    if (!existsSync(metaPath) || !existsSync(specPath)) return null;
+    let entry: OpenapiCacheEntry;
+    let spec: OpenapiSpec;
+    try {
+      entry = JSON.parse(await readFile(metaPath, "utf8")) as OpenapiCacheEntry;
+      spec = JSON.parse(await readFile(specPath, "utf8")) as OpenapiSpec;
+    } catch {
+      return null;
+    }
+    if (this.isExpired(entry)) return null;
+    return { entry, spec };
+  }
+
+  /**
+   * raw spec 을 검증 후 캐시에 기록. spec 본문은 안정적인 들여쓰기로 re-stringify
+   * 하므로 같은 내용이면 specHash 가 동일하게 유지된다.
+   */
+  async write(
+    input: string,
+    spec: OpenapiSpec,
+    ttlSeconds?: number,
+  ): Promise<{ entry: OpenapiCacheEntry; spec: OpenapiSpec }> {
+    assertOpenapiShape(spec);
+    const { key, specUrl } = resolveSpecKey(input);
+    const serialized = `${JSON.stringify(spec, null, 2)}\n`;
+    const entry: OpenapiCacheEntry = {
+      key,
+      specUrl,
+      cachedAt: new Date().toISOString(),
+      ttlSeconds: ttlSeconds ?? this.defaultTtl,
+      specHash: specHash(serialized),
+      title: typeof spec.info?.title === "string" ? spec.info.title : "(untitled)",
+      version: typeof spec.info?.version === "string" ? spec.info.version : "",
+      openapi:
+        typeof spec.openapi === "string"
+          ? spec.openapi
+          : typeof spec.swagger === "string"
+            ? spec.swagger
+            : "",
+      endpointCount: countEndpoints(spec),
+    };
+    await mkdir(this.dir, { recursive: true });
+    await writeFile(
+      join(this.dir, `${key}.json`),
+      `${JSON.stringify(entry, null, 2)}\n`,
+      "utf8",
+    );
+    await writeFile(join(this.dir, `${key}.spec.json`), serialized, "utf8");
+    return { entry, spec };
+  }
+
+  /**
+   * 캐시 메타 + 만료 여부.
+   * `.json` 또는 `.spec.json` 한쪽이라도 없으면 exists=false 로 보고한다 — read 와 일관.
+   */
+  async status(input: string): Promise<OpenapiCacheStatus> {
+    const { key } = resolveSpecKey(input);
+    const metaPath = join(this.dir, `${key}.json`);
+    const specPath = join(this.dir, `${key}.spec.json`);
+    if (!existsSync(metaPath) || !existsSync(specPath)) {
+      return { key, exists: false, expired: false };
+    }
+    try {
+      const entry = JSON.parse(
+        await readFile(metaPath, "utf8"),
+      ) as OpenapiCacheEntry;
+      const ageSeconds = Math.max(
+        0,
+        Math.floor((Date.now() - new Date(entry.cachedAt).getTime()) / 1000),
+      );
+      return {
+        key,
+        exists: true,
+        expired: this.isExpired(entry),
+        cachedAt: entry.cachedAt,
+        ttlSeconds: entry.ttlSeconds,
+        ageSeconds,
+        title: entry.title,
+        specUrl: entry.specUrl,
+      };
+    } catch {
+      return { key, exists: false, expired: false };
+    }
+  }
+
+  /** ttl 을 0 으로 갱신해 다음 read 에서 miss 처리. */
+  async invalidate(input: string): Promise<boolean> {
+    const status = await this.status(input);
+    if (!status.exists) return false;
+    const { key } = resolveSpecKey(input);
+    const metaPath = join(this.dir, `${key}.json`);
+    const entry = JSON.parse(
+      await readFile(metaPath, "utf8"),
+    ) as OpenapiCacheEntry;
+    entry.ttlSeconds = 0;
+    await writeFile(metaPath, `${JSON.stringify(entry, null, 2)}\n`, "utf8");
+    return true;
+  }
+
+  /**
+   * 캐시 디렉터리 안의 모든 entry 를 훑어 (entry, spec) 페어로 반환.
+   * 손상되거나 만료된 항목은 건너뛴다 — search 단의 입력 필터.
+   */
+  async list(): Promise<Array<{ entry: OpenapiCacheEntry; spec: OpenapiSpec }>> {
+    if (!existsSync(this.dir)) return [];
+    const files = await readdir(this.dir);
+    const out: Array<{ entry: OpenapiCacheEntry; spec: OpenapiSpec }> = [];
+    for (const f of files) {
+      // meta 파일만 골라낸 뒤, 짝이 되는 .spec.json 이 있는지 read 가 검증한다.
+      if (!f.endsWith(".json") || f.endsWith(".spec.json")) continue;
+      const key = f.slice(0, -".json".length);
+      const r = await this.read(key);
+      if (r) out.push(r);
+    }
+    return out;
+  }
+
+  private isExpired(entry: OpenapiCacheEntry): boolean {
+    if (entry.ttlSeconds <= 0) return true;
+    const cachedAtMs = new Date(entry.cachedAt).getTime();
+    if (!Number.isFinite(cachedAtMs)) return true;
+    return Date.now() >= cachedAtMs + entry.ttlSeconds * 1000;
+  }
+}
+
+/** env 변수에서 baseDir / TTL 을 읽어 인스턴스 생성. */
+export function createOpenapiCacheFromEnv(): OpenapiCache {
+  const baseDir = process.env.AGENT_TOOLKIT_OPENAPI_CACHE_DIR;
+  const ttlRaw = process.env.AGENT_TOOLKIT_OPENAPI_CACHE_TTL;
+  const ttl = ttlRaw ? Number.parseInt(ttlRaw, 10) : undefined;
+  return new OpenapiCache({
+    baseDir,
+    defaultTtlSeconds: Number.isFinite(ttl) && ttl! > 0 ? ttl : undefined,
+  });
+}

--- a/lib/openapi-context.ts
+++ b/lib/openapi-context.ts
@@ -16,8 +16,8 @@ import { createHash } from "node:crypto";
  * 환경변수는 `AGENT_TOOLKIT_OPENAPI_CACHE_*` 로 Notion 쪽과 분리되어 있다.
  *
  * 키 정규화: spec URL 자체는 길이/문자가 다양하므로 sha256 의 앞 16자(hex) 를 디스크 키로
- * 쓰고, 원본 URL 은 entry 의 `specUrl` 에 보관한다. `resolveSpecKey` 는 URL / 짧은 키
- * (32-hex 부분) 둘 다 받아 key 만 통일.
+ * 쓰고, 원본 URL 은 entry 의 `specUrl` 에 보관한다. `resolveSpecKey` 는 spec URL 과 이미
+ * 정규화된 16-hex 키 둘 다 받아 디스크 키만 통일하고 입력 종류는 `isKeyInput` 로 알려준다.
  */
 
 /** 캐시 파일 디렉터리 기본값 — 사용자 단위. `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` 로 덮어쓴다. */
@@ -99,6 +99,8 @@ export interface OpenapiCacheStatus {
   ageSeconds?: number;
   title?: string;
   specUrl?: string;
+  /** spec.paths 의 (path × method) 합. 캐시 hit 일 때만 채워진다. */
+  endpointCount?: number;
 }
 
 export interface OpenapiSpecResult {
@@ -129,15 +131,19 @@ export interface OpenapiEndpointMatch {
   tags?: string[];
 }
 
+/** 16자 hex (sha256 앞 16자 = 디스크 key 형식) 인지 검사. */
+const KEY_PATTERN = /^[0-9a-f]{16}$/;
+
 /**
- * spec URL / 디스크 key 양쪽을 받아 정규화된 key 를 반환.
+ * spec URL / 디스크 key 양쪽을 받아 정규화된 key 와 입력 종류를 반환.
  *
- * - 입력이 16자 hex 면 그대로 key 로 사용 (이미 정규화된 상태).
- * - 그 외에는 sha256(input) 의 앞 16자를 key 로 사용.
+ * - `isKeyInput=true`: 입력이 이미 16자 hex 키 (캐시 lookup 용 — URL 정보 없음).
+ * - `isKeyInput=false`: 입력이 spec URL 또는 그에 준하는 문자열 — sha256 의 앞 16자가 key.
  *
- * 이 함수는 URL 검증을 하지 않는다 — 호출 측이 fetch 단계에서 처리한다.
+ * URL 검증은 하지 않는다 (호출 측 fetch 단계에서 처리). write 처럼 URL 이 반드시
+ * 필요한 경로에서는 `isKeyInput` 을 보고 거부해야 한다.
  */
-export function resolveSpecKey(input: string): { key: string; specUrl: string } {
+export function resolveSpecKey(input: string): { key: string; isKeyInput: boolean } {
   if (!input || typeof input !== "string") {
     throw new Error("resolveSpecKey: input must be a non-empty string");
   }
@@ -145,12 +151,11 @@ export function resolveSpecKey(input: string): { key: string; specUrl: string } 
   if (!trimmed) {
     throw new Error("resolveSpecKey: input must be a non-empty string");
   }
-  // 16자 hex (이미 정규화된 디스크 key) 면 그대로.
-  if (/^[0-9a-f]{16}$/.test(trimmed)) {
-    return { key: trimmed, specUrl: trimmed };
+  if (KEY_PATTERN.test(trimmed)) {
+    return { key: trimmed, isKeyInput: true };
   }
   const key = createHash("sha256").update(trimmed, "utf8").digest("hex").slice(0, 16);
-  return { key, specUrl: trimmed };
+  return { key, isKeyInput: false };
 }
 
 /** 짧은(앞 16자) sha256 — spec 본문 동일성 비교용. */
@@ -160,7 +165,7 @@ export function specHash(content: string): string {
 
 /**
  * spec 의 path × method 합을 센다. malformed 입력은 0.
- * 표준 HTTP method 7 종만 카운트 (`get`/`put`/`post`/`delete`/`patch`/`head`/`options`/`trace`).
+ * OpenAPI 표준 HTTP method 8 종을 카운트 (`get`/`put`/`post`/`delete`/`patch`/`head`/`options`/`trace`).
  */
 const HTTP_METHODS = [
   "get",
@@ -299,14 +304,22 @@ export class OpenapiCache {
   /**
    * raw spec 을 검증 후 캐시에 기록. spec 본문은 안정적인 들여쓰기로 re-stringify
    * 하므로 같은 내용이면 specHash 가 동일하게 유지된다.
+   *
+   * `specUrl` 은 반드시 실제 URL (sha256 의 앞 16자 형식인 디스크 key 입력은 거부) —
+   * 캐시 entry 의 `specUrl` 필드가 후속 fetch 의 source-of-truth 이기 때문이다.
    */
   async write(
-    input: string,
+    specUrl: string,
     spec: OpenapiSpec,
     ttlSeconds?: number,
   ): Promise<{ entry: OpenapiCacheEntry; spec: OpenapiSpec }> {
     assertOpenapiShape(spec);
-    const { key, specUrl } = resolveSpecKey(input);
+    const { key, isKeyInput } = resolveSpecKey(specUrl);
+    if (isKeyInput) {
+      throw new Error(
+        `OpenapiCache.write requires a spec URL, got a 16-hex cache key "${specUrl}" — pass the original URL instead`,
+      );
+    }
     const serialized = `${JSON.stringify(spec, null, 2)}\n`;
     const entry: OpenapiCacheEntry = {
       key,
@@ -362,6 +375,7 @@ export class OpenapiCache {
         ageSeconds,
         title: entry.title,
         specUrl: entry.specUrl,
+        endpointCount: entry.endpointCount,
       };
     } catch {
       return { key, exists: false, expired: false };
@@ -380,6 +394,27 @@ export class OpenapiCache {
     entry.ttlSeconds = 0;
     await writeFile(metaPath, `${JSON.stringify(entry, null, 2)}\n`, "utf8");
     return true;
+  }
+
+  /**
+   * 메타 파일이 (만료 / .spec.json 누락 여부와 무관하게) 존재하면 그 안의 `specUrl` 만 꺼내 반환.
+   * fetchAndCacheSpec 이 16-hex key 입력으로부터 원본 URL 을 복구할 때 쓴다.
+   * 메타 자체가 없거나 파싱이 깨진 경우 null.
+   */
+  async peekSpecUrl(input: string): Promise<string | null> {
+    const { key } = resolveSpecKey(input);
+    const metaPath = join(this.dir, `${key}.json`);
+    if (!existsSync(metaPath)) return null;
+    try {
+      const entry = JSON.parse(
+        await readFile(metaPath, "utf8"),
+      ) as OpenapiCacheEntry;
+      return typeof entry.specUrl === "string" && entry.specUrl.length > 0
+        ? entry.specUrl
+        : null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/skills/openapi-client/SKILL.md
+++ b/skills/openapi-client/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: openapi-client
+description: Read a cached OpenAPI / Swagger spec under a cache-first policy and emit a `fetch` or `axios` call snippet (TypeScript) for one endpoint. Auto-trigger when the user supplies an OpenAPI spec URL or 16-hex spec key together with phrases like "이 endpoint 호출 코드 만들어줘" / "axios 로 작성해줘" / "fetch snippet 줘" / "POST /pets 호출 코드".
+allowed-tools: [swagger_get, swagger_status, swagger_refresh, swagger_search]
+license: MIT
+version: 0.1.0
+---
+
+# openapi-client
+
+## Role
+
+* Locate a single endpoint inside a cached OpenAPI / Swagger JSON spec and emit a TypeScript call snippet using either `fetch` (default) or `axios`, with path / query / body parameters and a response type when the spec defines one.
+* Single endpoint, single spec at a time. The skill does not generate full SDKs, mock servers, or multi-spec merges.
+
+## Mental model
+
+```
+agent (you)
+  ├── 1. swagger_status         ← cache metadata only (no remote call)
+  ├── 2. swagger_get            ← cache hit → spec / miss → GET URL + JSON-validate + cache write (one shot)
+  ├── 3. swagger_search         ← search across cached specs to locate the endpoint
+  └── 4. swagger_refresh        ← only when the user explicitly asks for "최신화" / refresh
+```
+
+The cache is a thin TTL layer in front of the spec URL. `swagger_get` already handles cache miss by downloading the spec, validating its shape (`openapi` 3.x or `swagger` 2.x), and persisting it — no separate write step is needed. JSON-only in this version: YAML specs throw, document the limitation when the user hits it.
+
+## Tool usage rules
+
+1. Reach OpenAPI specs only through `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search`. No direct `fetch`, Read, or Bash to download the spec yourself.
+2. Unless the user explicitly asks to refresh ("최신화" / "refresh"):
+   * Check cache state first with `swagger_status` when the spec URL or key is given.
+   * If `exists=true && expired=false`, use `swagger_get` (it returns instantly from cache) and `swagger_search` to locate the endpoint.
+   * Otherwise call `swagger_get` once — it will hit the remote on cache miss automatically.
+3. Do not download the same spec more than once per turn. Reuse the spec object you already have.
+4. Use `swagger_refresh` only when the user explicitly asks to re-download.
+5. `swagger_search` spans **every cached spec**. When the user has multiple specs cached and wants results from one, scope by passing a more specific query (e.g. include the spec title or a unique path prefix).
+
+## Locating the endpoint
+
+Given an ambiguous request ("POST /pets 호출 코드 만들어줘"):
+
+1. If the user already gave a spec URL / 16-hex key, run `swagger_get` for that spec, then look up the endpoint by `(method, path)` in `spec.paths`.
+2. Otherwise use `swagger_search` with the path and/or operationId substring. If multiple matches come back, surface the candidates (`specTitle` + `method path` + `summary`) and ask the user which one.
+3. If zero matches, do not invent the endpoint — quote what you searched for and ask the user to clarify the spec or the path.
+
+## Output format — fetch snippet (default)
+
+```ts
+// <method> <path> — <summary if present>
+// spec: <specTitle> @ <specUrl>
+type <PascalCaseOperationId>Response = /* response shape from spec, or `unknown` if not declared */;
+
+export async function <camelCaseOperationId>(
+  // path params, then query, then body — only ones the spec declares
+): Promise<<PascalCaseOperationId>Response> {
+  const url = `${BASE_URL}<path with ${pathParam} substitutions>`;
+  const res = await fetch(url, {
+    method: "<METHOD>",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: /* JSON.stringify(body) when there is a body, else undefined */,
+  });
+  if (!res.ok) {
+    throw new Error(`<operationId> failed: ${res.status} ${res.statusText}`);
+  }
+  return res.json() as Promise<<PascalCaseOperationId>Response>;
+}
+
+// Example
+// const u = await <camelCaseOperationId>(/* … */);
+```
+
+## Output format — axios snippet (on request)
+
+```ts
+// <method> <path> — <summary if present>
+// spec: <specTitle> @ <specUrl>
+import axios from "axios";
+
+type <PascalCaseOperationId>Response = /* … */;
+
+export async function <camelCaseOperationId>(
+  // path params, then query, then body
+): Promise<<PascalCaseOperationId>Response> {
+  const { data } = await axios.<method-lowercase>(
+    `${BASE_URL}<path>`,
+    /* body OR config — depends on method */,
+  );
+  return data as <PascalCaseOperationId>Response;
+}
+```
+
+## Writing rules
+
+* The body of the SKILL output (this skill's user-facing answer) is in Korean; the generated code is in English / TypeScript with English identifiers — no translation of operationIds or paths.
+* Use `operationId` to derive both the function name (camelCase) and response type (PascalCase). If `operationId` is absent, fall back to `<method>_<path-slug>` and call this out in one sentence.
+* Path parameters → required positional args, in spec declaration order.
+* Query parameters → one trailing `query?: { … }` arg with optional fields by default; required ones explicitly typed as required.
+* Request body → one trailing `body: <type>` arg when the operation declares a body; type pulled from `requestBody.content["application/json"].schema` if present, else `unknown`.
+* Response type → from the first `2xx` response's `application/json` schema. If the spec does not declare it, type as `unknown` and say so in one inline comment.
+* `BASE_URL` is a placeholder constant; do not bake a hostname into the snippet.
+
+## Do NOT
+
+* Do not download a spec without going through the `swagger_*` tools — that defeats the cache and skips the shape validation.
+* Do not generate code for an endpoint that is not present in the cached spec — quote the search query and ask.
+* Do not invent a response or body type. If the spec does not declare it, use `unknown` and surface the gap in one inline comment.
+* Do not paste the entire spec into the answer. The user wants one snippet plus a usage line.
+* Do not assume YAML support. If `swagger_get` rejects with a non-JSON body, tell the user the spec is YAML and that this skill is JSON-only in MVP.
+
+## Failure / error handling
+
+* `swagger_get` throws on timeout / network error / non-JSON body / missing `openapi` / `swagger` field → surface the error in one sentence and ask the user to verify the spec URL and `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS`.
+* `swagger_search` returns 0 matches → quote the query and ask which spec / path, do not hallucinate.
+* The endpoint exists but lacks `operationId` / response schema → emit the snippet with the documented fallback (path-slug name, `unknown` response) and call out the gap in one inline comment.


### PR DESCRIPTION
Closes #6.

## Summary

ROADMAP 의 Phase 4 — OpenAPI / Swagger JSON spec 캐시 + endpoint 검색 + 한 endpoint → `fetch`/`axios` snippet skill.

- `lib/openapi-context.ts` — `OpenapiCache` (read/write/status/invalidate/list 5 메서드) + `resolveSpecKey` (sha256(specUrl) 앞 16자) + `searchEndpoints` (path/method/tag/operationId/summary substring) + `assertOpenapiShape` (openapi 3.x / swagger 2.x 검증). 디스크 layout 은 Notion 캐시와 같은 두-파일 모양 (`<key>.json` 메타 + `<key>.spec.json` 본문).
- `.opencode/plugins/agent-toolkit.ts` — `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` 4 도구 + `downloadOpenapiSpec` (AbortController + JSON-only + shape 검증). 기존 `notion_*` 3 도구 그대로 유지, plugin 의 `config` 훅도 그대로.
- `skills/openapi-client/SKILL.md` — 캐시-우선 정책 + endpoint 검색 흐름 + `fetch` (default) / `axios` snippet 출력 형식 + Do NOT 가이드.
- 캐시 위치 컨벤션 변경: `~/.cache/` → `~/.config/opencode/agent-toolkit/*` (사용자 요청). Notion 캐시 기본값도 `~/.config/opencode/agent-toolkit/notion-pages` 로 이전. 환경변수 이름은 유지하고 기본값만 갱신.
- `README.md` / `AGENTS.md` / `.opencode/INSTALL.md` / `ROADMAP.md` 동기화 — 도구 / env-var / MVP scope / 디렉터리 트리 / 변경 체크리스트 / Phase 4 상태 (📋 → ✅ MVP).

## 설계 결정

- **JSON-only**: spec URL 다운로드 단계에서 YAML 미지원 (의존성 0 유지). YAML 필요해지면 후속 이슈로.
- **all-cached-specs 통합 검색**: `swagger_search` 는 캐시된 모든 spec 을 가로지른다. 사용자가 더 좁은 결과를 원하면 query 에 spec title / 고유 path prefix 를 넣어 좁힌다.
- **단일 endpoint 단위 snippet**: 전체 SDK / mock server / multi-spec merge 는 MVP scope 밖.

## Test plan

- [x] `bun run typecheck` 통과
- [x] `bun run test` (46 pass / 0 fail / 3 files — 기존 16 + 캐시 23 + plugin swagger 7)
- [ ] 수동: `AGENT_TOOLKIT_OPENAPI_CACHE_DIR=/tmp/oa` 로 두고 공개 spec (e.g. `https://petstore3.swagger.io/api/v3/openapi.json`) 으로 `swagger_status` → `swagger_get` (fromCache=false → true) → `swagger_search "/pet"` 흐름 확인
- [ ] opencode 에 plugin 로드 후 skill 목록에 `notion-context` + `openapi-client` 둘 다 보이는지 확인
- [ ] 기존 `~/.cache/notion-context/pages` 캐시를 쓰던 사용자에게는 새 위치 안내 (기본값만 바뀐 것이라 환경변수 명시 시 그대로 동작)



---
_Generated by [Claude Code](https://claude.ai/code/session_01QF81RMUzRxV8Dcbafmii9N)_