### PR TITLE
chore: add obra/superpowers marketplace at project level

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "extraKnownMarketplaces": {
+    "superpowers-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers-marketplace"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "superpowers@superpowers-marketplace": true
+  }
+}


### PR DESCRIPTION
## Summary

- `.claude/settings.json` 추가 — Claude Code 세션이 이 repo에서 자동으로 `obra/superpowers-marketplace` 를 등록하고 `superpowers` plugin 을 활성화하도록 설정.
- `/plugin` 명령이 비활성화된 환경에서도 settings.json 만으로 marketplace + plugin 이 자동 로드됨 (`extraKnownMarketplaces` + `enabledPlugins` 사용).
- Toolkit 런타임은 여전히 opencode-only — 본 변경은 Claude Code 측 개발 보조 도구만 영향.

## Test plan

- [ ] 새 Claude Code 세션에서 이 브랜치 체크아웃 시 superpowers plugin 이 자동 로드되는지 확인
- [ ] 기존 opencode 동작에 영향 없음 (`bun test`, `bun run typecheck`) 확인
- [ ] 다른 plugin (`superpowers-dev`, `episodic-memory` 등) 추가 시 `enabledPlugins` 에 한 줄 추가만으로 동작하는지 확인

https://claude.ai/code/session_01WQa9eqfWBrXPVAo5EBYJEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQa9eqfWBrXPVAo5EBYJEq)_