### PR TITLE
feat(phase4.5): OpenAPI environment registry — host:env:spec handles

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,6 +1,6 @@
-# opencode 설치
+# opencode install
 
-`opencode.json` 의 `plugin` 배열에 이 저장소를 추가한 뒤 opencode 를 재시작한다.
+Add this repository to the `plugin` array in `opencode.json` and restart opencode.
 
 ```json
 {
@@ -10,7 +10,7 @@
 }
 ```
 
-또는 로컬 체크아웃을 직접 쓰려면:
+Or, to use a local checkout directly:
 
 ```json
 {
@@ -18,46 +18,46 @@
 }
 ```
 
-## 환경변수
+## Environment variables
 
-전부 옵션이다. 기본값을 바꿔야 할 때만 설정한다.
+All optional. Set only when the defaults do not fit.
 
-| 변수 | 기본값 | 설명 |
+| Variable | Default | Description |
 | --- | --- | --- |
-| `AGENT_TOOLKIT_NOTION_MCP_URL` | `https://mcp.notion.com/mcp` | remote Notion MCP base URL. 인증은 OAuth 가 처리하므로 토큰 변수는 없다. |
-| `AGENT_TOOLKIT_NOTION_MCP_TIMEOUT_MS` | `15000` | remote Notion 호출 timeout (ms) |
-| `AGENT_TOOLKIT_CACHE_DIR` | `~/.config/opencode/agent-toolkit/notion-pages` | Notion 페이지 캐시 디렉터리 |
-| `AGENT_TOOLKIT_CACHE_TTL` | `86400` | Notion 캐시 TTL (초) |
-| `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` | `~/.config/opencode/agent-toolkit/openapi-specs` | OpenAPI / Swagger spec 캐시 디렉터리 |
-| `AGENT_TOOLKIT_OPENAPI_CACHE_TTL` | `86400` | OpenAPI 캐시 TTL (초) |
-| `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS` | `30000` | OpenAPI spec 다운로드 timeout (ms) |
-| `AGENT_TOOLKIT_CONFIG` | `~/.config/opencode/agent-toolkit/agent-toolkit.json` | user-level `agent-toolkit.json` 경로. project-level `./.opencode/agent-toolkit.json` 가 leaf 단위로 우선한다. |
+| `AGENT_TOOLKIT_NOTION_MCP_URL` | `https://mcp.notion.com/mcp` | Remote Notion MCP base URL. Auth goes through Notion's OAuth, so there is no token variable. |
+| `AGENT_TOOLKIT_NOTION_MCP_TIMEOUT_MS` | `15000` | Remote Notion call timeout (ms). |
+| `AGENT_TOOLKIT_CACHE_DIR` | `~/.config/opencode/agent-toolkit/notion-pages` | Notion page cache directory. |
+| `AGENT_TOOLKIT_CACHE_TTL` | `86400` | Notion cache TTL (seconds). |
+| `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` | `~/.config/opencode/agent-toolkit/openapi-specs` | OpenAPI / Swagger spec cache directory. |
+| `AGENT_TOOLKIT_OPENAPI_CACHE_TTL` | `86400` | OpenAPI cache TTL (seconds). |
+| `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS` | `30000` | OpenAPI spec download timeout (ms). |
+| `AGENT_TOOLKIT_CONFIG` | `~/.config/opencode/agent-toolkit/agent-toolkit.json` | User-level `agent-toolkit.json` path. The project-level `./.opencode/agent-toolkit.json` overrides it at the leaf level. |
 
-## 동작 확인
+## Smoke test
 
-opencode 를 띄운 뒤:
+Once opencode is running:
 
 ```
 > use skill tool to list skills
 ```
 
-목록에 `notion-context` / `openapi-client` 가 둘 다 보이면 skill 로딩 OK.
+If `notion-context` and `openapi-client` both show up, skills are loaded.
 
-도구 등록도 확인:
+Then verify the tools are registered:
 
 ```
 > use notion_status tool with input "<pageId or url>"
 > use notion_get tool with input "<pageId or url>"
 > use swagger_status tool with input "<spec URL or host:env:spec handle>"
 > use swagger_get tool with input "<spec URL or host:env:spec handle>"
-> use swagger_envs tool   # agent-toolkit.json 의 등록 목록을 평면 리스트로
+> use swagger_envs tool   # flatten the registry from agent-toolkit.json
 ```
 
-첫 호출은 `fromCache: false` 로 remote 가 한 번 불리고, 두 번째 호출은 `fromCache: true` 가 되어야 한다 (`notion_*` / `swagger_*` 둘 다 동일 정책).
+The first call returns `fromCache: false` — remote is hit once. The second call returns `fromCache: true` (same policy for `notion_*` and `swagger_*`).
 
 ## OpenAPI registry (`agent-toolkit.json`)
 
-`agent-toolkit.json` 을 작성하면 spec URL 대신 `host:env:spec` 형식의 짧은 handle 로 호출할 수 있다. project (`./.opencode/agent-toolkit.json`) 가 user (`~/.config/opencode/agent-toolkit/agent-toolkit.json`) 를 leaf 단위로 덮어쓴다.
+Once you write an `agent-toolkit.json`, the swagger tools accept short `host:env:spec` handles in addition to raw URLs. The project file (`./.opencode/agent-toolkit.json`) overrides the user file (`~/.config/opencode/agent-toolkit/agent-toolkit.json`) at the leaf level.
 
 ```jsonc
 {
@@ -74,31 +74,31 @@ opencode 를 띄운 뒤:
 }
 ```
 
-이후:
+After that:
 
 ```
 > use swagger_get tool with input "acme:dev:users"
 > use swagger_search tool with query "/pets" scope "acme:dev"
 ```
 
-식별자 패턴은 `^[a-zA-Z0-9_-]+$` — 콜론은 separator 로 예약. config 가 schema 를 어기면 plugin 은 콘솔에 한 줄 에러를 찍고 빈 registry 로 동작한다 (도구 자체가 죽지는 않음).
+Identifier pattern is `^[a-zA-Z0-9_-]+$` — colons are reserved as the handle separator. URLs must parse and use `http`, `https`, or `file` scheme. If the config violates the schema, the plugin logs a single error line and falls back to an empty registry — the tools themselves keep working.
 
 ## Agent (`rocky`)
 
-`agents/rocky.md` 가 plugin 의 config 훅을 통해 opencode agent 경로에 등록된다. `mode: all` 이라 primary 사이클(Tab) 과 다른 primary 의 subagent 위임 둘 다에서 보인다.
+`agents/rocky.md` is registered into opencode's agent path via the plugin's `config` hook. `mode: all` means it shows up both in the primary cycle (Tab) and as a delegation target from another primary agent.
 
-직접 호출 (컨텍스트 모드):
+Direct invocation (context mode):
 
 ```
 @rocky https://www.notion.so/.../<pageId>
 ```
 
-스펙 모드:
+Spec mode:
 
 ```
 @rocky <Notion URL> 스펙 정리해줘
 ```
 
-OmO 같이 자체 primary agent (Sisyphus 등) 를 쓰는 환경에선, primary 가 turn 시작 시 받는 subagent 목록에서 `rocky` 의 description 을 보고 Notion 관련 요청을 자동으로 위임한다 (보장은 안 됨 — primary 가 직접 처리하기로 결정할 수도 있음). Rocky 의 존재를 OmO 측 system prompt 에 박을 필요는 없다.
+In a setup that already has its own primary agent (e.g. OmO Sisyphus), that agent sees `rocky` in its subagent list (turn start) and routes Notion requests to it via the description — no need to hard-code Rocky's existence into the upstream agent's system prompt. Routing is not guaranteed; the primary may decide to handle it directly.
 
-plugin 이 미등록이거나 `agents.paths` 가 인식되지 않는 opencode 버전이면, 프로젝트의 `.opencode/agents/rocky.md` 로 직접 심볼릭 링크하거나 복사해서 쓴다.
+If the plugin is not registered, or the opencode version does not recognize `agents.paths`, drop a symlink or copy of `agents/rocky.md` into the project's `.opencode/agents/` instead.

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -31,6 +31,7 @@
 | `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` | `~/.config/opencode/agent-toolkit/openapi-specs` | OpenAPI / Swagger spec 캐시 디렉터리 |
 | `AGENT_TOOLKIT_OPENAPI_CACHE_TTL` | `86400` | OpenAPI 캐시 TTL (초) |
 | `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS` | `30000` | OpenAPI spec 다운로드 timeout (ms) |
+| `AGENT_TOOLKIT_CONFIG` | `~/.config/opencode/agent-toolkit/agent-toolkit.json` | user-level `agent-toolkit.json` 경로. project-level `./.opencode/agent-toolkit.json` 가 leaf 단위로 우선한다. |
 
 ## 동작 확인
 
@@ -47,11 +48,40 @@ opencode 를 띄운 뒤:
 ```
 > use notion_status tool with input "<pageId or url>"
 > use notion_get tool with input "<pageId or url>"
-> use swagger_status tool with input "<spec URL>"
-> use swagger_get tool with input "<spec URL>"
+> use swagger_status tool with input "<spec URL or host:env:spec handle>"
+> use swagger_get tool with input "<spec URL or host:env:spec handle>"
+> use swagger_envs tool   # agent-toolkit.json 의 등록 목록을 평면 리스트로
 ```
 
 첫 호출은 `fromCache: false` 로 remote 가 한 번 불리고, 두 번째 호출은 `fromCache: true` 가 되어야 한다 (`notion_*` / `swagger_*` 둘 다 동일 정책).
+
+## OpenAPI registry (`agent-toolkit.json`)
+
+`agent-toolkit.json` 을 작성하면 spec URL 대신 `host:env:spec` 형식의 짧은 handle 로 호출할 수 있다. project (`./.opencode/agent-toolkit.json`) 가 user (`~/.config/opencode/agent-toolkit/agent-toolkit.json`) 를 leaf 단위로 덮어쓴다.
+
+```jsonc
+{
+  "$schema": "https://raw.githubusercontent.com/minjun0219/coding-agent-toolkit/main/agent-toolkit.schema.json",
+  "openapi": {
+    "registry": {
+      "acme": {
+        "dev":  { "users": "https://dev.acme/users.json",
+                  "orders": "https://dev.acme/orders.json" },
+        "prod": { "users": "https://api.acme/users.json" }
+      }
+    }
+  }
+}
+```
+
+이후:
+
+```
+> use swagger_get tool with input "acme:dev:users"
+> use swagger_search tool with query "/pets" scope "acme:dev"
+```
+
+식별자 패턴은 `^[a-zA-Z0-9_-]+$` — 콜론은 separator 로 예약. config 가 schema 를 어기면 plugin 은 콘솔에 한 줄 에러를 찍고 빈 registry 로 동작한다 (도구 자체가 죽지는 않음).
 
 ## Agent (`rocky`)
 

--- a/.opencode/plugins/agent-toolkit.test.ts
+++ b/.opencode/plugins/agent-toolkit.test.ts
@@ -4,10 +4,12 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { NotionCache } from "../../lib/notion-context";
 import { OpenapiCache } from "../../lib/openapi-context";
+import type { OpenapiRegistry } from "../../lib/toolkit-config";
 import agentToolkitPlugin, {
   handleNotionGet,
   handleNotionRefresh,
   handleNotionStatus,
+  handleSwaggerEnvs,
   handleSwaggerGet,
   handleSwaggerRefresh,
   handleSwaggerSearch,
@@ -248,8 +250,115 @@ describe("swagger handlers", () => {
     const all = await handleSwaggerSearch(oaCache, "");
     expect(all.length).toBe(4);
 
-    const limited = await handleSwaggerSearch(oaCache, "", 2);
+    const limited = await handleSwaggerSearch(oaCache, "", { limit: 2 });
     expect(limited.length).toBe(2);
+  });
+});
+
+describe("swagger handlers — registry handles", () => {
+  let oaDir: string;
+  let oaCache: OpenapiCache;
+  let oaServer: ReturnType<typeof Bun.serve>;
+  let baseUrl: string;
+  let registry: OpenapiRegistry;
+
+  const SAMPLE = (title: string) => ({
+    openapi: "3.0.0",
+    info: { title, version: "1.0.0" },
+    paths: {
+      "/pets": {
+        get: { operationId: `${title}-listPets`, summary: "List", tags: ["pet"] },
+      },
+    },
+  });
+
+  beforeEach(() => {
+    oaDir = mkdtempSync(join(tmpdir(), "plugin-oa-reg-"));
+    oaCache = new OpenapiCache({ baseDir: oaDir, defaultTtlSeconds: 60 });
+    oaServer = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const u = new URL(req.url);
+        if (u.pathname === "/dev/users.json") return Response.json(SAMPLE("dev-users"));
+        if (u.pathname === "/dev/orders.json") return Response.json(SAMPLE("dev-orders"));
+        if (u.pathname === "/prod/users.json") return Response.json(SAMPLE("prod-users"));
+        return new Response("not found", { status: 404 });
+      },
+    });
+    baseUrl = `http://${oaServer.hostname}:${oaServer.port}`;
+    registry = {
+      acme: {
+        dev: {
+          users: `${baseUrl}/dev/users.json`,
+          orders: `${baseUrl}/dev/orders.json`,
+        },
+        prod: {
+          users: `${baseUrl}/prod/users.json`,
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    oaServer.stop(true);
+  });
+
+  it("swagger_get accepts a host:env:spec handle and resolves via registry", async () => {
+    const r = await handleSwaggerGet(oaCache, "acme:dev:users", registry);
+    expect(r.fromCache).toBe(false);
+    expect(r.entry.title).toBe("dev-users");
+    // 캐시에 같은 URL 로 박혀 있어야 — handle 이 아니라.
+    const status = await handleSwaggerStatus(oaCache, `${baseUrl}/dev/users.json`);
+    expect(status.exists).toBe(true);
+  });
+
+  it("swagger_get throws on unregistered handle", async () => {
+    await expect(
+      handleSwaggerGet(oaCache, "acme:dev:missing", registry),
+    ).rejects.toThrow(/acme:dev:missing/);
+  });
+
+  it("swagger_search scope=host:env limits the search to that env", async () => {
+    await handleSwaggerGet(oaCache, "acme:dev:users", registry);
+    await handleSwaggerGet(oaCache, "acme:dev:orders", registry);
+    await handleSwaggerGet(oaCache, "acme:prod:users", registry);
+
+    const dev = await handleSwaggerSearch(
+      oaCache,
+      "pet",
+      { scope: "acme:dev" },
+      registry,
+    );
+    expect(dev.length).toBe(2);
+    expect(dev.every((m) => m.specTitle.startsWith("dev-"))).toBe(true);
+
+    const prod = await handleSwaggerSearch(
+      oaCache,
+      "pet",
+      { scope: "acme:prod" },
+      registry,
+    );
+    expect(prod.length).toBe(1);
+    expect(prod[0]?.specTitle).toBe("prod-users");
+  });
+
+  it("swagger_search throws on unknown scope", async () => {
+    await handleSwaggerGet(oaCache, "acme:dev:users", registry);
+    await expect(
+      handleSwaggerSearch(oaCache, "pet", { scope: "nope" }, registry),
+    ).rejects.toThrow(/scope.*nope/i);
+  });
+
+  it("swagger_envs returns the flat registry list", () => {
+    const flat = handleSwaggerEnvs({ openapi: { registry } });
+    expect(flat.length).toBe(3);
+    const names = flat.map((e) => `${e.host}:${e.env}:${e.spec}`).sort();
+    expect(names).toEqual(["acme:dev:orders", "acme:dev:users", "acme:prod:users"]);
+  });
+
+  it("swagger_envs returns [] for empty config", () => {
+    expect(handleSwaggerEnvs({})).toEqual([]);
   });
 });
 

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -381,16 +381,13 @@ export default async function agentToolkitPlugin(_input: unknown) {
   const cache = createCacheFromEnv();
   const openapi = createOpenapiCacheFromEnv();
 
-  // user / project agent-toolkit.json 로드. 잘못된 config 가 plugin 로딩 자체를 막지
-  // 않도록 try-catch — registry 가 없는 상태로라도 plugin 은 동작해야 한다.
-  // err 가 Error 인스턴스가 아닐 가능성도 막아 컨텍스트 손실 방지.
-  let toolkitConfig: ToolkitConfig = {};
-  try {
-    toolkitConfig = await loadConfig();
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  // user / project agent-toolkit.json 로드. loadConfig 는 파일별 try-catch 로 자체
+  // 회복하므로 한 쪽이 손상돼도 다른 쪽은 그대로 살아나 registry 에 들어온다.
+  // 손상된 파일별 에러는 console.error 로 한 줄씩 surfacing.
+  const { config: toolkitConfig, errors: configErrors } = await loadConfig();
+  for (const e of configErrors) {
     console.error(
-      `agent-toolkit: failed to load config — ${message}. Continuing with empty registry.`,
+      `agent-toolkit: skipped config file ${e.source} — ${e.message}. Other config sources still apply.`,
     );
   }
   const registry = toolkitConfig.openapi?.registry;

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -383,12 +383,14 @@ export default async function agentToolkitPlugin(_input: unknown) {
 
   // user / project agent-toolkit.json 로드. 잘못된 config 가 plugin 로딩 자체를 막지
   // 않도록 try-catch — registry 가 없는 상태로라도 plugin 은 동작해야 한다.
+  // err 가 Error 인스턴스가 아닐 가능성도 막아 컨텍스트 손실 방지.
   let toolkitConfig: ToolkitConfig = {};
   try {
     toolkitConfig = await loadConfig();
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     console.error(
-      `agent-toolkit: failed to load config — ${(err as Error).message}. Continuing with empty registry.`,
+      `agent-toolkit: failed to load config — ${message}. Continuing with empty registry.`,
     );
   }
   const registry = toolkitConfig.openapi?.registry;

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -20,6 +20,18 @@ import {
   type OpenapiSpec,
   type OpenapiSpecResult,
 } from "../../lib/openapi-context";
+import {
+  isFullHandle,
+  listRegistry,
+  resolveHandleToUrl,
+  resolveScopeToUrls,
+  type OpenapiRegistryEntry,
+} from "../../lib/openapi-registry";
+import {
+  loadConfig,
+  type OpenapiRegistry,
+  type ToolkitConfig,
+} from "../../lib/toolkit-config";
 
 /**
  * opencode plugin entrypoint (Superpowers 형식).
@@ -249,44 +261,90 @@ async function fetchAndCacheSpec(
   return { ...written, fromCache: false };
 }
 
+/**
+ * 입력을 spec URL (또는 16-hex 디스크 key) 로 정규화한다.
+ *
+ * - URL 또는 16-hex 키 → 그대로 반환
+ * - `host:env:spec` handle → registry 에서 URL 로 해석. 미등록이면 throw.
+ *
+ * URL / key 의 구분은 cache 단의 `resolveSpecKey` 가 isKeyInput 으로 처리하므로
+ * 여기서는 그대로 흘려보낸다.
+ */
+function resolveSwaggerInput(
+  input: string,
+  registry: OpenapiRegistry | undefined,
+): string {
+  if (isFullHandle(input)) {
+    return resolveHandleToUrl(input, registry);
+  }
+  return input;
+}
+
+/** swagger_search 옵션 — `scope` 는 host / host:env / host:env:spec 중 하나. */
+export interface SwaggerSearchOptions {
+  limit?: number;
+  scope?: string;
+}
+
 /** 도구 핸들러: 캐시 우선. 단위 테스트에서 직접 호출 가능하도록 export. */
 export async function handleSwaggerGet(
   cache: OpenapiCache,
   input: string,
+  registry?: OpenapiRegistry,
 ): Promise<OpenapiSpecResult> {
-  const cached = await cache.read(input);
+  const url = resolveSwaggerInput(input, registry);
+  const cached = await cache.read(url);
   if (cached) return { ...cached, fromCache: true };
-  return fetchAndCacheSpec(cache, input);
+  return fetchAndCacheSpec(cache, url);
 }
 
 export async function handleSwaggerRefresh(
   cache: OpenapiCache,
   input: string,
+  registry?: OpenapiRegistry,
 ): Promise<OpenapiSpecResult> {
-  return fetchAndCacheSpec(cache, input);
+  const url = resolveSwaggerInput(input, registry);
+  return fetchAndCacheSpec(cache, url);
 }
 
 export async function handleSwaggerStatus(
   cache: OpenapiCache,
   input: string,
+  registry?: OpenapiRegistry,
 ): Promise<OpenapiCacheStatus> {
-  return cache.status(input);
+  const url = resolveSwaggerInput(input, registry);
+  return cache.status(url);
 }
 
 /**
- * 캐시된 모든 spec 을 가로질러 endpoint substring 검색.
- * - 결과는 caller 가 입력한 `limit` 까지 (기본 20).
- * - 빈 query 는 캐시된 모든 endpoint 를 limit 까지 나열.
+ * 캐시된 spec 을 가로질러 endpoint substring 검색.
+ * - `options.scope` (`host` / `host:env` / `host:env:spec`) 가 주어지면 registry 에서
+ *   해당 URL 들로 좁혀 그 안에서만 검색. 매칭 0 건이면 throw — 사용자가 잘못된 scope 를
+ *   넘겼음을 빨리 알리려고.
+ * - `options.limit` 는 결과 최대 개수 (기본 20).
+ * - 빈 query 는 (scope 안의) 모든 endpoint 를 limit 까지 나열.
  */
 export async function handleSwaggerSearch(
   cache: OpenapiCache,
   query: string,
-  limit?: number,
+  options: SwaggerSearchOptions = {},
+  registry?: OpenapiRegistry,
 ): Promise<OpenapiEndpointMatch[]> {
+  const { limit, scope } = options;
   const cap = Number.isFinite(limit) && (limit as number) > 0 ? (limit as number) : 20;
   const all = await cache.list();
+  let pool = all;
+  if (scope) {
+    const allowed = new Set(resolveScopeToUrls(scope, registry));
+    if (allowed.size === 0) {
+      throw new Error(
+        `swagger_search: scope "${scope}" matched no entries in openapi.registry — check ./.opencode/agent-toolkit.json or ~/.config/opencode/agent-toolkit/agent-toolkit.json`,
+      );
+    }
+    pool = all.filter((r) => allowed.has(r.entry.specUrl));
+  }
   const out: OpenapiEndpointMatch[] = [];
-  for (const { entry, spec } of all) {
+  for (const { entry, spec } of pool) {
     const remaining = cap - out.length;
     if (remaining <= 0) break;
     const matches = searchEndpoints(spec, query, remaining);
@@ -307,6 +365,13 @@ export async function handleSwaggerSearch(
   return out;
 }
 
+/** registry 트리를 평면 (host, env, spec, url) 리스트로 반환. remote 호출 없음. */
+export function handleSwaggerEnvs(
+  config: ToolkitConfig,
+): OpenapiRegistryEntry[] {
+  return listRegistry(config);
+}
+
 /**
  * opencode plugin default export.
  * `directory` 는 opencode 가 plugin 을 로드한 cwd. 우리는 import.meta 기반으로
@@ -315,6 +380,18 @@ export async function handleSwaggerSearch(
 export default async function agentToolkitPlugin(_input: unknown) {
   const cache = createCacheFromEnv();
   const openapi = createOpenapiCacheFromEnv();
+
+  // user / project agent-toolkit.json 로드. 잘못된 config 가 plugin 로딩 자체를 막지
+  // 않도록 try-catch — registry 가 없는 상태로라도 plugin 은 동작해야 한다.
+  let toolkitConfig: ToolkitConfig = {};
+  try {
+    toolkitConfig = await loadConfig();
+  } catch (err) {
+    console.error(
+      `agent-toolkit: failed to load config — ${(err as Error).message}. Continuing with empty registry.`,
+    );
+  }
+  const registry = toolkitConfig.openapi?.registry;
 
   return {
     /**
@@ -362,37 +439,54 @@ export default async function agentToolkitPlugin(_input: unknown) {
       },
       swagger_get: {
         description:
-          "OpenAPI / Swagger JSON spec 을 캐시 우선 정책으로 가져온다. 캐시 hit 이면 remote 호출 없음. miss 면 spec URL 을 GET 으로 받아 형식 검증 후 캐시에 저장. (input: spec URL 또는 이미 캐시된 16-hex key)",
+          "OpenAPI / Swagger JSON spec 을 캐시 우선 정책으로 가져온다. 캐시 hit 이면 remote 호출 없음. miss 면 spec URL 을 GET 으로 받아 형식 검증 후 캐시에 저장. (input: spec URL, agent-toolkit.json 의 host:env:spec handle, 또는 이미 캐시된 16-hex key)",
         parameters: { input: { type: "string", required: true } },
         async handler({ input }: { input: string }) {
-          return handleSwaggerGet(openapi, input);
+          return handleSwaggerGet(openapi, input, registry);
         },
       },
       swagger_refresh: {
         description:
-          "캐시를 무시하고 OpenAPI spec URL 에서 강제로 다시 가져와 캐시를 갱신한다. (input: spec URL)",
+          "캐시를 무시하고 OpenAPI spec URL 에서 강제로 다시 가져와 캐시를 갱신한다. (input: spec URL 또는 host:env:spec handle)",
         parameters: { input: { type: "string", required: true } },
         async handler({ input }: { input: string }) {
-          return handleSwaggerRefresh(openapi, input);
+          return handleSwaggerRefresh(openapi, input, registry);
         },
       },
       swagger_status: {
         description:
-          "캐시된 OpenAPI spec 의 메타(저장 시각, TTL, 만료 여부, title, endpoint 수)만 조회. remote 호출 없음. (input: spec URL 또는 16-hex key)",
+          "캐시된 OpenAPI spec 의 메타(저장 시각, TTL, 만료 여부, title, endpointCount)만 조회. remote 호출 없음. (input: spec URL, host:env:spec handle, 또는 16-hex key)",
         parameters: { input: { type: "string", required: true } },
         async handler({ input }: { input: string }) {
-          return handleSwaggerStatus(openapi, input);
+          return handleSwaggerStatus(openapi, input, registry);
         },
       },
       swagger_search: {
         description:
-          "캐시된 모든 OpenAPI spec 을 가로질러 path / method / tag / operationId / summary 를 substring 으로 검색한다. remote 호출 없음. (query: 검색어, limit?: 결과 최대 개수, 기본 20)",
+          "캐시된 OpenAPI spec 들을 가로질러 path / method / tag / operationId / summary 를 substring 으로 검색한다. remote 호출 없음. (query: 검색어, limit?: 결과 최대 개수 기본 20, scope?: agent-toolkit.json 에 등록된 host / host:env / host:env:spec — 주면 그 안에서만 검색)",
         parameters: {
           query: { type: "string", required: true },
           limit: { type: "number", required: false },
+          scope: { type: "string", required: false },
         },
-        async handler({ query, limit }: { query: string; limit?: number }) {
-          return handleSwaggerSearch(openapi, query, limit);
+        async handler({
+          query,
+          limit,
+          scope,
+        }: {
+          query: string;
+          limit?: number;
+          scope?: string;
+        }) {
+          return handleSwaggerSearch(openapi, query, { limit, scope }, registry);
+        },
+      },
+      swagger_envs: {
+        description:
+          "agent-toolkit.json 의 openapi.registry 를 host:env:spec 평면 리스트로 반환한다. remote 호출 없음. config 가 없거나 비어 있으면 빈 배열.",
+        parameters: {},
+        async handler() {
+          return handleSwaggerEnvs(toolkitConfig);
         },
       },
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,16 @@ Shared guide for AI coding agents (Claude Code, opencode, codex, etc.) working i
 
 ## Project in one line
 
-opencode-only plugin. Three Notion cache tools + four OpenAPI cache & search tools + two cache-first skills (`notion-context` for context / Korean specs, `openapi-client` for `fetch`/`axios` snippets) + one thin gateway agent (`rocky`, naming convention borrowed from [OmO](https://github.com/code-yeongyu/oh-my-openagent)'s named-specialist pattern). **Runtime is Bun (>=1.0). No Node. No build step (Bun runs TS directly).** Layout follows the [obra/superpowers](https://github.com/obra/superpowers) shape.
+opencode-only plugin. Three Notion cache tools + five OpenAPI tools (cache, search, environment registry) + two cache-first skills (`notion-context` for context / Korean specs, `openapi-client` for `fetch`/`axios` snippets) + one thin gateway agent (`rocky`, naming convention borrowed from [OmO](https://github.com/code-yeongyu/oh-my-openagent)'s named-specialist pattern). OpenAPI specs can be addressed by URL or by `host:env:spec` handles declared in `agent-toolkit.json` (project > user precedence). **Runtime is Bun (>=1.0). No Node. No build step (Bun runs TS directly).** Layout follows the [obra/superpowers](https://github.com/obra/superpowers) shape.
 
 ## Layout
 
-- `.opencode/plugins/agent-toolkit.ts` — plugin entrypoint. `config` hook registers `skills/` and `agents/`, and exposes seven tools: `notion_get` / `notion_refresh` / `notion_status` plus `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search`.
+- `.opencode/plugins/agent-toolkit.ts` — plugin entrypoint. `config` hook registers `skills/` and `agents/`, and exposes eight tools: `notion_get` / `notion_refresh` / `notion_status` plus `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` / `swagger_envs`.
 - `lib/notion-context.ts` — single-file TTL filesystem cache for Notion pages + `resolveCacheKey` + `notionToMarkdown`.
 - `lib/openapi-context.ts` — single-file TTL filesystem cache for OpenAPI / Swagger JSON specs + `resolveSpecKey` + `searchEndpoints` + shape validation.
+- `lib/openapi-registry.ts` — `host:env:spec` handle parsing, scope resolution, and registry flattening on top of the toolkit config.
+- `lib/toolkit-config.ts` — `agent-toolkit.json` loader (project `./.opencode/agent-toolkit.json` overrides user `~/.config/opencode/agent-toolkit/agent-toolkit.json`) with runtime shape validation.
+- `agent-toolkit.schema.json` — JSON Schema for `agent-toolkit.json` (IDE autocomplete; runtime validation lives in `toolkit-config.ts`).
 - `skills/notion-context/SKILL.md` — Notion cache-first read + Korean-language spec extraction skill.
 - `skills/openapi-client/SKILL.md` — cached OpenAPI spec → `fetch` or `axios` call snippet skill.
 - `agents/rocky.md` — thin gateway agent (`mode: all`) that exposes the toolkit's Notion flow to users and to other primary agents (e.g. OmO Sisyphus).
@@ -38,9 +41,9 @@ Only `AGENT_TOOLKIT_NOTION_MCP_URL` is required. See the README env-var table fo
 
 ## MVP scope (hold the line)
 
-**In**: single-page Notion read + cache + expiry, single OpenAPI / Swagger JSON spec cache + cross-spec endpoint search, two skills (`notion-context`, `openapi-client`), one gateway agent (`rocky`), opencode-only.
+**In**: single-page Notion read + cache + expiry, single OpenAPI / Swagger JSON spec cache + cross-spec endpoint search + `host:env:spec` registry (`agent-toolkit.json`, project > user precedence), two skills (`notion-context`, `openapi-client`), one gateway agent (`rocky`), opencode-only.
 
-**Out**: database queries, OAuth, Notion child pages, OpenAPI YAML parsing, full SDK code generation, multi-spec merge, mock servers, multi-host plugin layouts (`.claude-plugin/`, etc.), UI, codex integration, agent-side workflow orchestration (that lives in the caller, not in `rocky`). Anything beyond this scope ships as a separate PR proposal.
+**Out**: database queries, OAuth, Notion child pages, OpenAPI YAML parsing, runtime base-URL override (use `spec.servers`), full SDK code generation, multi-spec merge, mock servers, multi-host plugin layouts (`.claude-plugin/`, etc.), UI, codex integration, agent-side workflow orchestration (that lives in the caller, not in `rocky`). Anything beyond this scope ships as a separate PR proposal.
 
 The longer-term capability targets (auto memory, GitHub-issue tracking, OpenAPI client generation, …) live in [`ROADMAP.md`](./ROADMAP.md) — phase-by-phase, one PR at a time. Do not pull roadmap items into MVP unless the user explicitly asks.
 
@@ -51,6 +54,7 @@ The longer-term capability targets (auto memory, GitHub-issue tracking, OpenAPI 
 3. If the user-facing surface (tools / env vars) changes, sync `README.md` and `.opencode/INSTALL.md`
 4. If a new env var is added, also update the plugin's `readEnv()`
 5. If the plugin's tool contract changes, update the tool-usage rules in the relevant skill (`skills/notion-context/SKILL.md` for `notion_*`, `skills/openapi-client/SKILL.md` for `swagger_*`) and the corresponding tool description/rules in `agents/rocky.md` when Notion-side
+6. If `agent-toolkit.json` shape changes, update **both** `agent-toolkit.schema.json` (IDE autocomplete) **and** `lib/toolkit-config.ts` (runtime validation) — they must stay in lockstep
 
 ## MCP servers
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 
 ## 도구
 
-plugin 이 opencode 에 다음 7 개를 등록한다.
+plugin 이 opencode 에 다음 8 개를 등록한다.
 
 ### Notion (`notion_*`)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Toolkit
 
-opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 개, OpenAPI / Swagger JSON 을 캐시 우선으로 가져와 endpoint 검색까지 해 주는 도구 4 개, 그 도구들을 묶어 컨텍스트 / 한국어 스펙 / `fetch`·`axios` 호출 코드로 정리하는 skill 2 개, 그리고 회사 컨텍스트를 들고 있는 업무 파트너 agent 1 개(`rocky`) 를 제공한다. Notion 은 시작 소스이고, 회사 지식 표면은 이후 더 넓혀질 수 있다. 런타임은 **Bun (>=1.0)** 만 사용하며, 별도 빌드 단계는 없다 (Bun 이 TS 직접 실행).
+opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 개, OpenAPI / Swagger JSON 을 캐시 우선으로 가져와 endpoint 검색·환경별 등록 관리까지 해 주는 도구 5 개, 그 도구들을 묶어 컨텍스트 / 한국어 스펙 / `fetch`·`axios` 호출 코드로 정리하는 skill 2 개, 그리고 회사 컨텍스트를 들고 있는 업무 파트너 agent 1 개(`rocky`) 를 제공한다. OpenAPI 쪽은 host(API 묶음) → env(dev/staging/prod) → spec(개별 API) 3-단계 레지스트리를 `agent-toolkit.json` 으로 선언하면 `host:env:spec` handle 로 직접 호출 가능. Notion 은 시작 소스이고, 회사 지식 표면은 이후 더 넓혀질 수 있다. 런타임은 **Bun (>=1.0)** 만 사용하며, 별도 빌드 단계는 없다 (Bun 이 TS 직접 실행).
 
 구조는 [obra/superpowers](https://github.com/obra/superpowers) 형식을 따른다 — 단일 plugin 파일이 `skills/` / `agents/` 디렉터리를 opencode 탐색 경로에 등록하고 도구를 노출한다. `rocky` 의 캐릭터/네이밍 컨벤션은 [code-yeongyu/oh-my-openagent (OmO)](https://github.com/code-yeongyu/oh-my-openagent) 의 named-specialist 패턴에서 빌렸지만, 책임은 회사 컨텍스트 파트너 한 줄로 한정한다.
 
@@ -11,18 +11,23 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 ├── .opencode/
 │   ├── INSTALL.md                  # opencode 사용자용 설치 안내
 │   └── plugins/
-│       ├── agent-toolkit.ts        # plugin entrypoint + 도구 7 개 (notion 3 + swagger 4)
+│       ├── agent-toolkit.ts        # plugin entrypoint + 도구 8 개 (notion 3 + swagger 5)
 │       └── agent-toolkit.test.ts
 ├── lib/
 │   ├── notion-context.ts           # Notion TTL 파일 캐시 + key 정규화 + normalize
 │   ├── notion-context.test.ts
 │   ├── openapi-context.ts          # OpenAPI TTL 파일 캐시 + endpoint 검색
-│   └── openapi-context.test.ts
+│   ├── openapi-context.test.ts
+│   ├── openapi-registry.ts         # host:env:spec 핸들 / 스코프 해석 + 평면화
+│   ├── openapi-registry.test.ts
+│   ├── toolkit-config.ts           # agent-toolkit.json 로더 (project > user 우선순위)
+│   └── toolkit-config.test.ts
 ├── skills/
 │   ├── notion-context/SKILL.md     # Notion 캐시 우선 읽기 + 한국어 스펙 정리 skill
 │   └── openapi-client/SKILL.md     # 캐시된 OpenAPI spec → fetch / axios 호출 코드 skill
 ├── agents/
 │   └── rocky.md                    # 회사 컨텍스트 업무 파트너 (mode: all, Notion 시작)
+├── agent-toolkit.schema.json        # agent-toolkit.json 의 JSON Schema (IDE 자동완성용)
 ├── .mcp.json                        # context7 MCP 등록 (개발 보조용)
 ├── package.json / tsconfig.json
 ├── AGENTS.md / CLAUDE.md
@@ -76,9 +81,45 @@ plugin 이 opencode 에 다음 7 개를 등록한다.
 | `swagger_get` | 캐시 우선. hit 면 즉시 반환, miss 면 spec URL 을 GET 으로 다운로드 → JSON / shape 검증 → 캐시 저장 |
 | `swagger_refresh` | 캐시 무시하고 spec URL 에서 강제 다운로드 → 검증 → 캐시 갱신 |
 | `swagger_status` | 캐시 메타(저장 시각, TTL, 만료 여부, title, endpointCount) 만 조회. remote 호출 없음 |
-| `swagger_search` | 캐시된 모든 spec 을 가로질러 path / method / tag / operationId / summary 를 substring 으로 검색. remote 호출 없음 |
+| `swagger_search` | 캐시된 spec 들을 가로질러 path / method / tag / operationId / summary 를 substring 으로 검색. `scope` 로 host / host:env / host:env:spec 범위 제한 가능. remote 호출 없음 |
+| `swagger_envs` | `agent-toolkit.json` 의 `openapi.registry` 트리를 `[{ host, env, spec, url }]` 로 평면화해서 반환. remote 호출 없음 |
 
-`swagger_get` / `swagger_refresh` / `swagger_status` 의 `input` 은 spec URL 또는 이미 캐시된 16-hex key. `swagger_search` 는 `query: string`, `limit?: number` (기본 20). YAML spec 은 MVP 에서 미지원 — JSON 만 받는다.
+`swagger_get` / `swagger_refresh` / `swagger_status` 의 `input` 은 다음 중 하나를 받는다.
+
+- spec URL (`https://…` / `file://…`)
+- 이미 캐시된 16-hex 디스크 key (메타에서 URL 복구)
+- `agent-toolkit.json` 에 등록된 `host:env:spec` handle (registry 가 URL 로 해석)
+
+`swagger_search` 는 `query: string`, `limit?: number` (기본 20), `scope?: string` (host / host:env / host:env:spec — registry 안에 등록되어야 한다). YAML spec 은 MVP 에서 미지원 — JSON 만 받는다.
+
+## Config (`agent-toolkit.json`)
+
+OpenAPI registry 를 선언하면 `swagger_*` 도구를 URL 대신 `host:env:spec` handle 로 호출할 수 있다. 우선순위는 **project > user**:
+
+1. `./.opencode/agent-toolkit.json` (프로젝트 로컬)
+2. `~/.config/opencode/agent-toolkit/agent-toolkit.json` (사용자 단위) — `AGENT_TOOLKIT_CONFIG` 로 경로 override
+
+같은 leaf (`host:env:spec`) 가 양쪽에 있으면 project 가 이긴다. 새 host / env / spec 은 project 에서 추가 가능.
+
+스키마는 [`agent-toolkit.schema.json`](./agent-toolkit.schema.json) — VS Code 등 JSON Schema-aware 에디터는 `$schema` 만 박아 두면 자동완성 / 검증을 해 준다.
+
+```jsonc
+// ~/.config/opencode/agent-toolkit/agent-toolkit.json
+{
+  "$schema": "https://raw.githubusercontent.com/minjun0219/coding-agent-toolkit/main/agent-toolkit.schema.json",
+  "openapi": {
+    "registry": {
+      "acme": {
+        "dev":  { "users": "https://dev.acme.example/users/openapi.json",
+                  "orders": "https://dev.acme.example/orders/openapi.json" },
+        "prod": { "users": "https://api.acme.example/users/openapi.json" }
+      }
+    }
+  }
+}
+```
+
+`host` / `env` / `spec` 식별자는 `^[a-zA-Z0-9_-]+$` — 콜론은 handle separator 로 예약. URL 은 비어 있지 않은 문자열이어야 한다 (YAML 는 후속 이슈에서 다룬다).
 
 ## Agent
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@
 | 4 | Notion 캐싱 + TTL | ✅ MVP | — | `notion_get` / `notion_status` / `notion_refresh`, `lib/notion-context.ts` |
 | 5 | Notion → 개발 스펙 분해 | ✅ MVP | — | `skills/notion-context/SKILL.md` spec mode |
 | 6 | 스펙 → GitHub Issue 추적 | 📋 planned | [#4](https://github.com/minjun0219/coding-agent-toolkit/issues/4) | GitHub MCP / 자체 도구 어느 쪽으로 갈지 미정 |
-| 7 | OpenAPI 캐시 + client 작성 | ✅ MVP | [#6](https://github.com/minjun0219/coding-agent-toolkit/issues/6) | `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search`, `lib/openapi-context.ts`, `skills/openapi-client/SKILL.md` (JSON-only, 단일 endpoint 단위 snippet) |
+| 7 | OpenAPI 캐시 + client 작성 | ✅ MVP+registry | [#6](https://github.com/minjun0219/coding-agent-toolkit/issues/6) | `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` / `swagger_envs`, `lib/openapi-context.ts`, `lib/openapi-registry.ts`, `lib/toolkit-config.ts` + `agent-toolkit.schema.json`, `skills/openapi-client/SKILL.md` (JSON-only, 단일 endpoint 단위 snippet, host:env:spec 핸들 + scope 검색) |
 
 ## 제안 단계
 
@@ -45,6 +45,10 @@
 - **Phase 4 — OpenAPI 캐시 + client 작성 — 완료** *(memo #7, issue [#6](https://github.com/minjun0219/coding-agent-toolkit/issues/6))*
   - `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` 4 도구 + `lib/openapi-context.ts` TTL 파일 캐시 + `skills/openapi-client/SKILL.md`
   - JSON-only (YAML 미지원), 단일 endpoint → `fetch` / `axios` snippet 한 덩어리
+- **Phase 4.5 — OpenAPI environment registry — 완료** *(memo #7 확장)*
+  - `agent-toolkit.json` (project / user 두 위치, project 우선) 으로 host → env → spec 트리 선언
+  - `host:env:spec` 핸들 / `swagger_search` `scope` (host / host:env / host:env:spec) / `swagger_envs` 도구
+  - `agent-toolkit.schema.json` JSON Schema (IDE 자동완성) + `lib/toolkit-config.ts` 런타임 검증 (외부 의존성 0)
 - **횡단 — 코드 품질 정책 강화** *(memo #2, #3, issue [#7](https://github.com/minjun0219/coding-agent-toolkit/issues/7))*
   - 한글 주석 / JSDoc 정책의 lint 단 검증 (필요해지면)
 

--- a/agent-toolkit.schema.json
+++ b/agent-toolkit.schema.json
@@ -4,7 +4,6 @@
   "title": "agent-toolkit config",
   "description": "Plugin-wide configuration for the coding-agent-toolkit opencode plugin. Project config (./.opencode/agent-toolkit.json) overrides user config (~/.config/opencode/agent-toolkit/agent-toolkit.json) at the leaf level.",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "$schema": {
       "type": "string",
@@ -12,7 +11,6 @@
     },
     "openapi": {
       "type": "object",
-      "additionalProperties": false,
       "description": "OpenAPI / Swagger registry. Maps host:env:spec handles to spec download URLs.",
       "properties": {
         "registry": {

--- a/agent-toolkit.schema.json
+++ b/agent-toolkit.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/minjun0219/coding-agent-toolkit/main/agent-toolkit.schema.json",
+  "title": "agent-toolkit config",
+  "description": "Plugin-wide configuration for the coding-agent-toolkit opencode plugin. Project config (./.opencode/agent-toolkit.json) overrides user config (~/.config/opencode/agent-toolkit/agent-toolkit.json) at the leaf level.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this JSON Schema. Editors use this for autocomplete and validation."
+    },
+    "openapi": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "OpenAPI / Swagger registry. Maps host:env:spec handles to spec download URLs.",
+      "properties": {
+        "registry": {
+          "type": "object",
+          "description": "host name → environment name → spec name → spec URL. Names must match ^[a-zA-Z0-9_-]+$ (handles are colon-separated, so colons are reserved).",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "type": "object",
+              "description": "Environments under one logical host (project / platform).",
+              "minProperties": 1,
+              "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                  "type": "object",
+                  "description": "Spec name → spec URL.",
+                  "minProperties": 1,
+                  "patternProperties": {
+                    "^[a-zA-Z0-9_-]+$": {
+                      "type": "string",
+                      "format": "uri",
+                      "minLength": 1,
+                      "description": "Direct URL (https / http / file) to the OpenAPI / Swagger JSON document. YAML is not supported in this MVP."
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}

--- a/lib/openapi-context.test.ts
+++ b/lib/openapi-context.test.ts
@@ -106,6 +106,36 @@ describe("searchEndpoints", () => {
     expect(searchEndpoints(SAMPLE_SPEC, "").length).toBe(3);
     expect(searchEndpoints(SAMPLE_SPEC, "", 2).length).toBe(2);
   });
+
+  it("does not throw on non-string operationId / summary / tags", () => {
+    const malformed: OpenapiSpec = {
+      openapi: "3.0.0",
+      info: { title: "Bad", version: "0" },
+      paths: {
+        "/bad": {
+          get: {
+            operationId: 42 as unknown as string,
+            summary: null as unknown as string,
+            tags: ["ok", 7 as unknown as string, null as unknown as string],
+          },
+          post: {
+            // tags 가 배열이 아닌 경우.
+            tags: "not-an-array" as unknown as string[],
+          },
+        },
+      },
+    };
+    // 빈 query — 두 endpoint 모두 떨어져 들어와야 한다.
+    const all = searchEndpoints(malformed, "");
+    expect(all.length).toBe(2);
+    // 비-string 필드는 결과에서 omit, string-인 tag 만 살아남아야.
+    expect(all[0]?.operationId).toBeUndefined();
+    expect(all[0]?.summary).toBeUndefined();
+    expect(all[0]?.tags).toEqual(["ok"]);
+    expect(all[1]?.tags).toBeUndefined();
+    // 텍스트 필드 검색도 throw 없이 통과해야.
+    expect(() => searchEndpoints(malformed, "ok")).not.toThrow();
+  });
 });
 
 describe("assertOpenapiShape", () => {

--- a/lib/openapi-context.ts
+++ b/lib/openapi-context.ts
@@ -195,6 +195,9 @@ export function countEndpoints(spec: OpenapiSpec): number {
  * 매칭 대상: path / method / operationId / summary / tags.
  *
  * 빈 query 는 모든 endpoint 를 limit 까지 반환 — "이 spec 에 뭐 있는지 일단 보여줘" 용도.
+ *
+ * 외부 spec 은 종종 부분적으로 깨져 있다 (`operationId` 가 숫자, `tags` 가 배열이 아닌 등).
+ * `.toLowerCase()` 가 TypeError 로 검색 자체를 무너뜨리지 않도록 매 필드마다 typeof 가드.
  */
 export function searchEndpoints(
   spec: OpenapiSpec,
@@ -221,21 +224,29 @@ export function searchEndpoints(
     for (const m of HTTP_METHODS) {
       const op = (item as OpenapiPathItem)[m];
       if (!op || typeof op !== "object") continue;
+
+      // 안전 추출 — 비-string 은 ""/[] 로 떨어뜨려 매칭 / 결과 모두에서 제외한다.
+      const opId = typeof op.operationId === "string" ? op.operationId : "";
+      const summary = typeof op.summary === "string" ? op.summary : "";
+      const tagsArr = Array.isArray(op.tags)
+        ? op.tags.filter((t): t is string => typeof t === "string")
+        : [];
+
       // 빈 query 면 무조건 hit, 그 외에는 한 필드라도 substring 매칭되어야 한다.
       const hit =
         needle.length === 0 ||
         path.toLowerCase().includes(needle) ||
         m.includes(needle) ||
-        (op.operationId ?? "").toLowerCase().includes(needle) ||
-        (op.summary ?? "").toLowerCase().includes(needle) ||
-        (op.tags ?? []).some((t) => t.toLowerCase().includes(needle));
+        opId.toLowerCase().includes(needle) ||
+        summary.toLowerCase().includes(needle) ||
+        tagsArr.some((t) => t.toLowerCase().includes(needle));
       if (!hit) continue;
       out.push({
         method: m.toUpperCase(),
         path,
-        operationId: op.operationId,
-        summary: op.summary,
-        tags: op.tags,
+        operationId: opId !== "" ? opId : undefined,
+        summary: summary !== "" ? summary : undefined,
+        tags: tagsArr.length > 0 ? tagsArr : undefined,
       });
       if (out.length >= limit) return out;
     }

--- a/lib/openapi-registry.test.ts
+++ b/lib/openapi-registry.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "bun:test";
+import {
+  isFullHandle,
+  isScope,
+  listRegistry,
+  resolveHandleToUrl,
+  resolveScopeToUrls,
+} from "./openapi-registry";
+import type { ToolkitConfig } from "./toolkit-config";
+
+const CONFIG: ToolkitConfig = {
+  openapi: {
+    registry: {
+      acme: {
+        dev: {
+          users: "https://dev.acme/users.json",
+          orders: "https://dev.acme/orders.json",
+        },
+        prod: {
+          users: "https://api.acme/users.json",
+        },
+      },
+      beta: {
+        dev: {
+          svc: "https://dev.beta/svc.json",
+        },
+      },
+    },
+  },
+};
+
+describe("isFullHandle", () => {
+  it("matches host:env:spec", () => {
+    expect(isFullHandle("acme:dev:users")).toBe(true);
+  });
+  it("rejects partial / extra colons", () => {
+    expect(isFullHandle("acme:dev")).toBe(false);
+    expect(isFullHandle("acme")).toBe(false);
+    expect(isFullHandle("acme:dev:users:extra")).toBe(false);
+  });
+  it("rejects URLs and hex keys", () => {
+    expect(isFullHandle("https://example.com/spec.json")).toBe(false);
+    expect(isFullHandle("0123456789abcdef")).toBe(false);
+  });
+});
+
+describe("isScope", () => {
+  it("accepts host / host:env / host:env:spec", () => {
+    expect(isScope("acme")).toBe(true);
+    expect(isScope("acme:dev")).toBe(true);
+    expect(isScope("acme:dev:users")).toBe(true);
+  });
+  it("rejects URLs, hex keys, empty", () => {
+    expect(isScope("https://example.com/spec.json")).toBe(false);
+    expect(isScope("file:///tmp/spec.json")).toBe(false);
+    expect(isScope("0123456789abcdef")).toBe(false);
+    expect(isScope("")).toBe(false);
+  });
+  it("rejects identifiers with disallowed chars", () => {
+    expect(isScope("ac me")).toBe(false);
+    expect(isScope("acme:de v")).toBe(false);
+  });
+});
+
+describe("resolveHandleToUrl", () => {
+  it("returns the registered URL for a known handle", () => {
+    expect(
+      resolveHandleToUrl("acme:dev:users", CONFIG.openapi?.registry),
+    ).toBe("https://dev.acme/users.json");
+  });
+  it("throws on unregistered handle, with the handle in the message", () => {
+    expect(() =>
+      resolveHandleToUrl("acme:dev:nope", CONFIG.openapi?.registry),
+    ).toThrow(/acme:dev:nope/);
+  });
+  it("throws on malformed handle", () => {
+    expect(() =>
+      resolveHandleToUrl("acme:dev", CONFIG.openapi?.registry),
+    ).toThrow(/three colon-separated/i);
+  });
+  it("throws when registry is undefined", () => {
+    expect(() => resolveHandleToUrl("acme:dev:users", undefined)).toThrow(
+      /not found/i,
+    );
+  });
+});
+
+describe("resolveScopeToUrls", () => {
+  const reg = CONFIG.openapi?.registry;
+
+  it("expands a host scope to all of its specs", () => {
+    const urls = resolveScopeToUrls("acme", reg);
+    expect(urls.sort()).toEqual(
+      [
+        "https://api.acme/users.json",
+        "https://dev.acme/orders.json",
+        "https://dev.acme/users.json",
+      ].sort(),
+    );
+  });
+
+  it("expands a host:env scope to that env's specs only", () => {
+    const urls = resolveScopeToUrls("acme:dev", reg);
+    expect(urls.sort()).toEqual(
+      ["https://dev.acme/orders.json", "https://dev.acme/users.json"].sort(),
+    );
+  });
+
+  it("expands a host:env:spec scope to a one-element list", () => {
+    expect(resolveScopeToUrls("acme:prod:users", reg)).toEqual([
+      "https://api.acme/users.json",
+    ]);
+  });
+
+  it("returns an empty array for unknown / malformed scopes", () => {
+    expect(resolveScopeToUrls("nope", reg)).toEqual([]);
+    expect(resolveScopeToUrls("acme:nope", reg)).toEqual([]);
+    expect(resolveScopeToUrls("acme:dev:nope", reg)).toEqual([]);
+    expect(resolveScopeToUrls("not a scope", reg)).toEqual([]);
+    expect(resolveScopeToUrls("", reg)).toEqual([]);
+  });
+
+  it("returns an empty array when the registry is undefined", () => {
+    expect(resolveScopeToUrls("acme:dev:users", undefined)).toEqual([]);
+  });
+});
+
+describe("listRegistry", () => {
+  it("flattens host/env/spec/url tree", () => {
+    const flat = listRegistry(CONFIG);
+    expect(flat.length).toBe(4);
+    const got = flat
+      .map((e) => `${e.host}:${e.env}:${e.spec}=${e.url}`)
+      .sort();
+    expect(got).toEqual(
+      [
+        "acme:dev:users=https://dev.acme/users.json",
+        "acme:dev:orders=https://dev.acme/orders.json",
+        "acme:prod:users=https://api.acme/users.json",
+        "beta:dev:svc=https://dev.beta/svc.json",
+      ].sort(),
+    );
+  });
+
+  it("returns [] for empty config", () => {
+    expect(listRegistry({})).toEqual([]);
+    expect(listRegistry({ openapi: {} })).toEqual([]);
+    expect(listRegistry({ openapi: { registry: {} } })).toEqual([]);
+  });
+});

--- a/lib/openapi-registry.ts
+++ b/lib/openapi-registry.ts
@@ -1,4 +1,4 @@
-import type { OpenapiRegistry, ToolkitConfig } from "./toolkit-config";
+import { ID_BODY, type OpenapiRegistry, type ToolkitConfig } from "./toolkit-config";
 
 /**
  * `agent-toolkit.json` 의 `openapi.registry` 트리를 다루는 helper 모음.
@@ -20,10 +20,11 @@ export interface OpenapiRegistryEntry {
   url: string;
 }
 
-const ID = "[a-zA-Z0-9_-]+";
-const HANDLE_FULL = new RegExp(`^(${ID}):(${ID}):(${ID})$`);
-const HANDLE_HOST_ENV = new RegExp(`^(${ID}):(${ID})$`);
-const HANDLE_HOST = new RegExp(`^${ID}$`);
+// 식별자 본문은 toolkit-config 의 ID_BODY 와 동일해야 한다 (스키마 / config 검증과 동기).
+// drift 방지를 위해 한 곳 (`ID_BODY`) 만 두고 여기서는 그걸로 핸들 / 스코프 정규식을 합성.
+const HANDLE_FULL = new RegExp(`^(${ID_BODY}):(${ID_BODY}):(${ID_BODY})$`);
+const HANDLE_HOST_ENV = new RegExp(`^(${ID_BODY}):(${ID_BODY})$`);
+const HANDLE_HOST = new RegExp(`^${ID_BODY}$`);
 const HEX_KEY = /^[0-9a-f]{16}$/;
 
 /** 입력이 정확히 `host:env:spec` 형태인지. */

--- a/lib/openapi-registry.ts
+++ b/lib/openapi-registry.ts
@@ -1,0 +1,114 @@
+import type { OpenapiRegistry, ToolkitConfig } from "./toolkit-config";
+
+/**
+ * `agent-toolkit.json` 의 `openapi.registry` 트리를 다루는 helper 모음.
+ *
+ * 입력 표기:
+ *   - `host`            — 한 host 아래의 모든 spec
+ *   - `host:env`        — 한 host 의 한 env 아래의 모든 spec
+ *   - `host:env:spec`   — 정확히 한 spec
+ *
+ * 식별자는 `agent-toolkit.schema.json` 의 패턴(`^[a-zA-Z0-9_-]+$`)을 따라야 한다 — 콜론은
+ * separator 로 예약. 등록되지 않은 handle 은 lookup 실패 시 명확한 에러로 거부한다.
+ */
+
+/** 평면화된 한 항목. listRegistry 의 결과 row. */
+export interface OpenapiRegistryEntry {
+  host: string;
+  env: string;
+  spec: string;
+  url: string;
+}
+
+const ID = "[a-zA-Z0-9_-]+";
+const HANDLE_FULL = new RegExp(`^(${ID}):(${ID}):(${ID})$`);
+const HANDLE_HOST_ENV = new RegExp(`^(${ID}):(${ID})$`);
+const HANDLE_HOST = new RegExp(`^${ID}$`);
+const HEX_KEY = /^[0-9a-f]{16}$/;
+
+/** 입력이 정확히 `host:env:spec` 형태인지. */
+export function isFullHandle(s: string): boolean {
+  return HANDLE_FULL.test(s);
+}
+
+/** `host`, `host:env`, `host:env:spec` 중 하나라도 맞는지. 16-hex 키와 URL 은 false. */
+export function isScope(s: string): boolean {
+  if (!s || HEX_KEY.test(s)) return false;
+  if (s.startsWith("http://") || s.startsWith("https://") || s.startsWith("file://")) {
+    return false;
+  }
+  return HANDLE_FULL.test(s) || HANDLE_HOST_ENV.test(s) || HANDLE_HOST.test(s);
+}
+
+/**
+ * 정확한 `host:env:spec` handle 을 단일 URL 로 해석.
+ * handle 이 형식에 맞지 않거나 등록 안 되어 있으면 throw — 메시지에 handle 을 포함.
+ */
+export function resolveHandleToUrl(
+  handle: string,
+  registry: OpenapiRegistry | undefined,
+): string {
+  const m = HANDLE_FULL.exec(handle);
+  if (!m) {
+    throw new Error(
+      `Not a host:env:spec handle: "${handle}" (expected three colon-separated identifiers)`,
+    );
+  }
+  const [, host, env, spec] = m as unknown as [string, string, string, string];
+  const url = registry?.[host]?.[env]?.[spec];
+  if (!url) {
+    throw new Error(
+      `Handle "${handle}" not found in openapi.registry. Check ./.opencode/agent-toolkit.json or ~/.config/opencode/agent-toolkit/agent-toolkit.json.`,
+    );
+  }
+  return url;
+}
+
+/**
+ * scope (`host` / `host:env` / `host:env:spec`) 를 매칭되는 URL 리스트로 풀어 준다.
+ * 매칭 0 건이면 빈 배열. handle 형식에 안 맞으면 빈 배열 — caller 가 의도하지 않은 스코프를
+ * 안전하게 무시한다.
+ */
+export function resolveScopeToUrls(
+  scope: string,
+  registry: OpenapiRegistry | undefined,
+): string[] {
+  if (!registry || !scope) return [];
+  if (HANDLE_FULL.test(scope)) {
+    try {
+      return [resolveHandleToUrl(scope, registry)];
+    } catch {
+      return [];
+    }
+  }
+  const fullEnv = HANDLE_HOST_ENV.exec(scope);
+  if (fullEnv) {
+    const [, host, env] = fullEnv as unknown as [string, string, string];
+    const specs = registry[host]?.[env];
+    return specs ? Object.values(specs) : [];
+  }
+  if (HANDLE_HOST.test(scope)) {
+    const envs = registry[scope];
+    if (!envs) return [];
+    const out: string[] = [];
+    for (const env of Object.values(envs)) {
+      for (const url of Object.values(env)) out.push(url);
+    }
+    return out;
+  }
+  return [];
+}
+
+/** registry 트리를 평면 (host, env, spec, url) 리스트로 펼친다 — `swagger_envs` 의 출력 그대로. */
+export function listRegistry(config: ToolkitConfig): OpenapiRegistryEntry[] {
+  const reg = config.openapi?.registry ?? {};
+  const out: OpenapiRegistryEntry[] = [];
+  for (const [host, envs] of Object.entries(reg)) {
+    for (const [env, specs] of Object.entries(envs)) {
+      for (const [spec, url] of Object.entries(specs)) {
+        out.push({ host, env, spec, url });
+      }
+    }
+  }
+  return out;
+}

--- a/lib/toolkit-config.test.ts
+++ b/lib/toolkit-config.test.ts
@@ -75,10 +75,16 @@ describe("validateConfig", () => {
     ).toThrow(/env name/);
   });
 
-  it("rejects empty URL", () => {
+  it("rejects empty / whitespace-only URL", () => {
     expect(() =>
       validateConfig(
         { openapi: { registry: { acme: { dev: { users: "" } } } } },
+        "p",
+      ),
+    ).toThrow(/non-empty URL/);
+    expect(() =>
+      validateConfig(
+        { openapi: { registry: { acme: { dev: { users: "   " } } } } },
         "p",
       ),
     ).toThrow(/non-empty URL/);
@@ -91,6 +97,53 @@ describe("validateConfig", () => {
         "p",
       ),
     ).toThrow(/non-empty URL/);
+  });
+
+  it("rejects unparseable URL string", () => {
+    expect(() =>
+      validateConfig(
+        {
+          openapi: { registry: { acme: { dev: { users: "not a url" } } } },
+        },
+        "p",
+      ),
+    ).toThrow(/not a valid URL/);
+  });
+
+  it("rejects unsupported URL scheme", () => {
+    expect(() =>
+      validateConfig(
+        {
+          openapi: {
+            registry: {
+              acme: { dev: { users: "ftp://example.com/spec.json" } },
+            },
+          },
+        },
+        "p",
+      ),
+    ).toThrow(/unsupported scheme/);
+  });
+
+  it("accepts http / https / file URLs", () => {
+    for (const url of [
+      "http://example.com/spec.json",
+      "https://example.com/spec.json",
+      "file:///tmp/spec.json",
+    ]) {
+      expect(() =>
+        validateConfig(
+          { openapi: { registry: { acme: { dev: { users: url } } } } },
+          "p",
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it("allows unknown top-level keys for forward compatibility", () => {
+    expect(() =>
+      validateConfig({ futureFeature: { foo: "bar" } } as any, "p"),
+    ).not.toThrow();
   });
 });
 

--- a/lib/toolkit-config.test.ts
+++ b/lib/toolkit-config.test.ts
@@ -209,27 +209,30 @@ describe("mergeConfigs", () => {
 });
 
 describe("loadConfig", () => {
-  it("returns {} when neither file exists", async () => {
-    const config = await loadConfig({ userPath, projectRoot });
-    expect(config).toEqual({});
+  it("returns {} with no errors when neither file exists", async () => {
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.config).toEqual({});
+    expect(r.errors).toEqual([]);
   });
 
   it("loads user-only when project is absent", async () => {
     writeUser({
       openapi: { registry: { acme: { dev: { users: "https://u/u.json" } } } },
     });
-    const config = await loadConfig({ userPath, projectRoot });
-    expect(config.openapi?.registry?.acme?.dev?.users).toBe("https://u/u.json");
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe("https://u/u.json");
+    expect(r.errors).toEqual([]);
   });
 
   it("loads project-only when user is absent", async () => {
     writeProject({
       openapi: { registry: { acme: { prod: { users: "https://p/u.json" } } } },
     });
-    const config = await loadConfig({ userPath, projectRoot });
-    expect(config.openapi?.registry?.acme?.prod?.users).toBe(
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.config.openapi?.registry?.acme?.prod?.users).toBe(
       "https://p/u.json",
     );
+    expect(r.errors).toEqual([]);
   });
 
   it("merges with project taking precedence", async () => {
@@ -241,25 +244,73 @@ describe("loadConfig", () => {
         registry: { acme: { dev: { users: "https://project/u.json" } } },
       },
     });
-    const config = await loadConfig({ userPath, projectRoot });
-    expect(config.openapi?.registry?.acme?.dev?.users).toBe(
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe(
       "https://project/u.json",
     );
   });
 
-  it("throws on malformed JSON with the path in the message", async () => {
+  it("reports malformed JSON in errors[] without throwing", async () => {
     writeFileSync(userPath, "{ not json", "utf8");
-    await expect(loadConfig({ userPath, projectRoot })).rejects.toThrow(
-      /Failed to parse/,
-    );
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.errors.length).toBe(1);
+    expect(r.errors[0]?.source).toBe(userPath);
+    expect(r.errors[0]?.message).toMatch(/Failed to parse/);
+    expect(r.config).toEqual({});
   });
 
-  it("throws on schema-violating config with the path in the message", async () => {
+  it("reports schema-violating config in errors[] without throwing", async () => {
     writeUser({
       openapi: { registry: { "bad:host": { dev: { users: "u" } } } } as any,
     });
-    await expect(loadConfig({ userPath, projectRoot })).rejects.toThrow(
-      /host name/,
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.errors.length).toBe(1);
+    expect(r.errors[0]?.message).toMatch(/host name/);
+  });
+
+  it("preserves valid project config when user file is malformed (Codex P1)", async () => {
+    writeFileSync(userPath, "{ broken", "utf8");
+    writeProject({
+      openapi: {
+        registry: { acme: { prod: { users: "https://api.acme/u.json" } } },
+      },
+    });
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.errors.length).toBe(1);
+    expect(r.errors[0]?.source).toBe(userPath);
+    // 핵심: project 의 host:env:spec 이 그대로 살아나야.
+    expect(r.config.openapi?.registry?.acme?.prod?.users).toBe(
+      "https://api.acme/u.json",
     );
+  });
+
+  it("preserves valid user config when project file is malformed", async () => {
+    writeUser({
+      openapi: {
+        registry: { acme: { dev: { users: "https://dev.acme/u.json" } } },
+      },
+    });
+    const projectFile = join(projectRoot, ".opencode", "agent-toolkit.json");
+    mkdirSync(join(projectRoot, ".opencode"), { recursive: true });
+    writeFileSync(projectFile, "{ also broken", "utf8");
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.errors.length).toBe(1);
+    expect(r.errors[0]?.source).toBe(projectFile);
+    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe(
+      "https://dev.acme/u.json",
+    );
+  });
+
+  it("collects errors from both files when both are malformed", async () => {
+    writeFileSync(userPath, "{ user broken", "utf8");
+    mkdirSync(join(projectRoot, ".opencode"), { recursive: true });
+    writeFileSync(
+      join(projectRoot, ".opencode", "agent-toolkit.json"),
+      "{ project broken",
+      "utf8",
+    );
+    const r = await loadConfig({ userPath, projectRoot });
+    expect(r.errors.length).toBe(2);
+    expect(r.config).toEqual({});
   });
 });

--- a/lib/toolkit-config.test.ts
+++ b/lib/toolkit-config.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadConfig,
+  mergeConfigs,
+  validateConfig,
+  type ToolkitConfig,
+} from "./toolkit-config";
+
+let userDir: string;
+let userPath: string;
+let projectRoot: string;
+
+beforeEach(() => {
+  const root = mkdtempSync(join(tmpdir(), "agent-toolkit-config-"));
+  userDir = join(root, "user");
+  mkdirSync(userDir, { recursive: true });
+  userPath = join(userDir, "agent-toolkit.json");
+  projectRoot = mkdtempSync(join(tmpdir(), "agent-toolkit-project-"));
+});
+
+const writeUser = (config: ToolkitConfig) => {
+  writeFileSync(userPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+};
+
+const writeProject = (config: ToolkitConfig) => {
+  const dir = join(projectRoot, ".opencode");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "agent-toolkit.json"),
+    `${JSON.stringify(config, null, 2)}\n`,
+    "utf8",
+  );
+};
+
+describe("validateConfig", () => {
+  it("accepts an empty object", () => {
+    expect(validateConfig({}, "test")).toEqual({});
+  });
+
+  it("accepts a registry with valid identifiers", () => {
+    const config: ToolkitConfig = {
+      openapi: {
+        registry: {
+          acme: { dev: { users: "https://example.com/users.json" } },
+        },
+      },
+    };
+    expect(validateConfig(config, "test")).toEqual(config);
+  });
+
+  it("rejects non-object root", () => {
+    expect(() => validateConfig(null, "p")).toThrow(/must be a JSON object/);
+    expect(() => validateConfig([], "p")).toThrow(/must be a JSON object/);
+    expect(() => validateConfig("str", "p")).toThrow(/must be a JSON object/);
+  });
+
+  it("rejects host name with colon", () => {
+    expect(() =>
+      validateConfig(
+        { openapi: { registry: { "ac:me": { dev: { users: "u" } } } } },
+        "p",
+      ),
+    ).toThrow(/host name/);
+  });
+
+  it("rejects env name with whitespace", () => {
+    expect(() =>
+      validateConfig(
+        { openapi: { registry: { acme: { "de v": { users: "u" } } } } },
+        "p",
+      ),
+    ).toThrow(/env name/);
+  });
+
+  it("rejects empty URL", () => {
+    expect(() =>
+      validateConfig(
+        { openapi: { registry: { acme: { dev: { users: "" } } } } },
+        "p",
+      ),
+    ).toThrow(/non-empty URL/);
+  });
+
+  it("rejects non-string URL", () => {
+    expect(() =>
+      validateConfig(
+        { openapi: { registry: { acme: { dev: { users: 42 } } } } },
+        "p",
+      ),
+    ).toThrow(/non-empty URL/);
+  });
+});
+
+describe("mergeConfigs", () => {
+  it("project overrides user at the leaf", () => {
+    const user: ToolkitConfig = {
+      openapi: {
+        registry: {
+          acme: { dev: { users: "https://user/u.json", orders: "https://user/o.json" } },
+        },
+      },
+    };
+    const project: ToolkitConfig = {
+      openapi: {
+        registry: {
+          acme: { dev: { users: "https://project/u.json" } },
+        },
+      },
+    };
+    const merged = mergeConfigs(user, project);
+    expect(merged.openapi?.registry?.acme?.dev?.users).toBe(
+      "https://project/u.json",
+    );
+    // user-only spec survives.
+    expect(merged.openapi?.registry?.acme?.dev?.orders).toBe(
+      "https://user/o.json",
+    );
+  });
+
+  it("project can introduce new host / env / spec", () => {
+    const user: ToolkitConfig = {
+      openapi: { registry: { acme: { dev: { users: "https://u.example/u.json" } } } },
+    };
+    const project: ToolkitConfig = {
+      openapi: {
+        registry: {
+          acme: { prod: { users: "https://p.example/u.json" } },
+          beta: { dev: { svc: "https://b.example/svc.json" } },
+        },
+      },
+    };
+    const merged = mergeConfigs(user, project);
+    expect(merged.openapi?.registry?.acme?.prod?.users).toBe(
+      "https://p.example/u.json",
+    );
+    expect(merged.openapi?.registry?.beta?.dev?.svc).toBe(
+      "https://b.example/svc.json",
+    );
+    // user 의 dev.users 도 살아 있어야.
+    expect(merged.openapi?.registry?.acme?.dev?.users).toBe(
+      "https://u.example/u.json",
+    );
+  });
+
+  it("returns a deep clone — mutating the result does not touch input", () => {
+    const user: ToolkitConfig = {
+      openapi: { registry: { acme: { dev: { users: "https://u/u.json" } } } },
+    };
+    const merged = mergeConfigs(user, {});
+    merged.openapi!.registry!.acme!.dev!.users = "MUTATED";
+    expect(user.openapi?.registry?.acme?.dev?.users).toBe("https://u/u.json");
+  });
+});
+
+describe("loadConfig", () => {
+  it("returns {} when neither file exists", async () => {
+    const config = await loadConfig({ userPath, projectRoot });
+    expect(config).toEqual({});
+  });
+
+  it("loads user-only when project is absent", async () => {
+    writeUser({
+      openapi: { registry: { acme: { dev: { users: "https://u/u.json" } } } },
+    });
+    const config = await loadConfig({ userPath, projectRoot });
+    expect(config.openapi?.registry?.acme?.dev?.users).toBe("https://u/u.json");
+  });
+
+  it("loads project-only when user is absent", async () => {
+    writeProject({
+      openapi: { registry: { acme: { prod: { users: "https://p/u.json" } } } },
+    });
+    const config = await loadConfig({ userPath, projectRoot });
+    expect(config.openapi?.registry?.acme?.prod?.users).toBe(
+      "https://p/u.json",
+    );
+  });
+
+  it("merges with project taking precedence", async () => {
+    writeUser({
+      openapi: { registry: { acme: { dev: { users: "https://user/u.json" } } } },
+    });
+    writeProject({
+      openapi: {
+        registry: { acme: { dev: { users: "https://project/u.json" } } },
+      },
+    });
+    const config = await loadConfig({ userPath, projectRoot });
+    expect(config.openapi?.registry?.acme?.dev?.users).toBe(
+      "https://project/u.json",
+    );
+  });
+
+  it("throws on malformed JSON with the path in the message", async () => {
+    writeFileSync(userPath, "{ not json", "utf8");
+    await expect(loadConfig({ userPath, projectRoot })).rejects.toThrow(
+      /Failed to parse/,
+    );
+  });
+
+  it("throws on schema-violating config with the path in the message", async () => {
+    writeUser({
+      openapi: { registry: { "bad:host": { dev: { users: "u" } } } } as any,
+    });
+    await expect(loadConfig({ userPath, projectRoot })).rejects.toThrow(
+      /host name/,
+    );
+  });
+});

--- a/lib/toolkit-config.ts
+++ b/lib/toolkit-config.ts
@@ -1,0 +1,179 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+/**
+ * Plugin 의 단일 config 로더 + 검증.
+ *
+ * 두 위치를 병합한다 (project 가 leaf 단위로 user 를 덮어쓴다):
+ *   1. user:    ~/.config/opencode/agent-toolkit/agent-toolkit.json
+ *   2. project: <projectRoot>/.opencode/agent-toolkit.json
+ *
+ * 스키마는 repo 루트의 `agent-toolkit.schema.json` 에 동일 모양으로 박혀 있다 — IDE 자동완성용.
+ * 런타임은 외부 JSON Schema 라이브러리에 의존하지 않고 직접 검증한다 (의존성 0 유지).
+ */
+
+/** spec 등록 단위. host → env → spec → URL 평면 트리. */
+export interface OpenapiRegistry {
+  [host: string]: {
+    [env: string]: {
+      [spec: string]: string;
+    };
+  };
+}
+
+export interface ToolkitConfig {
+  $schema?: string;
+  openapi?: {
+    registry?: OpenapiRegistry;
+  };
+}
+
+export interface LoadConfigOptions {
+  /** user config 경로 override. 기본 `USER_CONFIG_PATH`. */
+  userPath?: string;
+  /** project root. 기본 `process.cwd()`. */
+  projectRoot?: string;
+}
+
+/** user-level config 기본 경로. `AGENT_TOOLKIT_CONFIG` 로 오버라이드. */
+export const USER_CONFIG_PATH = join(
+  homedir(),
+  ".config",
+  "opencode",
+  "agent-toolkit",
+  "agent-toolkit.json",
+);
+
+/** project-level config 의 상대 경로. */
+export const PROJECT_CONFIG_RELATIVE = ".opencode/agent-toolkit.json";
+
+/** host / env / spec 식별자에 허용되는 문자 — 콜론은 handle separator 로 예약. */
+export const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * 파싱된 JSON 값이 ToolkitConfig 인지 검증한다. 어긋나면 throw — 메시지에 source(path) 포함.
+ * 부분 적합도 OK (모든 필드 optional). registry 가 있으면 깊이 끝까지 식별자 / URL 검증.
+ */
+export function validateConfig(input: unknown, source: string): ToolkitConfig {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`${source}: config must be a JSON object`);
+  }
+  const config = input as Record<string, unknown>;
+  // openapi 만 검증한다 — 다른 top-level key 는 미래 확장 여지로 둔다.
+  if (config.openapi !== undefined) {
+    if (
+      config.openapi === null ||
+      typeof config.openapi !== "object" ||
+      Array.isArray(config.openapi)
+    ) {
+      throw new Error(`${source}: openapi must be an object`);
+    }
+    const oapi = config.openapi as Record<string, unknown>;
+    if (oapi.registry !== undefined) {
+      validateRegistry(oapi.registry, source);
+    }
+  }
+  return config as ToolkitConfig;
+}
+
+function validateRegistry(reg: unknown, source: string): asserts reg is OpenapiRegistry {
+  if (reg === null || typeof reg !== "object" || Array.isArray(reg)) {
+    throw new Error(`${source}: openapi.registry must be an object`);
+  }
+  for (const [host, envs] of Object.entries(reg as Record<string, unknown>)) {
+    if (!ID_PATTERN.test(host)) {
+      throw new Error(
+        `${source}: host name "${host}" must match ${ID_PATTERN} (alphanumeric, "_" or "-" only — colons are reserved for handle separators)`,
+      );
+    }
+    if (envs === null || typeof envs !== "object" || Array.isArray(envs)) {
+      throw new Error(
+        `${source}: openapi.registry["${host}"] must be an object of environments`,
+      );
+    }
+    for (const [env, specs] of Object.entries(envs as Record<string, unknown>)) {
+      if (!ID_PATTERN.test(env)) {
+        throw new Error(
+          `${source}: env name "${host}:${env}" must match ${ID_PATTERN}`,
+        );
+      }
+      if (specs === null || typeof specs !== "object" || Array.isArray(specs)) {
+        throw new Error(
+          `${source}: openapi.registry["${host}"]["${env}"] must be an object of specs`,
+        );
+      }
+      for (const [spec, url] of Object.entries(specs as Record<string, unknown>)) {
+        if (!ID_PATTERN.test(spec)) {
+          throw new Error(
+            `${source}: spec name "${host}:${env}:${spec}" must match ${ID_PATTERN}`,
+          );
+        }
+        if (typeof url !== "string" || url.length === 0) {
+          throw new Error(
+            `${source}: openapi.registry["${host}"]["${env}"]["${spec}"] must be a non-empty URL string`,
+          );
+        }
+      }
+    }
+  }
+}
+
+async function loadOne(path: string): Promise<ToolkitConfig | null> {
+  if (!existsSync(path)) return null;
+  const raw = await readFile(path, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${path} as JSON: ${(err as Error).message}`,
+    );
+  }
+  return validateConfig(parsed, path);
+}
+
+/**
+ * user → project 순서로 깊이 병합. 같은 leaf (host:env:spec) 는 project 가 이긴다.
+ * 새 host / env / spec 은 project 쪽에서 추가 가능.
+ */
+export function mergeConfigs(
+  user: ToolkitConfig,
+  project: ToolkitConfig,
+): ToolkitConfig {
+  // structuredClone 도 가능하지만 Bun runtime 호환성을 보수적으로 — JSON round-trip 으로 deep clone.
+  const out = JSON.parse(JSON.stringify(user)) as ToolkitConfig;
+  if (project.openapi?.registry) {
+    out.openapi ??= {};
+    out.openapi.registry ??= {};
+    for (const [host, envs] of Object.entries(project.openapi.registry)) {
+      out.openapi.registry[host] ??= {};
+      for (const [env, specs] of Object.entries(envs)) {
+        out.openapi.registry[host]![env] ??= {};
+        for (const [spec, url] of Object.entries(specs)) {
+          out.openapi.registry[host]![env]![spec] = url;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * user + project config 를 읽어 merge 된 결과를 반환.
+ * 두 파일 모두 없으면 빈 객체를 반환한다 (config 가 optional 이므로).
+ *
+ * `AGENT_TOOLKIT_CONFIG` 환경변수가 있으면 user 경로를 그 값으로 덮어쓴다.
+ */
+export async function loadConfig(
+  options: LoadConfigOptions = {},
+): Promise<ToolkitConfig> {
+  const userPath =
+    options.userPath ?? process.env.AGENT_TOOLKIT_CONFIG ?? USER_CONFIG_PATH;
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const projectPath = resolve(projectRoot, PROJECT_CONFIG_RELATIVE);
+  const user = (await loadOne(userPath)) ?? {};
+  const project = (await loadOne(projectPath)) ?? {};
+  return mergeConfigs(user, project);
+}

--- a/lib/toolkit-config.ts
+++ b/lib/toolkit-config.ts
@@ -37,6 +37,20 @@ export interface LoadConfigOptions {
   projectRoot?: string;
 }
 
+export interface LoadConfigError {
+  /** 실패한 파일의 절대 경로. */
+  source: string;
+  /** 파싱 또는 검증 실패 메시지 (Error.message 또는 stringified). */
+  message: string;
+}
+
+export interface LoadConfigResult {
+  /** user + project 를 leaf 단위로 merge 한 결과. 둘 다 실패 / 둘 다 부재면 빈 객체. */
+  config: ToolkitConfig;
+  /** 파싱 / 검증에 실패한 파일별 에러. caller 가 logging / surfacing 결정. */
+  errors: LoadConfigError[];
+}
+
 /** user-level config 기본 경로. `AGENT_TOOLKIT_CONFIG` 로 오버라이드. */
 export const USER_CONFIG_PATH = join(
   homedir(),
@@ -184,19 +198,43 @@ export function mergeConfigs(
 }
 
 /**
- * user + project config 를 읽어 merge 된 결과를 반환.
- * 두 파일 모두 없으면 빈 객체를 반환한다 (config 가 optional 이므로).
+ * user + project config 를 읽어 merge 된 결과 + 파일별 에러를 반환.
  *
- * `AGENT_TOOLKIT_CONFIG` 환경변수가 있으면 user 경로를 그 값으로 덮어쓴다.
+ * 한 쪽 파일이 손상되어도 다른 쪽은 그대로 살린다 — 즉 잘못된 user 파일이 정상 project
+ * registry 를 무력화하지 않는다 (반대도 마찬가지). caller 는 `errors` 를 보고 logging /
+ * surfacing 을 결정한다 (plugin 은 console.error 로 한 줄씩 흘린다).
+ *
+ * 두 파일 모두 없으면 `{ config: {}, errors: [] }`. `AGENT_TOOLKIT_CONFIG` 환경변수가
+ * 있으면 user 경로를 그 값으로 덮어쓴다.
  */
 export async function loadConfig(
   options: LoadConfigOptions = {},
-): Promise<ToolkitConfig> {
+): Promise<LoadConfigResult> {
   const userPath =
     options.userPath ?? process.env.AGENT_TOOLKIT_CONFIG ?? USER_CONFIG_PATH;
   const projectRoot = options.projectRoot ?? process.cwd();
   const projectPath = resolve(projectRoot, PROJECT_CONFIG_RELATIVE);
-  const user = (await loadOne(userPath)) ?? {};
-  const project = (await loadOne(projectPath)) ?? {};
-  return mergeConfigs(user, project);
+  const errors: LoadConfigError[] = [];
+
+  let user: ToolkitConfig = {};
+  try {
+    user = (await loadOne(userPath)) ?? {};
+  } catch (err) {
+    errors.push({
+      source: userPath,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  let project: ToolkitConfig = {};
+  try {
+    project = (await loadOne(projectPath)) ?? {};
+  } catch (err) {
+    errors.push({
+      source: projectPath,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return { config: mergeConfigs(user, project), errors };
 }

--- a/lib/toolkit-config.ts
+++ b/lib/toolkit-config.ts
@@ -49,8 +49,18 @@ export const USER_CONFIG_PATH = join(
 /** project-level config 의 상대 경로. */
 export const PROJECT_CONFIG_RELATIVE = ".opencode/agent-toolkit.json";
 
-/** host / env / spec 식별자에 허용되는 문자 — 콜론은 handle separator 로 예약. */
-export const ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+/**
+ * host / env / spec 식별자 본문 (anchor 없음).
+ * 다른 모듈 (`openapi-registry.ts`) 이 핸들 / 스코프 정규식을 합성할 때 재사용한다 —
+ * 이 한 군데만 바꾸면 schema / registry 둘 다 같이 따라간다.
+ */
+export const ID_BODY = "[a-zA-Z0-9_-]+";
+
+/** host / env / spec 식별자 정규식 (앵커 포함). 콜론은 handle separator 로 예약. */
+export const ID_PATTERN = new RegExp(`^${ID_BODY}$`);
+
+/** 레지스트리 leaf URL 에 허용되는 스킴. spec 다운로드 단이 받는 종류와 동일. */
+const URL_SCHEMES = new Set(["http:", "https:", "file:"]);
 
 /**
  * 파싱된 JSON 값이 ToolkitConfig 인지 검증한다. 어긋나면 throw — 메시지에 source(path) 포함.
@@ -110,9 +120,22 @@ function validateRegistry(reg: unknown, source: string): asserts reg is OpenapiR
             `${source}: spec name "${host}:${env}:${spec}" must match ${ID_PATTERN}`,
           );
         }
-        if (typeof url !== "string" || url.length === 0) {
+        if (typeof url !== "string" || url.trim().length === 0) {
           throw new Error(
             `${source}: openapi.registry["${host}"]["${env}"]["${spec}"] must be a non-empty URL string`,
+          );
+        }
+        let parsed: URL;
+        try {
+          parsed = new URL(url);
+        } catch {
+          throw new Error(
+            `${source}: openapi.registry["${host}"]["${env}"]["${spec}"] is not a valid URL — got "${url}"`,
+          );
+        }
+        if (!URL_SCHEMES.has(parsed.protocol)) {
+          throw new Error(
+            `${source}: openapi.registry["${host}"]["${env}"]["${spec}"] uses unsupported scheme "${parsed.protocol}" — only http / https / file are accepted`,
           );
         }
       }

--- a/skills/openapi-client/SKILL.md
+++ b/skills/openapi-client/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: openapi-client
-description: Read a cached OpenAPI / Swagger spec under a cache-first policy and emit a `fetch` or `axios` call snippet (TypeScript) for one endpoint. Auto-trigger when the user supplies an OpenAPI spec URL or 16-hex spec key together with phrases like "이 endpoint 호출 코드 만들어줘" / "axios 로 작성해줘" / "fetch snippet 줘" / "POST /pets 호출 코드".
-allowed-tools: [swagger_get, swagger_status, swagger_refresh, swagger_search]
+description: Read a cached OpenAPI / Swagger spec under a cache-first policy and emit a `fetch` or `axios` call snippet (TypeScript) for one endpoint. Auto-trigger when the user supplies an OpenAPI spec URL, a 16-hex cache key, or a `host:env:spec` registry handle (configured in `agent-toolkit.json`) together with phrases like "이 endpoint 호출 코드 만들어줘" / "axios 로 작성해줘" / "fetch snippet 줘" / "POST /pets 호출 코드 / acme:dev:users 의 …".
+allowed-tools: [swagger_get, swagger_status, swagger_refresh, swagger_search, swagger_envs]
 license: MIT
-version: 0.1.0
+version: 0.2.0
 ---
 
 # openapi-client
@@ -17,32 +17,52 @@ version: 0.1.0
 
 ```
 agent (you)
+  ├── 0. swagger_envs           ← list registered host:env:spec handles (no remote call)
   ├── 1. swagger_status         ← cache metadata only (no remote call)
   ├── 2. swagger_get            ← cache hit → spec / miss → GET URL + JSON-validate + cache write (one shot)
-  ├── 3. swagger_search         ← search across cached specs to locate the endpoint
+  ├── 3. swagger_search         ← search across cached specs (optionally scoped) to locate the endpoint
   └── 4. swagger_refresh        ← only when the user explicitly asks for "최신화" / refresh
 ```
 
 The cache is a thin TTL layer in front of the spec URL. `swagger_get` already handles cache miss by downloading the spec, validating its shape (`openapi` 3.x or `swagger` 2.x), and persisting it — no separate write step is needed. JSON-only in this version: YAML specs throw, document the limitation when the user hits it.
 
+## Inputs
+
+`swagger_get` / `swagger_status` / `swagger_refresh` accept any of:
+
+- **Spec URL** (`https://…` or `file://…`) — direct download source.
+- **16-hex cache key** — disk key returned by `swagger_status` / `swagger_search`. Resolves via cache metadata; if the metadata is gone, the tool throws with a clear "no recoverable spec URL" message.
+- **`host:env:spec` handle** — symbolic name registered in `agent-toolkit.json` (`./.opencode/agent-toolkit.json` overrides `~/.config/opencode/agent-toolkit/agent-toolkit.json`). Resolves to a spec URL via the registry. Unregistered handles throw.
+
+`swagger_search` accepts an optional `scope`:
+
+- **`host`** — search inside every spec under one host
+- **`host:env`** — search inside one environment
+- **`host:env:spec`** — search inside one spec
+- **omitted** — search across every cached spec
+
+Use `swagger_envs` first when the user does not name a specific handle but talks about "이 환경 / 그 spec".
+
 ## Tool usage rules
 
-1. Reach OpenAPI specs only through `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search`. No direct `fetch`, Read, or Bash to download the spec yourself.
+1. Reach OpenAPI specs only through `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` / `swagger_envs`. No direct `fetch`, Read, or Bash to download the spec yourself.
 2. Unless the user explicitly asks to refresh ("최신화" / "refresh"):
-   * Check cache state first with `swagger_status` when the spec URL or key is given.
+   * Check cache state first with `swagger_status` when the input (URL / key / handle) is given.
    * If `exists=true && expired=false`, use `swagger_get` (it returns instantly from cache) and `swagger_search` to locate the endpoint.
    * Otherwise call `swagger_get` once — it will hit the remote on cache miss automatically.
 3. Do not download the same spec more than once per turn. Reuse the spec object you already have.
 4. Use `swagger_refresh` only when the user explicitly asks to re-download.
-5. `swagger_search` spans **every cached spec**. When the user has multiple specs cached and wants results from one, scope by passing a more specific query (e.g. include the spec title or a unique path prefix).
+5. **Prefer `host:env:spec` handles when the user works with multiple environments.** Resolve the user's environment / service intent by calling `swagger_envs` once, presenting the matching handles, and asking which one if it is ambiguous. Pass the handle as-is to the swagger_* tools — never expand it to a URL yourself.
+6. **Use `swagger_search` `scope` when the user has multiple environments cached.** A scope of `acme:dev` keeps results inside that environment. When the user does not name an environment, leave `scope` off and search across everything.
 
 ## Locating the endpoint
 
 Given an ambiguous request ("POST /pets 호출 코드 만들어줘"):
 
-1. If the user already gave a spec URL / 16-hex key, run `swagger_get` for that spec, then look up the endpoint by `(method, path)` in `spec.paths`.
-2. Otherwise use `swagger_search` with the path and/or operationId substring. If multiple matches come back, surface the candidates (`specTitle` + `method path` + `summary`) and ask the user which one.
-3. If zero matches, do not invent the endpoint — quote what you searched for and ask the user to clarify the spec or the path.
+1. If the user already gave a spec URL / 16-hex key / `host:env:spec` handle, run `swagger_get` for that input, then look up the endpoint by `(method, path)` in `spec.paths`.
+2. If the user names an environment but not a specific spec ("acme:dev 의 POST /pets"), call `swagger_envs` once, identify the matching specs under that scope, and run `swagger_search` with `scope: "acme:dev"`. If multiple candidates remain, surface them (`specTitle` + `method path` + `summary`) and ask the user which one.
+3. Otherwise use `swagger_search` (no scope) with the path and/or operationId substring across every cached spec. If multiple matches come back, surface the candidates and ask the user which one — including the `specTitle` so it is clear which environment / service.
+4. If zero matches, do not invent the endpoint — quote what you searched for and ask the user to clarify the spec, environment, or path.
 
 ## Output format — fetch snippet (default)
 
@@ -107,9 +127,13 @@ export async function <camelCaseOperationId>(
 * Do not invent a response or body type. If the spec does not declare it, use `unknown` and surface the gap in one inline comment.
 * Do not paste the entire spec into the answer. The user wants one snippet plus a usage line.
 * Do not assume YAML support. If `swagger_get` rejects with a non-JSON body, tell the user the spec is YAML and that this skill is JSON-only in MVP.
+* Do not silently pick an environment when the user has more than one (`acme:dev`, `acme:staging`, …). Ask which one before running `swagger_get`.
+* Do not invent registry handles. If a handle is not in `swagger_envs`, surface the available handles and ask the user to pick — do not guess "this looks like dev so I'll try `acme:dev`".
 
 ## Failure / error handling
 
 * `swagger_get` throws on timeout / network error / non-JSON body / missing `openapi` / `swagger` field → surface the error in one sentence and ask the user to verify the spec URL and `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS`.
-* `swagger_search` returns 0 matches → quote the query and ask which spec / path, do not hallucinate.
+* `swagger_get` / `swagger_status` throws when a `host:env:spec` handle is unregistered → ask the user to add it under `openapi.registry` in `agent-toolkit.json`, or quote the available handles from `swagger_envs`.
+* `swagger_search` throws on a scope that matches no entries (typo in `host` / `host:env`) → quote the scope and the available handles from `swagger_envs`, ask the user to correct it.
+* `swagger_search` returns 0 matches with a valid scope → quote the query and ask which spec / path, do not hallucinate.
 * The endpoint exists but lacks `operationId` / response schema → emit the snippet with the documented fallback (path-slug name, `unknown` response) and call out the gap in one inline comment.


### PR DESCRIPTION
Phase 4 (#9) 머지 후 base 를 `main` 으로 변경. 이전엔 `claude/openapi-context-phase4` 위에 stacked 되어 있었음.

## Summary

Phase 4 가 OpenAPI spec 을 URL 로만 다뤘다면, Phase 4.5 는 **host (API 묶음) → env (dev/staging/prod) → spec (개별 API)** 3-단계 레지스트리를 `agent-toolkit.json` 에 선언해 두고 `host:env:spec` 짧은 핸들로 도구를 호출할 수 있게 한다. 한 회사가 여러 환경에서 여러 spec 을 관리하는 현실적 구조에 맞춤.

## 핵심 변경

- **`agent-toolkit.schema.json`** — `agent-toolkit.json` 의 JSON Schema. VS Code 등 JSON-Schema-aware 에디터에서 자동완성 / 검증.
- **`lib/toolkit-config.ts`** — project (`./.opencode/agent-toolkit.json`) > user (`~/.config/opencode/agent-toolkit/agent-toolkit.json`) 우선순위 로더 + 런타임 shape 검증 (외부 의존성 0). 한 파일이 손상돼도 다른 쪽은 살리는 per-file 회복 (Codex P1 fix). `AGENT_TOOLKIT_CONFIG` 로 user 경로 override.
- **`lib/openapi-registry.ts`** — `host:env:spec` full handle + `host` / `host:env` / `host:env:spec` scope 표기 파싱·해석, registry 평면화. 식별자 본문은 `toolkit-config` 의 `ID_BODY` 를 import 해 한 곳에서만 관리.
- **`.opencode/plugins/agent-toolkit.ts`**
  - `swagger_get` / `swagger_refresh` / `swagger_status` 가 핸들도 input 으로 수용 (URL / 16-hex 키와 같은 자리). 미등록 핸들은 throw.
  - `swagger_search` 에 optional `scope` 추가 — host / host:env / host:env:spec 범위 제한. 매칭 0 건이면 throw 로 typo 즉시 알림.
  - **신규 `swagger_envs`** — 등록 트리를 `[{host, env, spec, url}]` 평면 리스트로 반환.
  - plugin init 에서 손상된 config 파일별로 `console.error` 한 줄씩 surfacing 후 정상적인 파일들로 계속 동작 (graceful degrade).
- **`skills/openapi-client/SKILL.md`** — handle / scope 흐름 + 환경 모호성 처리 가이드 (여러 env 캐시 시 silently 고르지 말 것).
- **`.opencode/INSTALL.md`** — 전체 영문화 (에이전트가 보는 파일 — 사용자 요청 반영).
- **README / AGENTS / ROADMAP** — 도구 표·env-var·layout·MVP scope·체크리스트·레지스트리 예시 동기화.

## 설계 결정

- **JSON-only spec 다운로드 유지** (Phase 4 와 동일). YAML 후속 이슈.
- **Hosts in registry**: spec URL 만. 런타임 BASE_URL 은 spec 의 `servers[]` 사용 — 별도 host 필드 없음.
- **Config 위치**: project + user, project 가 leaf 단위로 우선. 새 host/env/spec 은 project 에서 추가 가능.
- **Identifier 규칙**: `^[a-zA-Z0-9_-]+$` — 콜론은 핸들 separator 로 예약. URL 은 `new URL()` 파싱 + http/https/file 스킴만.
- **외부 의존성 0**: JSON Schema 는 IDE 자동완성용으로만 두고 런타임은 직접 검증.
- **Schema vs runtime lockstep**: schema 의 root / `openapi` 는 미지정 키 허용 (forward-compat). host / env / spec 는 strict (식별자 패턴 외 거부).
- **Per-file 회복**: 한 쪽 config 가 손상돼도 다른 쪽은 살아남고 errors 는 로그로만 surfacing.

## Test plan

- [x] `bun run typecheck` 통과
- [x] `bun run test` (101 pass / 0 fail / 5 files — 기존 46 + toolkit-config 19 + openapi-registry 17 + plugin registry 6 + 기존 search 옵션-객체 마이그레이션 + 회복 / URL 검증 / 타입 가드 케이스)
- 수동 검증은 별도 이슈로 트래킹:
  - #12 — Manual smoke test: registry handles + scoped search
  - #13 — Manual smoke test: malformed `agent-toolkit.json` graceful degrade
