### PR TITLE
feat(phase3): agent journal — append-only JSONL memory across turns (closes #5)

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -31,6 +31,7 @@ All optional. Set only when the defaults do not fit.
 | `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` | `~/.config/opencode/agent-toolkit/openapi-specs` | OpenAPI / Swagger spec cache directory. |
 | `AGENT_TOOLKIT_OPENAPI_CACHE_TTL` | `86400` | OpenAPI cache TTL (seconds). |
 | `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS` | `30000` | OpenAPI spec download timeout (ms). |
+| `AGENT_TOOLKIT_JOURNAL_DIR` | `~/.config/opencode/agent-toolkit/journal` | Agent journal directory. Holds a single `journal.jsonl` (append-only, no TTL). |
 | `AGENT_TOOLKIT_CONFIG` | `~/.config/opencode/agent-toolkit/agent-toolkit.json` | User-level `agent-toolkit.json` path. The project-level `./.opencode/agent-toolkit.json` overrides it at the leaf level. |
 
 ## Smoke test
@@ -51,9 +52,11 @@ Then verify the tools are registered:
 > use swagger_status tool with input "<spec URL or host:env:spec handle>"
 > use swagger_get tool with input "<spec URL or host:env:spec handle>"
 > use swagger_envs tool   # flatten the registry from agent-toolkit.json
+> use journal_append tool with content "decided to ship Phase 3" kind "decision"
+> use journal_read tool   # most recent first
 ```
 
-The first call returns `fromCache: false` — remote is hit once. The second call returns `fromCache: true` (same policy for `notion_*` and `swagger_*`).
+The first call returns `fromCache: false` — remote is hit once. The second call returns `fromCache: true` (same policy for `notion_*` and `swagger_*`). `journal_*` does not hit any remote — it only reads / writes the local JSONL file.
 
 ## OpenAPI registry (`agent-toolkit.json`)
 

--- a/.opencode/plugins/agent-toolkit.test.ts
+++ b/.opencode/plugins/agent-toolkit.test.ts
@@ -5,7 +5,12 @@ import { basename, join } from "node:path";
 import { NotionCache } from "../../lib/notion-context";
 import { OpenapiCache } from "../../lib/openapi-context";
 import type { OpenapiRegistry } from "../../lib/toolkit-config";
+import { AgentJournal } from "../../lib/agent-journal";
 import agentToolkitPlugin, {
+  handleJournalAppend,
+  handleJournalRead,
+  handleJournalSearch,
+  handleJournalStatus,
   handleNotionGet,
   handleNotionRefresh,
   handleNotionStatus,
@@ -359,6 +364,66 @@ describe("swagger handlers — registry handles", () => {
 
   it("swagger_envs returns [] for empty config", () => {
     expect(handleSwaggerEnvs({})).toEqual([]);
+  });
+});
+
+describe("journal handlers", () => {
+  let jDir: string;
+  let journal: AgentJournal;
+
+  beforeEach(() => {
+    jDir = mkdtempSync(join(tmpdir(), "plugin-journal-"));
+    journal = new AgentJournal({ baseDir: jDir });
+  });
+
+  it("journal_append: writes a normalized entry", async () => {
+    const entry = await handleJournalAppend(journal, {
+      content: "decided to ship phase 3",
+      kind: "decision",
+      tags: ["phase3"],
+    });
+    expect(entry.kind).toBe("decision");
+    expect(entry.tags).toEqual(["phase3"]);
+    expect(entry.content).toBe("decided to ship phase 3");
+  });
+
+  it("journal_read: returns most recent first across turns", async () => {
+    await handleJournalAppend(journal, { content: "turn-1 decision", kind: "decision" });
+    await handleJournalAppend(journal, { content: "turn-2 blocker", kind: "blocker" });
+    // 시뮬레이션: 다음 turn 에서 새 인스턴스로 읽기.
+    const next = new AgentJournal({ baseDir: jDir });
+    const r = await handleJournalRead(next);
+    expect(r.length).toBe(2);
+    expect(r[0]?.content).toBe("turn-2 blocker");
+    expect(r[1]?.content).toBe("turn-1 decision");
+  });
+
+  it("journal_read: kind filter narrows the result", async () => {
+    await handleJournalAppend(journal, { content: "a", kind: "decision" });
+    await handleJournalAppend(journal, { content: "b", kind: "blocker" });
+    const r = await handleJournalRead(journal, { kind: "decision" });
+    expect(r.length).toBe(1);
+    expect(r[0]?.content).toBe("a");
+  });
+
+  it("journal_search: matches across content and tags", async () => {
+    await handleJournalAppend(journal, { content: "use Bun for runtime", tags: ["infra"] });
+    await handleJournalAppend(journal, { content: "auth blocker", kind: "blocker" });
+    expect((await handleJournalSearch(journal, "bun")).length).toBe(1);
+    expect((await handleJournalSearch(journal, "infra")).length).toBe(1);
+    expect((await handleJournalSearch(journal, "MISSING")).length).toBe(0);
+  });
+
+  it("journal_status: reflects journal state", async () => {
+    const before = await handleJournalStatus(journal);
+    expect(before.exists).toBe(false);
+    expect(before.totalEntries).toBe(0);
+
+    const last = await handleJournalAppend(journal, { content: "first" });
+    const after = await handleJournalStatus(journal);
+    expect(after.exists).toBe(true);
+    expect(after.totalEntries).toBe(1);
+    expect(after.lastEntryAt).toBe(last.timestamp);
   });
 });
 

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -539,7 +539,11 @@ export default async function agentToolkitPlugin(_input: unknown) {
         parameters: {
           content: { type: "string", required: true },
           kind: { type: "string", required: false },
-          tags: { type: "array", required: false },
+          tags: {
+            type: "array",
+            items: { type: "string" },
+            required: false,
+          },
           pageId: { type: "string", required: false },
         },
         async handler({
@@ -604,7 +608,7 @@ export default async function agentToolkitPlugin(_input: unknown) {
       },
       journal_status: {
         description:
-          "저널 메타(파일 경로, 존재 여부, 총 라인 수, 바이트 크기, 마지막 항목 시각) 만 조회한다. remote 호출 없음.",
+          "저널 메타(파일 경로, 존재 여부, 유효 항목 수 — 손상 라인 skip, 바이트 크기, 마지막 항목 시각) 만 조회한다. remote 호출 없음.",
         parameters: {},
         async handler() {
           return handleJournalStatus(journal);

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -32,6 +32,15 @@ import {
   type OpenapiRegistry,
   type ToolkitConfig,
 } from "../../lib/toolkit-config";
+import {
+  AgentJournal,
+  createJournalFromEnv,
+  type JournalAppendInput,
+  type JournalEntry,
+  type JournalReadOptions,
+  type JournalSearchOptions,
+  type JournalStatus,
+} from "../../lib/agent-journal";
 
 /**
  * opencode plugin entrypoint (Superpowers 형식).
@@ -373,6 +382,41 @@ export function handleSwaggerEnvs(
 }
 
 /**
+ * 도구 핸들러: 저널에 한 줄 append. remote 호출 없음.
+ * 입력 검증과 정규화는 `AgentJournal.append` 가 담당한다.
+ */
+export async function handleJournalAppend(
+  journal: AgentJournal,
+  input: JournalAppendInput,
+): Promise<JournalEntry> {
+  return journal.append(input);
+}
+
+/** 도구 핸들러: 가장 최근 항목부터 필터 / limit 적용해 반환. remote 호출 없음. */
+export async function handleJournalRead(
+  journal: AgentJournal,
+  options: JournalReadOptions = {},
+): Promise<JournalEntry[]> {
+  return journal.read(options);
+}
+
+/** 도구 핸들러: substring 검색 (case-insensitive). remote 호출 없음. */
+export async function handleJournalSearch(
+  journal: AgentJournal,
+  query: string,
+  options: JournalSearchOptions = {},
+): Promise<JournalEntry[]> {
+  return journal.search(query, options);
+}
+
+/** 도구 핸들러: 저널 메타 (라인 수, 바이트 수, 마지막 항목 시각). remote 호출 없음. */
+export async function handleJournalStatus(
+  journal: AgentJournal,
+): Promise<JournalStatus> {
+  return journal.status();
+}
+
+/**
  * opencode plugin default export.
  * `directory` 는 opencode 가 plugin 을 로드한 cwd. 우리는 import.meta 기반으로
  * 자기 저장소의 skills/ 를 절대 경로로 잡는다.
@@ -380,6 +424,7 @@ export function handleSwaggerEnvs(
 export default async function agentToolkitPlugin(_input: unknown) {
   const cache = createCacheFromEnv();
   const openapi = createOpenapiCacheFromEnv();
+  const journal = createJournalFromEnv();
 
   // user / project agent-toolkit.json 로드. loadConfig 는 파일별 try-catch 로 자체
   // 회복하므로 한 쪽이 손상돼도 다른 쪽은 그대로 살아나 registry 에 들어온다.
@@ -486,6 +531,83 @@ export default async function agentToolkitPlugin(_input: unknown) {
         parameters: {},
         async handler() {
           return handleSwaggerEnvs(toolkitConfig);
+        },
+      },
+      journal_append: {
+        description:
+          "에이전트 저널에 한 줄을 append-only 로 기록한다. 다음 turn 에 인용할 결정 / blocker / 사용자 답변 / 메모를 남길 때 사용. (content: 본문 필수, kind?: decision/blocker/answer/note 등 자유 문자열, 기본 'note', tags?: 문자열 배열, pageId?: 연결할 Notion page id 또는 URL — 정규화되어 저장)",
+        parameters: {
+          content: { type: "string", required: true },
+          kind: { type: "string", required: false },
+          tags: { type: "array", required: false },
+          pageId: { type: "string", required: false },
+        },
+        async handler({
+          content,
+          kind,
+          tags,
+          pageId,
+        }: {
+          content: string;
+          kind?: string;
+          tags?: string[];
+          pageId?: string;
+        }) {
+          return handleJournalAppend(journal, { content, kind, tags, pageId });
+        },
+      },
+      journal_read: {
+        description:
+          "저널을 가장 최근 항목부터 필터 / limit 적용해 반환한다. 손상된 라인은 자동 skip. remote 호출 없음. (limit?: 결과 최대 개수 기본 20, kind?: 종류 정확 일치, tag?: 태그 정확 일치, pageId?: Notion page id / URL 로 page 묶인 항목만, since?: ISO8601 — 그 시각 이후 항목만)",
+        parameters: {
+          limit: { type: "number", required: false },
+          kind: { type: "string", required: false },
+          tag: { type: "string", required: false },
+          pageId: { type: "string", required: false },
+          since: { type: "string", required: false },
+        },
+        async handler({
+          limit,
+          kind,
+          tag,
+          pageId,
+          since,
+        }: {
+          limit?: number;
+          kind?: string;
+          tag?: string;
+          pageId?: string;
+          since?: string;
+        }) {
+          return handleJournalRead(journal, { limit, kind, tag, pageId, since });
+        },
+      },
+      journal_search: {
+        description:
+          "저널을 substring (case-insensitive) 으로 검색한다. content / kind / tags / pageId 를 매칭한다. 빈 query 는 (kind 필터 한정) 가장 최근부터 나열. remote 호출 없음. (query: 검색어, limit?: 결과 최대 개수 기본 20, kind?: 종류 필터)",
+        parameters: {
+          query: { type: "string", required: true },
+          limit: { type: "number", required: false },
+          kind: { type: "string", required: false },
+        },
+        async handler({
+          query,
+          limit,
+          kind,
+        }: {
+          query: string;
+          limit?: number;
+          kind?: string;
+        }) {
+          return handleJournalSearch(journal, query, { limit, kind });
+        },
+      },
+      journal_status: {
+        description:
+          "저널 메타(파일 경로, 존재 여부, 총 라인 수, 바이트 크기, 마지막 항목 시각) 만 조회한다. remote 호출 없음.",
+        parameters: {},
+        async handler() {
+          return handleJournalStatus(journal);
         },
       },
     },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,19 +4,20 @@ Shared guide for AI coding agents (Claude Code, opencode, codex, etc.) working i
 
 ## Project in one line
 
-opencode-only plugin. Three Notion cache tools + five OpenAPI tools (cache, search, environment registry) + two cache-first skills (`notion-context` for context / Korean specs, `openapi-client` for `fetch`/`axios` snippets) + one thin gateway agent (`rocky`, naming convention borrowed from [OmO](https://github.com/code-yeongyu/oh-my-openagent)'s named-specialist pattern). OpenAPI specs can be addressed by URL or by `host:env:spec` handles declared in `agent-toolkit.json` (project > user precedence). **Runtime is Bun (>=1.0). No Node. No build step (Bun runs TS directly).** Layout follows the [obra/superpowers](https://github.com/obra/superpowers) shape.
+opencode-only plugin. Three Notion cache tools + five OpenAPI tools (cache, search, environment registry) + four append-only journal tools (turn-spanning agent memory) + two cache-first skills (`notion-context` for context / Korean specs, `openapi-client` for `fetch`/`axios` snippets) + one thin gateway agent (`rocky`, naming convention borrowed from [OmO](https://github.com/code-yeongyu/oh-my-openagent)'s named-specialist pattern). OpenAPI specs can be addressed by URL or by `host:env:spec` handles declared in `agent-toolkit.json` (project > user precedence). **Runtime is Bun (>=1.0). No Node. No build step (Bun runs TS directly).** Layout follows the [obra/superpowers](https://github.com/obra/superpowers) shape.
 
 ## Layout
 
-- `.opencode/plugins/agent-toolkit.ts` — plugin entrypoint. `config` hook registers `skills/` and `agents/`, and exposes eight tools: `notion_get` / `notion_refresh` / `notion_status` plus `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` / `swagger_envs`.
+- `.opencode/plugins/agent-toolkit.ts` — plugin entrypoint. `config` hook registers `skills/` and `agents/`, and exposes twelve tools: `notion_get` / `notion_refresh` / `notion_status` + `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` / `swagger_envs` + `journal_append` / `journal_read` / `journal_search` / `journal_status`.
 - `lib/notion-context.ts` — single-file TTL filesystem cache for Notion pages + `resolveCacheKey` + `notionToMarkdown`.
 - `lib/openapi-context.ts` — single-file TTL filesystem cache for OpenAPI / Swagger JSON specs + `resolveSpecKey` + `searchEndpoints` + shape validation.
 - `lib/openapi-registry.ts` — `host:env:spec` handle parsing, scope resolution, and registry flattening on top of the toolkit config.
 - `lib/toolkit-config.ts` — `agent-toolkit.json` loader (project `./.opencode/agent-toolkit.json` overrides user `~/.config/opencode/agent-toolkit/agent-toolkit.json`) with runtime shape validation.
+- `lib/agent-journal.ts` — append-only JSONL agent journal (decisions / blockers / answers / notes). No TTL; corruption-tolerant on read.
 - `agent-toolkit.schema.json` — JSON Schema for `agent-toolkit.json` (IDE autocomplete; runtime validation lives in `toolkit-config.ts`).
 - `skills/notion-context/SKILL.md` — Notion cache-first read + Korean-language spec extraction skill.
 - `skills/openapi-client/SKILL.md` — cached OpenAPI spec → `fetch` or `axios` call snippet skill.
-- `agents/rocky.md` — thin gateway agent (`mode: all`) that exposes the toolkit's Notion flow to users and to other primary agents (e.g. OmO Sisyphus).
+- `agents/rocky.md` — thin gateway agent (`mode: all`) that exposes the toolkit's Notion flow + journal recall / append to users and to other primary agents (e.g. OmO Sisyphus).
 - `.opencode/INSTALL.md` — install guide for opencode users.
 
 ## Common commands
@@ -41,9 +42,9 @@ Only `AGENT_TOOLKIT_NOTION_MCP_URL` is required. See the README env-var table fo
 
 ## MVP scope (hold the line)
 
-**In**: single-page Notion read + cache + expiry, single OpenAPI / Swagger JSON spec cache + cross-spec endpoint search + `host:env:spec` registry (`agent-toolkit.json`, project > user precedence), two skills (`notion-context`, `openapi-client`), one gateway agent (`rocky`), opencode-only.
+**In**: single-page Notion read + cache + expiry, single OpenAPI / Swagger JSON spec cache + cross-spec endpoint search + `host:env:spec` registry (`agent-toolkit.json`, project > user precedence), append-only agent journal (turn-spanning memory: decisions / blockers / answers / notes — disk only, no TTL, time / page-key / kind / tag-shaped lookup + substring search), two skills (`notion-context`, `openapi-client`), one gateway agent (`rocky`), opencode-only.
 
-**Out**: database queries, OAuth, Notion child pages, OpenAPI YAML parsing, runtime base-URL override (use `spec.servers`), full SDK code generation, multi-spec merge, mock servers, multi-host plugin layouts (`.claude-plugin/`, etc.), UI, codex integration, agent-side workflow orchestration (that lives in the caller, not in `rocky`). Anything beyond this scope ships as a separate PR proposal.
+**Out**: database queries, OAuth, Notion child pages, OpenAPI YAML parsing, runtime base-URL override (use `spec.servers`), full SDK code generation, multi-spec merge, mock servers, multi-host plugin layouts (`.claude-plugin/`, etc.), UI, codex integration, agent-side workflow orchestration (that lives in the caller, not in `rocky`), cross-machine journal sync, embedding / natural-language journal search, journal compaction or summarization. Anything beyond this scope ships as a separate PR proposal.
 
 The longer-term capability targets (auto memory, GitHub-issue tracking, OpenAPI client generation, …) live in [`ROADMAP.md`](./ROADMAP.md) — phase-by-phase, one PR at a time. Do not pull roadmap items into MVP unless the user explicitly asks.
 
@@ -53,7 +54,7 @@ The longer-term capability targets (auto memory, GitHub-issue tracking, OpenAPI 
 2. `bun test` passes
 3. If the user-facing surface (tools / env vars) changes, sync `README.md` and `.opencode/INSTALL.md`
 4. If a new env var is added, also update the plugin's `readEnv()`
-5. If the plugin's tool contract changes, update the tool-usage rules in the relevant skill (`skills/notion-context/SKILL.md` for `notion_*`, `skills/openapi-client/SKILL.md` for `swagger_*`) and the corresponding tool description/rules in `agents/rocky.md` when Notion-side
+5. If the plugin's tool contract changes, update the tool-usage rules in the relevant skill (`skills/notion-context/SKILL.md` for `notion_*`, `skills/openapi-client/SKILL.md` for `swagger_*`) and the corresponding tool description/rules in `agents/rocky.md` when Notion-side or journal-side (`journal_*` is owned by `rocky` directly — no separate skill)
 6. If `agent-toolkit.json` shape changes, update **both** `agent-toolkit.schema.json` (IDE autocomplete) **and** `lib/toolkit-config.ts` (runtime validation) — they must stay in lockstep
 
 ## MCP servers

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ turn / session 경계를 넘는 에이전트 메모. 캐시와 달리 **append-o
 | `journal_append` | 한 항목 append. (content 필수, kind?: `decision`/`blocker`/`answer`/`note` 등 자유 문자열·기본 `note`, tags?: 문자열 배열, pageId?: Notion page id/URL — 입력 시 `8-4-4-4-12` 형식으로 정규화 후 저장) |
 | `journal_read` | 최근 항목부터 필터/limit 적용해 반환. (limit?: 기본 20, kind?, tag?, pageId?: page-key 기반 lookup, since?: ISO8601 — 그 시각 이후만) |
 | `journal_search` | content / kind / tags / pageId 를 substring (case-insensitive) 매칭. (query 필수, limit?, kind?) |
-| `journal_status` | 파일 경로 / 존재 여부 / 라인 수 / 바이트 / 마지막 항목 시각만 조회 |
+| `journal_status` | 파일 경로 / 존재 여부 / 유효 항목 수 (손상 라인 제외) / 바이트 / 마지막 항목 시각만 조회 |
 
 손상 / 부분 쓰기 라인은 read 단계에서 자동 skip — 한 줄이 깨져도 다음 turn 의 read 가 throw 하지 않고 나머지를 반환한다.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Toolkit
 
-opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 개, OpenAPI / Swagger JSON 을 캐시 우선으로 가져와 endpoint 검색·환경별 등록 관리까지 해 주는 도구 5 개, 그 도구들을 묶어 컨텍스트 / 한국어 스펙 / `fetch`·`axios` 호출 코드로 정리하는 skill 2 개, 그리고 회사 컨텍스트를 들고 있는 업무 파트너 agent 1 개(`rocky`) 를 제공한다. OpenAPI 쪽은 host(API 묶음) → env(dev/staging/prod) → spec(개별 API) 3-단계 레지스트리를 `agent-toolkit.json` 으로 선언하면 `host:env:spec` handle 로 직접 호출 가능. Notion 은 시작 소스이고, 회사 지식 표면은 이후 더 넓혀질 수 있다. 런타임은 **Bun (>=1.0)** 만 사용하며, 별도 빌드 단계는 없다 (Bun 이 TS 직접 실행).
+opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 개, OpenAPI / Swagger JSON 을 캐시 우선으로 가져와 endpoint 검색·환경별 등록 관리까지 해 주는 도구 5 개, turn 단위 결정 / blocker / 사용자 답변을 append-only 로 적재하고 다음 turn 에 인용 가능하게 하는 저널 도구 4 개, 그 도구들을 묶어 컨텍스트 / 한국어 스펙 / `fetch`·`axios` 호출 코드로 정리하는 skill 2 개, 그리고 회사 컨텍스트를 들고 있는 업무 파트너 agent 1 개(`rocky`) 를 제공한다. OpenAPI 쪽은 host(API 묶음) → env(dev/staging/prod) → spec(개별 API) 3-단계 레지스트리를 `agent-toolkit.json` 으로 선언하면 `host:env:spec` handle 로 직접 호출 가능. Notion 은 시작 소스이고, 회사 지식 표면은 이후 더 넓혀질 수 있다. 런타임은 **Bun (>=1.0)** 만 사용하며, 별도 빌드 단계는 없다 (Bun 이 TS 직접 실행).
 
 구조는 [obra/superpowers](https://github.com/obra/superpowers) 형식을 따른다 — 단일 plugin 파일이 `skills/` / `agents/` 디렉터리를 opencode 탐색 경로에 등록하고 도구를 노출한다. `rocky` 의 캐릭터/네이밍 컨벤션은 [code-yeongyu/oh-my-openagent (OmO)](https://github.com/code-yeongyu/oh-my-openagent) 의 named-specialist 패턴에서 빌렸지만, 책임은 회사 컨텍스트 파트너 한 줄로 한정한다.
 
@@ -11,7 +11,7 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 ├── .opencode/
 │   ├── INSTALL.md                  # opencode 사용자용 설치 안내
 │   └── plugins/
-│       ├── agent-toolkit.ts        # plugin entrypoint + 도구 8 개 (notion 3 + swagger 5)
+│       ├── agent-toolkit.ts        # plugin entrypoint + 도구 12 개 (notion 3 + swagger 5 + journal 4)
 │       └── agent-toolkit.test.ts
 ├── lib/
 │   ├── notion-context.ts           # Notion TTL 파일 캐시 + key 정규화 + normalize
@@ -21,7 +21,9 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 │   ├── openapi-registry.ts         # host:env:spec 핸들 / 스코프 해석 + 평면화
 │   ├── openapi-registry.test.ts
 │   ├── toolkit-config.ts           # agent-toolkit.json 로더 (project > user 우선순위)
-│   └── toolkit-config.test.ts
+│   ├── toolkit-config.test.ts
+│   ├── agent-journal.ts            # turn 단위 결정/blocker/사용자 답변 append-only JSONL 저널
+│   └── agent-journal.test.ts
 ├── skills/
 │   ├── notion-context/SKILL.md     # Notion 캐시 우선 읽기 + 한국어 스펙 정리 skill
 │   └── openapi-client/SKILL.md     # 캐시된 OpenAPI spec → fetch / axios 호출 코드 skill
@@ -59,10 +61,11 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 | `AGENT_TOOLKIT_OPENAPI_CACHE_DIR` | `~/.config/opencode/agent-toolkit/openapi-specs` | OpenAPI / Swagger spec 캐시 디렉터리 |
 | `AGENT_TOOLKIT_OPENAPI_CACHE_TTL` | `86400` | OpenAPI 캐시 TTL (초) |
 | `AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS` | `30000` | OpenAPI spec 다운로드 timeout (ms) |
+| `AGENT_TOOLKIT_JOURNAL_DIR` | `~/.config/opencode/agent-toolkit/journal` | 에이전트 저널 디렉터리 (안에 단일 `journal.jsonl` 파일) |
 
 ## 도구
 
-plugin 이 opencode 에 다음 8 개를 등록한다.
+plugin 이 opencode 에 다음 12 개를 등록한다.
 
 ### Notion (`notion_*`)
 
@@ -91,6 +94,19 @@ plugin 이 opencode 에 다음 8 개를 등록한다.
 - `agent-toolkit.json` 에 등록된 `host:env:spec` handle (registry 가 URL 로 해석)
 
 `swagger_search` 는 `query: string`, `limit?: number` (기본 20), `scope?: string` (host / host:env / host:env:spec — registry 안에 등록되어야 한다). YAML spec 은 MVP 에서 미지원 — JSON 만 받는다.
+
+### Journal (`journal_*`)
+
+turn / session 경계를 넘는 에이전트 메모. 캐시와 달리 **append-only** 이고 만료가 없다 — "다음 turn 에 인용해야 할 결정 / blocker / 사용자 답변" 을 한 줄(JSONL) 씩 적재한다.
+
+| 도구 | 동작 |
+| --- | --- |
+| `journal_append` | 한 항목 append. (content 필수, kind?: `decision`/`blocker`/`answer`/`note` 등 자유 문자열·기본 `note`, tags?: 문자열 배열, pageId?: Notion page id/URL — 입력 시 `8-4-4-4-12` 형식으로 정규화 후 저장) |
+| `journal_read` | 최근 항목부터 필터/limit 적용해 반환. (limit?: 기본 20, kind?, tag?, pageId?: page-key 기반 lookup, since?: ISO8601 — 그 시각 이후만) |
+| `journal_search` | content / kind / tags / pageId 를 substring (case-insensitive) 매칭. (query 필수, limit?, kind?) |
+| `journal_status` | 파일 경로 / 존재 여부 / 라인 수 / 바이트 / 마지막 항목 시각만 조회 |
+
+손상 / 부분 쓰기 라인은 read 단계에서 자동 skip — 한 줄이 깨져도 다음 turn 의 read 가 throw 하지 않고 나머지를 반환한다.
 
 ## Config (`agent-toolkit.json`)
 
@@ -150,6 +166,15 @@ OpenAPI registry 를 선언하면 `swagger_*` 도구를 URL 대신 `host:env:spe
 ```
 
 `<key>` 는 `sha256(specUrl)` 의 앞 16자 hex. `.json` 또는 `.spec.json` 한쪽이 누락되면 `swagger_status` / `swagger_get` 모두 cache miss 로 본다.
+
+### Journal (`AGENT_TOOLKIT_JOURNAL_DIR`)
+
+```
+<AGENT_TOOLKIT_JOURNAL_DIR>/
+  journal.jsonl   # 한 줄 = 한 항목 (id, timestamp, kind, content, tags, pageId?)
+```
+
+캐시와 달리 디렉터리 / TTL 모델이 없다 — 저널 자체가 source of truth 이므로 만료 / 무효화 / 덮어쓰기는 일어나지 않는다. 항목 한 줄이 깨져도 read 단계에서 그 줄만 skip 된다.
 
 ## 개발
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@
 
 | # | 항목 | 상태 | 추적 issue | 비고 |
 | --- | --- | --- | --- | --- |
-| 1 | 에이전트 자동 기억/기록 | 📋 planned | [#5](https://github.com/minjun0219/coding-agent-toolkit/issues/5) | turn / session / 디스크 어느 층까지 영속할지 결정 필요 |
+| 1 | 에이전트 자동 기억/기록 | ✅ MVP | [#5](https://github.com/minjun0219/coding-agent-toolkit/issues/5) | `journal_append` / `journal_read` / `journal_search` / `journal_status`, `lib/agent-journal.ts` (append-only JSONL, 디스크 영속, 시간순 + page-key 기반 lookup) |
 | 2 | 상세 주석 | 🚧 부분 | [#7](https://github.com/minjun0219/coding-agent-toolkit/issues/7) | JSDoc 규칙 (`AGENTS.md`) 으로 정책은 박힘; 강제 / 검증은 미구현 |
 | 3 | 한글 주석/설명 | ✅ 정책 (검증 미구현) | [#7](https://github.com/minjun0219/coding-agent-toolkit/issues/7) | `AGENTS.md` coding rules + output 정책 |
 | 4 | Notion 캐싱 + TTL | ✅ MVP | — | `notion_get` / `notion_status` / `notion_refresh`, `lib/notion-context.ts` |
@@ -39,9 +39,10 @@
 - **Phase 2 — 스펙 → GitHub Issue / Project 동기화** *(memo #6, issue [#4](https://github.com/minjun0219/coding-agent-toolkit/issues/4))*
   - Rocky 의 spec 모드 출력을 그대로 issue 시리즈로 변환하는 skill / 도구
   - 매핑 후보: 한 Notion 페이지 = 한 epic, "TODO" 섹션의 bullet 1 개 = 한 issue
-- **Phase 3 — 에이전트 자동 기억 / 기록** *(memo #1, issue [#5](https://github.com/minjun0219/coding-agent-toolkit/issues/5))*
-  - turn 단위 결정 / blocker / 사용자 답변을 캐시 디렉터리 옆에 append-only 로 저장
-  - Rocky 가 "이전 turn 에 X 로 결정했음" 같은 기억을 인용 가능하게
+- **Phase 3 — 에이전트 자동 기억 / 기록 — 완료** *(memo #1, issue [#5](https://github.com/minjun0219/coding-agent-toolkit/issues/5))*
+  - `journal_append` / `journal_read` / `journal_search` / `journal_status` 4 도구 + `lib/agent-journal.ts` append-only JSONL (TTL 없음, 손상 라인 graceful skip)
+  - 시간순 + `kind` / `tag` / `pageId` / `since` 필터 + substring 검색
+  - Rocky 본문에 "read 먼저 → append 마지막" 인용 규칙 박힘 (`agents/rocky.md` Memory 절)
 - **Phase 4 — OpenAPI 캐시 + client 작성 — 완료** *(memo #7, issue [#6](https://github.com/minjun0219/coding-agent-toolkit/issues/6))*
   - `swagger_get` / `swagger_refresh` / `swagger_status` / `swagger_search` 4 도구 + `lib/openapi-context.ts` TTL 파일 캐시 + `skills/openapi-client/SKILL.md`
   - JSON-only (YAML 미지원), 단일 endpoint → `fetch` / `axios` snippet 한 덩어리
@@ -54,6 +55,6 @@
 
 ## 미정 / 결정 필요
 
-- memo #1 의 "기억" 이 얼마나 영속적이어야 하는지 (turn → session → 디스크).
+- memo #1 의 "기억" 영속 층은 디스크로 결정 (Phase 3 MVP). cross-machine 동기화 / 자연어 검색 / 자동 요약 / 압축은 후속 phase.
 - memo #6 의 GitHub 연동을 외부 MCP 로 위임할지 자체 도구로 만들지.
 - Rocky 의 책임이 어느 단계에서 분할되어야 하는지 — 현재는 단일 파트너; phase 가 늘면 sub-partner 분리(`linear`, `swagger` 등) 검토.

--- a/agents/rocky.md
+++ b/agents/rocky.md
@@ -1,6 +1,6 @@
 ---
 name: rocky
-description: Company-context work partner for the agent stack. Rocky carries the user's **company-specific knowledge** — specs, requirements, conventions, internal docs — and actively helps locate the right material when the question is vague. Notion is the starting source (more may join later). Any input that mentions a Notion URL, a Notion page id, or phrases like "스펙 정리해줘" / "요구사항 뽑아줘" / "Notion 페이지 X 가 Y 에 대해 뭐라고 하는지" / company-context lookups in general must route here. Wraps the `notion-context` skill and the `notion_get` / `notion_status` / `notion_refresh` tools — returns either cached markdown (context mode) or a Korean-language spec (spec mode). Generic primary agents (e.g. OmO Sisyphus) know OSS / patterns / libraries but not the user's company; delegate any company-context lookup to `@rocky`.
+description: Company-context work partner for the agent stack. Rocky carries the user's **company-specific knowledge** — specs, requirements, conventions, internal docs — and actively helps locate the right material when the question is vague. Notion is the starting source (more may join later). Any input that mentions a Notion URL, a Notion page id, or phrases like "스펙 정리해줘" / "요구사항 뽑아줘" / "Notion 페이지 X 가 Y 에 대해 뭐라고 하는지" / company-context lookups in general must route here. Wraps the `notion-context` skill and the `notion_get` / `notion_status` / `notion_refresh` tools — returns either cached markdown (context mode) or a Korean-language spec (spec mode). Also carries an append-only journal (`journal_append` / `journal_read` / `journal_search` / `journal_status`) so decisions, blockers, and user answers from earlier turns can be cited verbatim instead of rediscovered. Generic primary agents (e.g. OmO Sisyphus) know OSS / patterns / libraries but not the user's company; delegate any company-context lookup to `@rocky`.
 mode: all
 model: anthropic/claude-opus-4-7
 temperature: 0.2
@@ -36,6 +36,21 @@ Either way, the contract is the same: Rocky receives one Notion-shaped task, com
    - **Context mode** ("이 페이지 뭐라고 했지", "Notion X 의 Y", grounding-style asks) → return the markdown body, lightly summarized for long pages.
    - **Spec mode** ("스펙 정리", "요구사항 뽑아", "스펙 만들어") → produce the exact Korean output format defined in `skills/notion-context/SKILL.md` (문서 요약 / 요구사항 / 화면 단위 / API 의존성 / TODO / 확인 필요 사항).
 4. Return the result and stop. Do not propose follow-up implementation work, do not ask the user "다음 무엇을 도와드릴까요" — the caller decides what is next.
+
+## Memory (journal)
+
+Rocky owns a small append-only journal for "다음 turn 에 인용해야 할 사실" — decisions, blockers, user answers. The journal is a turn / cross-session memory layer; Notion remains the source of truth for company knowledge.
+
+1. **Read first, every turn.** At the start of a turn, before answering, call `journal_read` with `pageId` filter (when the request mentions a Notion page) — and additionally `kind: "decision"` / `"blocker"` when the request hints at "이전에 어떻게 정했지" / "왜 막혔지" 같은 회고 질문. If a relevant past entry exists, cite it inline ("이전 turn 에 X 로 결정했음 — `<id>`") and proceed.
+2. **Append on the way out.** When the current turn produces a decision, surfaces a new blocker, or captures a user answer that future turns will need, call `journal_append` once with:
+   - `kind`: `decision` / `blocker` / `answer` / `note`
+   - `content`: 한 줄 요약 (동사로 시작, 결정의 *결과*만)
+   - `tags`: 자유 — 보통 `["spec", "auth", …]`
+   - `pageId`: 해당 Notion 페이지를 다루고 있다면 그 id / URL — page-key 기반 lookup 의 키
+   Do not append for trivial back-and-forth or for facts already present in Notion.
+3. **Cite, don't re-derive.** If a past journal entry already answers the question, surface it (with `id` / `timestamp`) instead of re-deriving from Notion. Only call `notion_*` when the journal is empty / stale / contradicted by the user.
+4. **Use `journal_search`** for free-text recall ("auth 관련 결정 있었나"); use `journal_read` for time / page / kind / tag-shaped recall.
+5. **Do not** treat the journal as canonical for company facts — it stores *agent-side decisions about the work*, not the work itself. When journal and Notion disagree on a fact about the product, Notion wins; flag the conflict and ask.
 
 ## Failure modes
 

--- a/lib/agent-journal.test.ts
+++ b/lib/agent-journal.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { appendFileSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentJournal, JOURNAL_FILE } from "./agent-journal";
+
+const PAGE = "1234abcd1234abcd1234abcd1234abcd";
+const PAGE_DASHED = "1234abcd-1234-abcd-1234-abcd1234abcd";
+const OTHER_PAGE = "abcd1234abcd1234abcd1234abcd1234";
+const OTHER_PAGE_DASHED = "abcd1234-abcd-1234-abcd-1234abcd1234";
+
+let dir: string;
+let journal: AgentJournal;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agent-toolkit-journal-"));
+  journal = new AgentJournal({ baseDir: dir });
+});
+
+describe("AgentJournal.append", () => {
+  it("writes a JSONL line with normalized fields", async () => {
+    const entry = await journal.append({
+      content: "  decided to use Bun  ",
+      kind: "decision",
+      tags: [" notion ", "", "infra"],
+      pageId: PAGE,
+    });
+    expect(entry.content).toBe("decided to use Bun");
+    expect(entry.kind).toBe("decision");
+    expect(entry.tags).toEqual(["notion", "infra"]);
+    expect(entry.pageId).toBe(PAGE_DASHED);
+    expect(entry.id).toMatch(/^\d+-[0-9a-f]{6}$/);
+    expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("defaults kind to 'note' and tags to []", async () => {
+    const entry = await journal.append({ content: "blocker" });
+    expect(entry.kind).toBe("note");
+    expect(entry.tags).toEqual([]);
+    expect(entry.pageId).toBeUndefined();
+  });
+
+  it("rejects empty / whitespace content", async () => {
+    await expect(journal.append({ content: "" })).rejects.toThrow(/non-empty/i);
+    await expect(journal.append({ content: "   " })).rejects.toThrow(/non-empty/i);
+  });
+
+  it("rejects non-string pageId via resolveCacheKey", async () => {
+    await expect(
+      journal.append({ content: "x", pageId: "not-a-page" }),
+    ).rejects.toThrow(/Notion page id/);
+  });
+});
+
+describe("AgentJournal.read", () => {
+  it("returns most recent first up to limit (default 20)", async () => {
+    for (let i = 0; i < 25; i += 1) {
+      await journal.append({ content: `entry ${i}` });
+    }
+    const recent = await journal.read();
+    expect(recent.length).toBe(20);
+    expect(recent[0]?.content).toBe("entry 24");
+    expect(recent[19]?.content).toBe("entry 5");
+  });
+
+  it("filters by kind", async () => {
+    await journal.append({ content: "a", kind: "decision" });
+    await journal.append({ content: "b", kind: "blocker" });
+    await journal.append({ content: "c", kind: "decision" });
+    const r = await journal.read({ kind: "decision" });
+    expect(r.map((e) => e.content)).toEqual(["c", "a"]);
+  });
+
+  it("filters by tag (exact membership)", async () => {
+    await journal.append({ content: "a", tags: ["api", "review"] });
+    await journal.append({ content: "b", tags: ["review"] });
+    await journal.append({ content: "c", tags: ["api"] });
+    const r = await journal.read({ tag: "api" });
+    expect(r.map((e) => e.content)).toEqual(["c", "a"]);
+  });
+
+  it("filters by pageId after normalization", async () => {
+    await journal.append({ content: "a", pageId: PAGE });
+    await journal.append({ content: "b", pageId: OTHER_PAGE });
+    await journal.append({ content: "c", pageId: PAGE_DASHED });
+    // URL 형태로 줘도 같은 키로 묶여야.
+    const r = await journal.read({
+      pageId: `https://www.notion.so/team/Title-${PAGE}`,
+    });
+    expect(r.map((e) => e.content)).toEqual(["c", "a"]);
+    expect(r.every((e) => e.pageId === PAGE_DASHED)).toBe(true);
+  });
+
+  it("filters by since (strictly after)", async () => {
+    const a = await journal.append({ content: "before" });
+    // 1ms 차이는 시스템에 따라 동일 timestamp 가 나올 수 있어 명시적으로 sleep.
+    await new Promise((r) => setTimeout(r, 5));
+    const after = new Date().toISOString();
+    await new Promise((r) => setTimeout(r, 5));
+    await journal.append({ content: "after-1" });
+    await journal.append({ content: "after-2" });
+    const r = await journal.read({ since: after });
+    expect(r.map((e) => e.content)).toEqual(["after-2", "after-1"]);
+    expect(r.every((e) => e.id !== a.id)).toBe(true);
+  });
+
+  it("returns [] when journal does not exist yet", async () => {
+    expect(await journal.read()).toEqual([]);
+  });
+});
+
+describe("AgentJournal.search", () => {
+  beforeEach(async () => {
+    await journal.append({ content: "Decided to use Bun", kind: "decision" });
+    await journal.append({ content: "Blocked on auth", kind: "blocker" });
+    await journal.append({ content: "User confirmed PRD", kind: "answer", tags: ["prd"] });
+    await journal.append({ content: "linked page", pageId: PAGE });
+  });
+
+  it("matches content substring case-insensitively", async () => {
+    const r = await journal.search("BUN");
+    expect(r.length).toBe(1);
+    expect(r[0]?.content).toBe("Decided to use Bun");
+  });
+
+  it("matches by tag", async () => {
+    const r = await journal.search("prd");
+    expect(r.length).toBe(1);
+    expect(r[0]?.kind).toBe("answer");
+  });
+
+  it("matches by pageId substring", async () => {
+    const r = await journal.search(PAGE_DASHED.slice(0, 8));
+    expect(r.length).toBe(1);
+    expect(r[0]?.pageId).toBe(PAGE_DASHED);
+  });
+
+  it("kind filter scopes the pool before substring match", async () => {
+    const r = await journal.search("", { kind: "blocker" });
+    expect(r.length).toBe(1);
+    expect(r[0]?.content).toBe("Blocked on auth");
+  });
+
+  it("respects limit", async () => {
+    for (let i = 0; i < 30; i += 1) {
+      await journal.append({ content: `noise ${i}` });
+    }
+    const r = await journal.search("noise", { limit: 3 });
+    expect(r.length).toBe(3);
+  });
+});
+
+describe("AgentJournal.status", () => {
+  it("reports exists=false before any writes", async () => {
+    const s = await journal.status();
+    expect(s.exists).toBe(false);
+    expect(s.totalEntries).toBe(0);
+    expect(s.sizeBytes).toBe(0);
+    expect(s.lastEntryAt).toBeUndefined();
+  });
+
+  it("reports totalEntries / lastEntryAt after writes", async () => {
+    await journal.append({ content: "a" });
+    const last = await journal.append({ content: "b" });
+    const s = await journal.status();
+    expect(s.exists).toBe(true);
+    expect(s.totalEntries).toBe(2);
+    expect(s.sizeBytes).toBeGreaterThan(0);
+    expect(s.lastEntryAt).toBe(last.timestamp);
+  });
+});
+
+describe("graceful degradation", () => {
+  it("skips corrupt JSON lines but keeps valid ones", async () => {
+    await journal.append({ content: "first" });
+    appendFileSync(
+      join(dir, JOURNAL_FILE),
+      "{ this is not json\n",
+      "utf8",
+    );
+    await journal.append({ content: "second" });
+    const r = await journal.read();
+    expect(r.map((e) => e.content)).toEqual(["second", "first"]);
+  });
+
+  it("skips entries missing required fields", async () => {
+    await journal.append({ content: "valid" });
+    appendFileSync(
+      join(dir, JOURNAL_FILE),
+      `${JSON.stringify({ id: "x", timestamp: "now" })}\n`,
+      "utf8",
+    );
+    const r = await journal.read();
+    expect(r.map((e) => e.content)).toEqual(["valid"]);
+  });
+
+  it("tolerates a trailing partial line (no newline)", async () => {
+    await journal.append({ content: "first" });
+    appendFileSync(
+      join(dir, JOURNAL_FILE),
+      `${JSON.stringify({ id: "p", timestamp: "now", kind: "note", content: "partial" }).slice(0, 20)}`,
+      "utf8",
+    );
+    const r = await journal.read();
+    expect(r.map((e) => e.content)).toEqual(["first"]);
+  });
+
+  it("returns [] on entirely garbage file without throwing", async () => {
+    writeFileSync(join(dir, JOURNAL_FILE), "garbage\n}{also garbage\n", "utf8");
+    expect(await journal.read()).toEqual([]);
+    const s = await journal.status();
+    expect(s.exists).toBe(true);
+    expect(s.totalEntries).toBe(0);
+  });
+});

--- a/lib/agent-journal.test.ts
+++ b/lib/agent-journal.test.ts
@@ -45,7 +45,8 @@ describe("AgentJournal.append", () => {
     await expect(journal.append({ content: "   " })).rejects.toThrow(/non-empty/i);
   });
 
-  it("rejects non-string pageId via resolveCacheKey", async () => {
+  it("rejects an invalid pageId string via resolveCacheKey", async () => {
+    // 입력은 string 이지만 Notion page id 형식이 아닌 값 — resolveCacheKey 가 거부.
     await expect(
       journal.append({ content: "x", pageId: "not-a-page" }),
     ).rejects.toThrow(/Notion page id/);
@@ -203,6 +204,21 @@ describe("graceful degradation", () => {
     );
     const r = await journal.read();
     expect(r.map((e) => e.content)).toEqual(["first"]);
+  });
+
+  it("does not concatenate a new entry onto an unterminated last line (Codex P1)", async () => {
+    // 직전 프로세스가 mid-write 로 죽어 마지막 줄이 `\n` 없이 끝난 시뮬레이션.
+    appendFileSync(
+      join(dir, JOURNAL_FILE),
+      '{"id":"crashed","timestamp":"',
+      "utf8",
+    );
+    // 새 entry append — leading `\n` 으로 라인 경계가 강제되어야 새 항목이 살아남는다.
+    const fresh = await journal.append({ content: "after-restart" });
+    const r = await journal.read();
+    expect(r.length).toBe(1);
+    expect(r[0]?.id).toBe(fresh.id);
+    expect(r[0]?.content).toBe("after-restart");
   });
 
   it("returns [] on entirely garbage file without throwing", async () => {

--- a/lib/agent-journal.ts
+++ b/lib/agent-journal.ts
@@ -1,0 +1,340 @@
+import { appendFile, mkdir, readFile, stat } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { randomBytes } from "node:crypto";
+import { resolveCacheKey } from "./notion-context";
+
+/**
+ * Append-only 에이전트 저널.
+ *
+ * 한 turn 안에서 결정 / blocker / 사용자 답변 등 "다음 turn 에 인용하고 싶은 사실"
+ * 을 디스크에 한 줄(JSONL) 씩 쌓는다. 캐시처럼 정규화된 키 / TTL 모델을 쓰지 않는
+ * 이유는 — 캐시는 외부 source of truth 의 사본이지만, 저널은 그 자체가 source of
+ * truth 이기 때문이다. 따라서 만료 / 무효화 / 덮어쓰기 없음.
+ *
+ * 디스크 레이아웃:
+ *   <baseDir>/journal.jsonl   각 줄이 하나의 JournalEntry
+ *
+ * baseDir 기본값은 `~/.config/opencode/agent-toolkit/journal` — Notion / OpenAPI
+ * 캐시와 같은 부모 아래에 두되 디렉터리는 분리한다 (`AGENT_TOOLKIT_JOURNAL_DIR`).
+ *
+ * 동시 쓰기:
+ *   `appendFile` 는 POSIX 의 O_APPEND 로 동작해 한 줄(< PIPE_BUF) 단위 append 는
+ *   원자적이다. 정상적인 항목 크기에서는 race 가 라인 경계에서만 발생한다.
+ *   라인 단위 손상은 read 단계의 graceful skip 으로 흡수된다.
+ */
+
+/** 기본 저널 디렉터리 — `AGENT_TOOLKIT_JOURNAL_DIR` 로 덮어쓴다. */
+export const DEFAULT_JOURNAL_DIR = join(
+  homedir(),
+  ".config",
+  "opencode",
+  "agent-toolkit",
+  "journal",
+);
+
+/** 저널 파일 이름 — 한 디렉터리에 단일 파일을 둔다 (MVP). */
+export const JOURNAL_FILE = "journal.jsonl";
+
+/**
+ * 항목 종류. 저널은 자유 문자열을 허용하지만 흔한 4 가지를 권장 값으로 둔다.
+ * 호출자가 새 종류를 도입해도 read / search 가 자동으로 따라간다.
+ */
+export type JournalKind =
+  | "decision"
+  | "blocker"
+  | "answer"
+  | "note"
+  | (string & {});
+
+/**
+ * 저널 한 줄.
+ * - `id`: timestamp + 6 hex — 같은 ms 안에 두 번 append 해도 충돌 안 나게.
+ * - `timestamp`: append 시각 ISO8601 (UTC).
+ * - `pageId`: 옵셔널 Notion page id 연결고리. 입력은 URL/dash-less 모두 허용하되
+ *   디스크에는 정규화된 dash 형식(`8-4-4-4-12`)으로 저장 — page-key 기반 lookup 의 키.
+ */
+export interface JournalEntry {
+  id: string;
+  timestamp: string;
+  kind: JournalKind;
+  content: string;
+  tags: string[];
+  pageId?: string;
+}
+
+export interface JournalAppendInput {
+  content: string;
+  kind?: JournalKind;
+  tags?: string[];
+  pageId?: string;
+}
+
+/**
+ * read 필터. 모두 옵셔널 — 다 비우면 가장 최근 `limit` (기본 20) 개를 반환.
+ * `since` 는 ISO8601 또는 `Date.parse` 가 받아들이는 형식이면 된다 — 비교는 ms 단위.
+ */
+export interface JournalReadOptions {
+  limit?: number;
+  kind?: string;
+  tag?: string;
+  pageId?: string;
+  since?: string;
+}
+
+export interface JournalSearchOptions {
+  limit?: number;
+  kind?: string;
+}
+
+export interface JournalStatus {
+  path: string;
+  exists: boolean;
+  totalEntries: number;
+  sizeBytes: number;
+  lastEntryAt?: string;
+}
+
+export interface AgentJournalOptions {
+  baseDir?: string;
+}
+
+const DEFAULT_LIMIT = 20;
+
+/**
+ * 파일시스템 기반 append-only 저널.
+ *
+ * 외부에 노출되는 메서드는 append / read / search / status 4 가지.
+ * 모든 read 경로는 손상된 라인을 건너뛰고 graceful 하게 동작한다 — 부분 쓰기가
+ * 직전 turn 끝에 있어도 다음 turn 에서 나머지를 읽을 수 있다.
+ */
+export class AgentJournal {
+  private readonly dir: string;
+  private readonly file: string;
+
+  constructor(options: AgentJournalOptions = {}) {
+    this.dir = resolve(options.baseDir ?? DEFAULT_JOURNAL_DIR);
+    this.file = join(this.dir, JOURNAL_FILE);
+  }
+
+  getDir(): string {
+    return this.dir;
+  }
+
+  getPath(): string {
+    return this.file;
+  }
+
+  /**
+   * 저널에 한 줄 append.
+   *
+   * `content` 는 trim 후 비어 있으면 throw — 의미 없는 빈 줄 방지.
+   * `pageId` 가 들어오면 `resolveCacheKey` 로 정규화 후 저장 → 입력이 URL 이든
+   * dash-less hex 든 같은 키로 묶인다.
+   */
+  async append(input: JournalAppendInput): Promise<JournalEntry> {
+    if (!input || typeof input !== "object") {
+      throw new Error("AgentJournal.append: input must be an object");
+    }
+    const rawContent = typeof input.content === "string" ? input.content : "";
+    const content = rawContent.trim();
+    if (!content) {
+      throw new Error(
+        "AgentJournal.append: content must be a non-empty string after trim",
+      );
+    }
+    const kind =
+      typeof input.kind === "string" && input.kind.trim().length > 0
+        ? input.kind.trim()
+        : "note";
+    const tags = Array.isArray(input.tags)
+      ? input.tags
+          .filter((t): t is string => typeof t === "string")
+          .map((t) => t.trim())
+          .filter((t) => t.length > 0)
+      : [];
+    let pageId: string | undefined;
+    if (typeof input.pageId === "string" && input.pageId.trim().length > 0) {
+      pageId = resolveCacheKey(input.pageId).pageId;
+    }
+    const entry: JournalEntry = {
+      id: `${Date.now()}-${randomBytes(3).toString("hex")}`,
+      timestamp: new Date().toISOString(),
+      kind,
+      content,
+      tags,
+      ...(pageId ? { pageId } : {}),
+    };
+    await mkdir(this.dir, { recursive: true });
+    // 한 줄 = 한 entry. JSON 안에 줄바꿈이 들어가지 않도록 stringify default 를 쓴다.
+    await appendFile(this.file, `${JSON.stringify(entry)}\n`, "utf8");
+    return entry;
+  }
+
+  /**
+   * 가장 최근 항목부터 `limit` 개를 반환. 필터는 AND 결합.
+   *
+   * - `kind`: 정확 일치
+   * - `tag`: 태그 배열 안에 포함되어야 함 (정확 일치)
+   * - `pageId`: `resolveCacheKey` 로 정규화 후 정확 일치
+   * - `since`: 해당 시각 *이후* 항목만 (Date.parse 실패 시 필터 무시)
+   */
+  async read(options: JournalReadOptions = {}): Promise<JournalEntry[]> {
+    const all = await this.readAll();
+    let filtered: JournalEntry[] = all;
+    if (typeof options.kind === "string" && options.kind.length > 0) {
+      const k = options.kind;
+      filtered = filtered.filter((e) => e.kind === k);
+    }
+    if (typeof options.tag === "string" && options.tag.length > 0) {
+      const t = options.tag;
+      filtered = filtered.filter((e) => e.tags.includes(t));
+    }
+    if (typeof options.pageId === "string" && options.pageId.length > 0) {
+      const pid = resolveCacheKey(options.pageId).pageId;
+      filtered = filtered.filter((e) => e.pageId === pid);
+    }
+    if (typeof options.since === "string" && options.since.length > 0) {
+      const sinceMs = Date.parse(options.since);
+      if (Number.isFinite(sinceMs)) {
+        filtered = filtered.filter((e) => {
+          const ms = Date.parse(e.timestamp);
+          return Number.isFinite(ms) && ms > sinceMs;
+        });
+      }
+    }
+    // 가장 최근 항목이 앞에 오도록.
+    const reversed = [...filtered].reverse();
+    const cap = capOrDefault(options.limit);
+    return reversed.slice(0, cap);
+  }
+
+  /**
+   * substring 검색 (case-insensitive). 매칭 대상: `content` / `kind` / `tags` / `pageId`.
+   * 빈 query 는 전체 (kind 필터만 적용) 를 가장 최근부터 반환 — `read` 와 같은 동작.
+   */
+  async search(
+    query: string,
+    options: JournalSearchOptions = {},
+  ): Promise<JournalEntry[]> {
+    const all = await this.readAll();
+    const needle = (typeof query === "string" ? query : "").trim().toLowerCase();
+    let pool: JournalEntry[] = all;
+    if (typeof options.kind === "string" && options.kind.length > 0) {
+      const k = options.kind;
+      pool = pool.filter((e) => e.kind === k);
+    }
+    const matches =
+      needle.length === 0
+        ? pool
+        : pool.filter((e) => entryMatchesNeedle(e, needle));
+    const reversed = [...matches].reverse();
+    const cap = capOrDefault(options.limit);
+    return reversed.slice(0, cap);
+  }
+
+  /**
+   * 저널 메타 (파일 존재, 라인 수, 바이트 크기, 마지막 항목 시각).
+   * 디스크 IO 는 file stat + 전체 read — 항목 수가 폭증하면 최적화 대상이 되겠지만,
+   * MVP 의 사용 패턴(turn 단위 한두 줄 추가) 에서는 충분.
+   */
+  async status(): Promise<JournalStatus> {
+    if (!existsSync(this.file)) {
+      return { path: this.file, exists: false, totalEntries: 0, sizeBytes: 0 };
+    }
+    let sizeBytes = 0;
+    try {
+      const s = await stat(this.file);
+      sizeBytes = s.size;
+    } catch {
+      // stat 가 깨져도 read 자체는 시도 — 부분 정보라도 surface.
+    }
+    const all = await this.readAll();
+    const last = all[all.length - 1];
+    return {
+      path: this.file,
+      exists: true,
+      totalEntries: all.length,
+      sizeBytes,
+      lastEntryAt: last?.timestamp,
+    };
+  }
+
+  /**
+   * 모든 valid entry 를 append 순(시간 오름차순) 으로 반환.
+   * 손상 / 부분 쓰기 라인은 건너뛴다 — 호출자가 throw 를 받지 않게.
+   */
+  private async readAll(): Promise<JournalEntry[]> {
+    if (!existsSync(this.file)) return [];
+    let raw: string;
+    try {
+      raw = await readFile(this.file, "utf8");
+    } catch {
+      return [];
+    }
+    if (!raw) return [];
+    const out: JournalEntry[] = [];
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const entry = normalizeEntry(parsed);
+      if (entry) out.push(entry);
+    }
+    return out;
+  }
+}
+
+function capOrDefault(limit: unknown): number {
+  if (typeof limit !== "number") return DEFAULT_LIMIT;
+  if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT;
+  return Math.floor(limit);
+}
+
+function entryMatchesNeedle(entry: JournalEntry, needle: string): boolean {
+  if (entry.content.toLowerCase().includes(needle)) return true;
+  if (entry.kind.toLowerCase().includes(needle)) return true;
+  if (entry.pageId && entry.pageId.toLowerCase().includes(needle)) return true;
+  for (const t of entry.tags) {
+    if (t.toLowerCase().includes(needle)) return true;
+  }
+  return false;
+}
+
+/**
+ * raw JSON 한 줄을 JournalEntry 로 정규화. 필수 필드가 비어 있으면 null —
+ * read 단에서 그대로 skip 된다.
+ */
+function normalizeEntry(value: unknown): JournalEntry | null {
+  if (!value || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  if (typeof o.id !== "string" || o.id.length === 0) return null;
+  if (typeof o.timestamp !== "string" || o.timestamp.length === 0) return null;
+  if (typeof o.kind !== "string" || o.kind.length === 0) return null;
+  if (typeof o.content !== "string") return null;
+  const tags = Array.isArray(o.tags)
+    ? o.tags.filter((t): t is string => typeof t === "string")
+    : [];
+  const pageId =
+    typeof o.pageId === "string" && o.pageId.length > 0 ? o.pageId : undefined;
+  return {
+    id: o.id,
+    timestamp: o.timestamp,
+    kind: o.kind,
+    content: o.content,
+    tags,
+    ...(pageId ? { pageId } : {}),
+  };
+}
+
+/** env 변수에서 baseDir 을 읽어 인스턴스 생성. */
+export function createJournalFromEnv(): AgentJournal {
+  const baseDir = process.env.AGENT_TOOLKIT_JOURNAL_DIR;
+  return new AgentJournal({ baseDir });
+}

--- a/lib/agent-journal.ts
+++ b/lib/agent-journal.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, readFile, stat } from "node:fs/promises";
+import { appendFile, mkdir, open, readFile, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
@@ -20,9 +20,12 @@ import { resolveCacheKey } from "./notion-context";
  * 캐시와 같은 부모 아래에 두되 디렉터리는 분리한다 (`AGENT_TOOLKIT_JOURNAL_DIR`).
  *
  * 동시 쓰기:
- *   `appendFile` 는 POSIX 의 O_APPEND 로 동작해 한 줄(< PIPE_BUF) 단위 append 는
- *   원자적이다. 정상적인 항목 크기에서는 race 가 라인 경계에서만 발생한다.
- *   라인 단위 손상은 read 단계의 graceful skip 으로 흡수된다.
+ *   `appendFile` 는 append 모드로 기록하지만, 일반 파일에서 라인 단위 비-interleaving
+ *   이 항상 보장된다고 가정하지 않는다 — POSIX 의 보장 범위와 Node/Bun 의 내부 분할
+ *   동작이 다를 수 있다. 동시 append 시 레코드가 섞이거나 부분 줄이 관찰될 수 있고,
+ *   직전 프로세스가 mid-write 로 죽으면 마지막 줄이 `\n` 없이 끝날 수 있다. 그래서
+ *   append 단계에서 마지막 바이트를 peek 해 newline 이 아니면 leading `\n` 을 붙이고,
+ *   read 단계에서는 파싱되지 않는 줄을 graceful skip 으로 흡수한다.
  */
 
 /** 기본 저널 디렉터리 — `AGENT_TOOLKIT_JOURNAL_DIR` 로 덮어쓴다. */
@@ -91,6 +94,7 @@ export interface JournalSearchOptions {
 export interface JournalStatus {
   path: string;
   exists: boolean;
+  /** 파싱 / 정규화에 성공한 유효 항목 수. 손상된 라인은 카운트에 들어가지 않는다. */
   totalEntries: number;
   sizeBytes: number;
   lastEntryAt?: string;
@@ -168,8 +172,36 @@ export class AgentJournal {
     };
     await mkdir(this.dir, { recursive: true });
     // 한 줄 = 한 entry. JSON 안에 줄바꿈이 들어가지 않도록 stringify default 를 쓴다.
-    await appendFile(this.file, `${JSON.stringify(entry)}\n`, "utf8");
+    // 직전 프로세스가 appendFile 도중 죽어 마지막 줄이 `\n` 없이 끝나 있으면, 그 뒤에
+    // 새 entry 를 그대로 붙이면 두 줄이 하나로 합쳐져 둘 다 parse 실패로 손실된다.
+    // 마지막 바이트가 newline 이 아닐 때만 leading `\n` 을 붙여 새 entry 의 라인 경계
+    // 를 강제한다.
+    const prefix = (await this.endsWithNewline()) ? "" : "\n";
+    await appendFile(this.file, `${prefix}${JSON.stringify(entry)}\n`, "utf8");
     return entry;
+  }
+
+  /**
+   * 파일 끝 바이트가 `\n` 인지 한 바이트만 peek. 파일이 없거나 비어 있으면 true
+   * (leading `\n` 불필요). 읽기 실패는 best-effort 로 true 처리해 append 자체가
+   * 막히지 않도록 한다.
+   */
+  private async endsWithNewline(): Promise<boolean> {
+    if (!existsSync(this.file)) return true;
+    try {
+      const st = await stat(this.file);
+      if (st.size === 0) return true;
+      const fh = await open(this.file, "r");
+      try {
+        const buf = Buffer.alloc(1);
+        await fh.read(buf, 0, 1, st.size - 1);
+        return buf[0] === 0x0a;
+      } finally {
+        await fh.close();
+      }
+    } catch {
+      return true;
+    }
   }
 
   /**
@@ -183,25 +215,37 @@ export class AgentJournal {
   async read(options: JournalReadOptions = {}): Promise<JournalEntry[]> {
     const all = await this.readAll();
     let filtered: JournalEntry[] = all;
-    if (typeof options.kind === "string" && options.kind.length > 0) {
-      const k = options.kind;
-      filtered = filtered.filter((e) => e.kind === k);
+    // 모든 옵션은 append 단의 정규화(trim)와 같은 규칙으로 비교 — 사용자가 공백
+    // 섞인 입력을 넘겨도 매칭이 깨지지 않게.
+    if (typeof options.kind === "string") {
+      const k = options.kind.trim();
+      if (k.length > 0) {
+        filtered = filtered.filter((e) => e.kind === k);
+      }
     }
-    if (typeof options.tag === "string" && options.tag.length > 0) {
-      const t = options.tag;
-      filtered = filtered.filter((e) => e.tags.includes(t));
+    if (typeof options.tag === "string") {
+      const t = options.tag.trim();
+      if (t.length > 0) {
+        filtered = filtered.filter((e) => e.tags.includes(t));
+      }
     }
-    if (typeof options.pageId === "string" && options.pageId.length > 0) {
-      const pid = resolveCacheKey(options.pageId).pageId;
-      filtered = filtered.filter((e) => e.pageId === pid);
+    if (typeof options.pageId === "string") {
+      const rawPageId = options.pageId.trim();
+      if (rawPageId.length > 0) {
+        const pid = resolveCacheKey(rawPageId).pageId;
+        filtered = filtered.filter((e) => e.pageId === pid);
+      }
     }
-    if (typeof options.since === "string" && options.since.length > 0) {
-      const sinceMs = Date.parse(options.since);
-      if (Number.isFinite(sinceMs)) {
-        filtered = filtered.filter((e) => {
-          const ms = Date.parse(e.timestamp);
-          return Number.isFinite(ms) && ms > sinceMs;
-        });
+    if (typeof options.since === "string") {
+      const since = options.since.trim();
+      if (since.length > 0) {
+        const sinceMs = Date.parse(since);
+        if (Number.isFinite(sinceMs)) {
+          filtered = filtered.filter((e) => {
+            const ms = Date.parse(e.timestamp);
+            return Number.isFinite(ms) && ms > sinceMs;
+          });
+        }
       }
     }
     // 가장 최근 항목이 앞에 오도록.
@@ -221,9 +265,11 @@ export class AgentJournal {
     const all = await this.readAll();
     const needle = (typeof query === "string" ? query : "").trim().toLowerCase();
     let pool: JournalEntry[] = all;
-    if (typeof options.kind === "string" && options.kind.length > 0) {
-      const k = options.kind;
-      pool = pool.filter((e) => e.kind === k);
+    if (typeof options.kind === "string") {
+      const k = options.kind.trim();
+      if (k.length > 0) {
+        pool = pool.filter((e) => e.kind === k);
+      }
     }
     const matches =
       needle.length === 0
@@ -235,7 +281,10 @@ export class AgentJournal {
   }
 
   /**
-   * 저널 메타 (파일 존재, 라인 수, 바이트 크기, 마지막 항목 시각).
+   * 저널 메타 (파일 존재, 유효 항목 수, 바이트 크기, 마지막 항목 시각).
+   * `totalEntries` 는 파싱 / 정규화를 통과한 유효 entry 수만 센다 — 손상된 라인은
+   * read 단계에서 skip 되므로 카운트에서 빠진다. raw 라인 수가 필요해지면 별도
+   * 필드로 도입.
    * 디스크 IO 는 file stat + 전체 read — 항목 수가 폭증하면 최적화 대상이 되겠지만,
    * MVP 의 사용 패턴(turn 단위 한두 줄 추가) 에서는 충분.
    */
@@ -308,26 +357,43 @@ function entryMatchesNeedle(entry: JournalEntry, needle: string): boolean {
 }
 
 /**
- * raw JSON 한 줄을 JournalEntry 로 정규화. 필수 필드가 비어 있으면 null —
- * read 단에서 그대로 skip 된다.
+ * raw JSON 한 줄을 JournalEntry 로 정규화. 필수 필드가 비어 있거나 유효하지 않으면
+ * null — read 단에서 그대로 skip 된다.
+ *
+ * 손상 / 수동 편집 / 부분 쓰기 라인을 최대한 걸러내려고 append 단의 정규화와 같은
+ * 규칙으로 trim 후 비교한다: id / kind / content 는 trim 후 비어 있으면 reject,
+ * timestamp 는 Date.parse 가능해야 한다.
  */
 function normalizeEntry(value: unknown): JournalEntry | null {
   if (!value || typeof value !== "object") return null;
   const o = value as Record<string, unknown>;
-  if (typeof o.id !== "string" || o.id.length === 0) return null;
-  if (typeof o.timestamp !== "string" || o.timestamp.length === 0) return null;
-  if (typeof o.kind !== "string" || o.kind.length === 0) return null;
+  if (typeof o.id !== "string") return null;
+  if (typeof o.timestamp !== "string") return null;
+  if (typeof o.kind !== "string") return null;
   if (typeof o.content !== "string") return null;
+  const id = o.id.trim();
+  const timestamp = o.timestamp.trim();
+  const kind = o.kind.trim();
+  const content = o.content.trim();
+  if (id.length === 0) return null;
+  if (timestamp.length === 0 || Number.isNaN(Date.parse(timestamp))) return null;
+  if (kind.length === 0) return null;
+  if (content.length === 0) return null;
   const tags = Array.isArray(o.tags)
-    ? o.tags.filter((t): t is string => typeof t === "string")
+    ? o.tags
+        .filter((t): t is string => typeof t === "string")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0)
     : [];
   const pageId =
-    typeof o.pageId === "string" && o.pageId.length > 0 ? o.pageId : undefined;
+    typeof o.pageId === "string" && o.pageId.trim().length > 0
+      ? o.pageId.trim()
+      : undefined;
   return {
-    id: o.id,
-    timestamp: o.timestamp,
-    kind: o.kind,
-    content: o.content,
+    id,
+    timestamp,
+    kind,
+    content,
     tags,
     ...(pageId ? { pageId } : {}),
   };


### PR DESCRIPTION
## Summary

ROADMAP의 Phase 3 (memo #1, issue #5). 에이전트가 turn / session 경계를 넘어 결정 / blocker / 사용자 답변을 자동으로 기록하고 다음 turn 에 인용할 수 있게 한다.

- **`lib/agent-journal.ts`** — 단일 JSONL 파일 (`<journalDir>/journal.jsonl`) append-only 저널. 캐시와 달리 TTL / 무효화 / 덮어쓰기 없음 (저널 자체가 source of truth). `AgentJournal.append/read/search/status` 4 메서드. read 는 손상된 라인 / 부분 쓰기를 graceful 하게 skip. `pageId` 입력은 `resolveCacheKey` 로 정규화 후 저장 → page-key 기반 lookup 의 키.
- **plugin 도구 4 개** — `journal_append` / `journal_read` / `journal_search` / `journal_status`. handler 함수는 단위 테스트에서 직접 호출 가능하도록 export. 새 환경변수 `AGENT_TOOLKIT_JOURNAL_DIR` (기본 `~/.config/opencode/agent-toolkit/journal`).
- **Rocky 갱신** — description 에 journal 도구 노출, 본문에 Memory 절 추가 ("turn 시작 read first → turn 끝 append" 규칙, kind/pageId/tag 사용 가이드, Notion 우선 정책 — 저널은 *결정*의 기록이지 회사 사실의 기록이 아님).
- **README / INSTALL / AGENTS / ROADMAP** 동기화: 도구 수 8 → 12, 환경변수 표, layout, MVP scope, Phase 3 ✅.

## Acceptance criteria

- [x] turn 안에서 추가된 항목이 다음 turn 에서 읽힌다 (`agent-toolkit.test.ts` 의 새 인스턴스 read 케이스로 검증)
- [x] 손상 / 부분 쓰기에도 read 가 graceful degrade (`lib/agent-journal.test.ts` 의 graceful degradation 4 케이스)
- [x] `bun run typecheck` ✅
- [x] `bun test` ✅ (102 pass / 0 fail / 5 files)
- [x] 저널 디렉터리 layout / 환경변수 README 반영

## Test plan

- [x] `bun run typecheck` — 통과
- [x] `bun test` — 102 pass / 0 fail (lib/agent-journal: 21, plugin handlers: +5)
- [ ] 사용자 검증: opencode 에서 plugin 재로드 → `journal_append` / `journal_read` / `journal_search` / `journal_status` 도구가 보이는지, `@rocky` 가 "이전 turn 에 X 로 결정했음" 같은 인용을 생성하는지

## Out of scope (별도 PR)

cross-machine 동기화, 임베딩 / 자연어 검색, 자동 요약 / 압축 — ROADMAP 의 미정 항목으로 남겨 둔다.

https://claude.ai/code/session_016PP7dSVtVurJLWiyzMYJsd

---
_Generated by [Claude Code](https://claude.ai/code/session_016PP7dSVtVurJLWiyzMYJsd)_