### PR TITLE
Add minimal Codex (CLI/Desktop) plugin compatibility and local marketplace manifest

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "agent-toolkit-local",
+  "interface": {
+    "displayName": "Agent Toolkit Local"
+  },
+  "plugins": [
+    {
+      "name": "agent-toolkit",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin.md
+++ b/.codex-plugin.md
@@ -1,0 +1,23 @@
+# Codex plugin (experimental)
+
+이 저장소는 opencode plugin이 기본이지만, Codex CLI/데스크탑에서도 OpenAI 공식 플러그인 구조를 통해 최소 호환으로 쓸 수 있다.
+
+## 포함된 Codex 자산
+
+- `.codex-plugin/plugin.json` — Codex 플러그인 매니페스트
+- `.agents/plugins/marketplace.json` — 로컬 레포 마켓플레이스 예시
+- `skills/notion-context/SKILL.md` — 재사용 스킬
+- `.mcp.json` — MCP 서버 설정(context7)
+
+## Codex 데스크탑/CLI에서 쓰는 방법
+
+1. 이 레포를 로컬에 clone 한다.
+2. Codex에서 이 레포를 열거나, 마켓플레이스 파일을 읽을 수 있는 위치에 둔다.
+3. Codex를 재시작하고 플러그인 목록에서 `agent-toolkit`을 설치/활성화한다.
+4. 설치 후 스킬 목록에서 `notion-context`가 보이는지 확인한다.
+
+## 참고
+
+- 이 호환은 어디까지나 "최소" 지원이다.
+- opencode의 `config` 훅 동작(예: agents 경로 자동 주입)과 완전히 동일하지 않을 수 있다.
+- 필요하면 `agents/rocky.md`는 Codex의 subagent/지침 규칙에 맞춰 별도 연결한다.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "agent-toolkit",
+  "version": "0.1.0",
+  "description": "Notion cache-first toolkit with reusable skill for Codex.",
+  "author": {
+    "name": "agent-toolkit maintainers"
+  },
+  "license": "MIT",
+  "keywords": ["notion", "knowledge", "skill"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Agent Toolkit",
+    "shortDescription": "Notion cache-first context toolkit",
+    "longDescription": "Provides a Notion context skill and MCP server wiring for Codex environments.",
+    "developerName": "agent-toolkit maintainers",
+    "category": "Productivity"
+  }
+}

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -67,3 +67,11 @@ opencode 를 띄운 뒤:
 OmO 같이 자체 primary agent (Sisyphus 등) 를 쓰는 환경에선, primary 가 turn 시작 시 받는 subagent 목록에서 `rocky` 의 description 을 보고 Notion 관련 요청을 자동으로 위임한다 (보장은 안 됨 — primary 가 직접 처리하기로 결정할 수도 있음). Rocky 의 존재를 OmO 측 system prompt 에 박을 필요는 없다.
 
 plugin 이 미등록이거나 `agents.paths` 가 인식되지 않는 opencode 버전이면, 프로젝트의 `.opencode/agents/rocky.md` 로 직접 심볼릭 링크하거나 복사해서 쓴다.
+
+## Codex CLI/데스크탑 최소 호환 (선택)
+
+opencode 외 환경에서도 같은 Notion 컨텍스트 자산을 쓰고 싶다면, 문서 기반 최소 호환 가이드를 따른다.
+
+- [`.codex-plugin.md`](../.codex-plugin.md)
+
+참고: Codex에서는 `.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json` 조합으로 로컬 플러그인 설치 흐름을 사용할 수 있다. 단, opencode의 `config` 훅과 완전히 동일한 동작을 보장하진 않는다.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 └── README.md
 ```
 
-> 다른 host (Claude Code, Cursor, Codex CLI) 호환은 후속 작업 — 필요 시 Superpowers 처럼 `.claude-plugin/`, `.cursor-plugin/` 디렉터리를 추가하면 된다. 지금은 opencode 전용.
+> 다른 host 호환은 기본적으로 후속 작업이지만, **Codex CLI/데스크탑 최소 플러그인 호환**을 추가했다. 자세한 내용은 [`.codex-plugin.md`](./.codex-plugin.md), 매니페스트는 [`.codex-plugin/plugin.json`](./.codex-plugin/plugin.json) 참고.
 
 ## 설치 / 사용
 


### PR DESCRIPTION
### Motivation
- Provide a minimal compatibility layer so the repo's Notion cache-first toolkit can be installed/used from Codex CLI/Desktop environments in addition to opencode.
- Offer a local marketplace manifest to make the local plugin discoverable and installable by Codex via a marketplace-style file.

### Description
- Added a Codex plugin manifest at `.codex-plugin/plugin.json` describing the `agent-toolkit` plugin and its `skills`/`mcpServers` locations.
- Added `.codex-plugin.md` with instructions for using the repository as a minimal Codex-compatible plugin and pointers to included assets.
- Added a local marketplace entry at `.agents/plugins/marketplace.json` that exposes `agent-toolkit` as a `local` source and sets installation/authentication policy.
- Updated documentation in `README.md` and `.opencode/INSTALL.md` to document the optional Codex CLI/desktop compatibility and reference the new files.

### Testing
- No automated tests were added for these documentation and manifest changes and no automated test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f23c524483299f8f8c35fb01389f)