### PR TITLE
docs: REVIEW.md 추가 — Claude Code Code Review 리뷰 지침

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,46 @@
+# 리뷰 지침
+
+이 파일은 Claude Code Code Review 가 PR 을 검토할 때 따르는 최우선 규칙이다. `CLAUDE.md` / `AGENTS.md` 보다 우선한다. 모든 리뷰 코멘트는 한국어로 작성한다 — 코드 식별자 / 경로 / 명령어는 영어 그대로 둔다.
+
+## 코멘트 형식
+
+- summary 첫 줄에 한 줄 집계: `🔴 N 중요 / 🟡 M nit / 🟣 K 기존`. 중요 0 개면 "중요 이슈 없음" 으로 시작.
+- inline 코멘트는 `문제 / 영향 / 제안` 3 줄. 가능하면 적용 가능한 수정 예시를 함께.
+
+## 🔴 Important 의 정의 (이 repo 한정)
+
+아래만 Important 로 올린다. 나머지는 Nit 이하.
+
+- **MVP 스코프 위반**: `AGENTS.md` "MVP scope" 의 *Out* 을 들이는 변경 — YAML OpenAPI 파서, multi-spec merge, mock server, multi-host plugin layout, OAuth, Notion child page, 저널 TTL / 요약 / 임베딩, Rocky 의 직접 multi-step 구현 등.
+- **공개 contract 깨짐**: 12 개 plugin 도구 (`notion_*` / `swagger_*` / `journal_*`) 의 입력·출력 shape, agent (`rocky`) 라우팅, skill (`notion-context` / `openapi-client`) 의 사용 규칙.
+- **lockstep 드리프트**: `agent-toolkit.json` shape 가 바뀌었는데 `agent-toolkit.schema.json` 과 `lib/toolkit-config.ts` 가 둘 다 동기화되지 않은 경우.
+- **문서 동기화 누락**: 사용자 노출 표면 (도구 / 환경변수 / handle 형식) 이 바뀌었는데 `README.md` / `.opencode/INSTALL.md` 가 따라오지 않은 경우. 새 환경변수가 plugin `readEnv()` 에 추가되지 않은 경우. plugin 의 도구 contract 가 바뀌었는데 해당 skill / `agents/rocky.md` 가 갱신되지 않은 경우.
+- **런타임 안전 위반**: `__dirname` 사용 (ESM 금지 — `import.meta.url` / `import.meta.dir` 만), import 에 `.js` / `.ts` 확장자 부착, Bun 전용 런타임 가정을 깨는 Node 한정 API 도입.
+- **에러·보안**: 비밀값 / 토큰 / Notion 인증 흐름의 민감 정보 로깅, 에러 메시지에 컨텍스트 (입력값 / timeout / status / pageId mismatch 등) 누락, 외부 입력으로 만든 fs path 의 정규화 / sanitize 누락.
+- **journal 무결성**: append-only / corruption-tolerant 계약을 깨는 변경 (한 줄 깨졌다고 read 가 throw, 기존 라인 mutate, TTL 도입 등).
+- **의존성 추가**: `package.json` 에 새 runtime dep 이 들어왔는데 standard library / Bun built-in 으로 대체 가능하거나 정당화가 없는 경우.
+
+## 🟡 Nit (한 리뷰당 최대 5 개)
+
+스타일 / 네이밍 / 소소한 JSDoc 누락 / 테스트 파일 위치 (`*.test.ts` 가 소스 옆에 있어야 함) / fs 의존 테스트의 `mkdtempSync` 격리 누락 / 가독성 개선은 모두 Nit. inline 은 5 개까지만 달고, 나머지는 summary 끝에 `유사 항목 N 개 더` 로 집계만.
+
+## 보고하지 않는다
+
+- `bun.lock`, `node_modules/`, `dist/`, `*.tsbuildinfo`, `.env*` (gitignore 대상).
+- `bun run typecheck` / `bun test` 로 이미 잡히는 타입·테스트 실패 — CI 가 처리한다. 단, 새 lib 모듈에 인접 `*.test.ts` 자체가 빠진 경우는 Nit 으로 보고.
+- `ROADMAP.md` 의 phase 항목을 MVP 로 끌어들이는 PR 이 *명시적으로 그렇게 요청된* 경우, 스코프 확장 그 자체는 Important 가 아니다 (요청 범위 안의 변경).
+
+## 항상 확인
+
+- `AGENTS.md` "Change checklist" 6 개 항목과 PR 변경 표면이 일치하는가.
+- 새 export 함수 / 클래스에 JSDoc 이 붙었는가.
+- 에러 메시지에 식별 가능한 컨텍스트가 포함됐는가.
+- 사용자 노출 텍스트 (`README.md`, `.opencode/INSTALL.md`, `skills/*/SKILL.md`, `agents/rocky.md`) 가 변경된 도구 / 환경변수 / handle 형식과 일치하는가.
+
+## 인용 기준
+
+"이 코드가 X 한다" 류의 행동 단정은 추정이 아니라 `파일경로:라인` 인용으로 뒷받침한다. 네이밍에서 추론한 행동만으로 Important 를 올리지 않는다.
+
+## 재리뷰 수렴
+
+같은 PR 의 두 번째 리뷰부터는 새 Nit 을 올리지 않는다 — Important 와 새로 도입된 Pre-existing 만 올린다. 이전 리뷰에서 지적된 항목이 고쳐지면 thread 가 자동 resolve 된다는 점을 신뢰한다.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -26,7 +26,7 @@ Style, naming, minor JSDoc gaps, test-file location (`*.test.ts` must sit next t
 
 ## Do not report
 
-- gitignored files: `bun.lock`, `node_modules/`, `dist/`, `*.tsbuildinfo`, `.env*`.
+- Lockfiles and generated artifacts: `bun.lock`, plus anything matched by the repo's `.gitignore` (`node_modules/`, `dist/`, `*.tsbuildinfo`, `.env`, `.env.local`, …).
 - Type errors and test failures already caught by `bun run typecheck` / `bun test` — CI handles those. Exception: if a new module under `lib/` ships without an adjacent `*.test.ts`, report that as a Nit.
 - A PR that *was explicitly asked* to pull in a `ROADMAP.md` phase item is not, by that fact alone, an MVP-scope violation — the scope expansion is part of the request.
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,46 +1,46 @@
-# 리뷰 지침
+# Review instructions
 
-이 파일은 Claude Code Code Review 가 PR 을 검토할 때 따르는 최우선 규칙이다. `CLAUDE.md` / `AGENTS.md` 보다 우선한다. 모든 리뷰 코멘트는 한국어로 작성한다 — 코드 식별자 / 경로 / 명령어는 영어 그대로 둔다.
+This file is the highest-priority instruction block for Claude Code Code Review on this repo. It overrides `CLAUDE.md` and `AGENTS.md` where they conflict. Write every review comment in Korean — keep code identifiers, paths, and commands in English (see `AGENTS.md` "Output / communication").
 
-## 코멘트 형식
+## Comment format
 
-- summary 첫 줄에 한 줄 집계: `🔴 N 중요 / 🟡 M nit / 🟣 K 기존`. 중요 0 개면 "중요 이슈 없음" 으로 시작.
-- inline 코멘트는 `문제 / 영향 / 제안` 3 줄. 가능하면 적용 가능한 수정 예시를 함께.
+- Open the summary with a one-line tally: `🔴 N important / 🟡 M nit / 🟣 K pre-existing`. If there are zero important findings, lead with "중요 이슈 없음".
+- Each inline comment is three bullets: `문제 / 영향 / 제안`. Include a directly applicable fix snippet when possible.
 
-## 🔴 Important 의 정의 (이 repo 한정)
+## What 🔴 Important means here
 
-아래만 Important 로 올린다. 나머지는 Nit 이하.
+Reserve Important for the categories below. Everything else is Nit at most.
 
-- **MVP 스코프 위반**: `AGENTS.md` "MVP scope" 의 *Out* 을 들이는 변경 — YAML OpenAPI 파서, multi-spec merge, mock server, multi-host plugin layout, OAuth, Notion child page, 저널 TTL / 요약 / 임베딩, Rocky 의 직접 multi-step 구현 등.
-- **공개 contract 깨짐**: 12 개 plugin 도구 (`notion_*` / `swagger_*` / `journal_*`) 의 입력·출력 shape, agent (`rocky`) 라우팅, skill (`notion-context` / `openapi-client`) 의 사용 규칙.
-- **lockstep 드리프트**: `agent-toolkit.json` shape 가 바뀌었는데 `agent-toolkit.schema.json` 과 `lib/toolkit-config.ts` 가 둘 다 동기화되지 않은 경우.
-- **문서 동기화 누락**: 사용자 노출 표면 (도구 / 환경변수 / handle 형식) 이 바뀌었는데 `README.md` / `.opencode/INSTALL.md` 가 따라오지 않은 경우. 새 환경변수가 plugin `readEnv()` 에 추가되지 않은 경우. plugin 의 도구 contract 가 바뀌었는데 해당 skill / `agents/rocky.md` 가 갱신되지 않은 경우.
-- **런타임 안전 위반**: `__dirname` 사용 (ESM 금지 — `import.meta.url` / `import.meta.dir` 만), import 에 `.js` / `.ts` 확장자 부착, Bun 전용 런타임 가정을 깨는 Node 한정 API 도입.
-- **에러·보안**: 비밀값 / 토큰 / Notion 인증 흐름의 민감 정보 로깅, 에러 메시지에 컨텍스트 (입력값 / timeout / status / pageId mismatch 등) 누락, 외부 입력으로 만든 fs path 의 정규화 / sanitize 누락.
-- **journal 무결성**: append-only / corruption-tolerant 계약을 깨는 변경 (한 줄 깨졌다고 read 가 throw, 기존 라인 mutate, TTL 도입 등).
-- **의존성 추가**: `package.json` 에 새 runtime dep 이 들어왔는데 standard library / Bun built-in 으로 대체 가능하거나 정당화가 없는 경우.
+- **MVP scope violation**: a change that pulls in anything listed under *Out* in `AGENTS.md` "MVP scope" — YAML OpenAPI parsing, multi-spec merge, mock servers, multi-host plugin layouts, OAuth, Notion child pages, journal TTL / summarization / embeddings, Rocky running multi-step implementation directly, and so on.
+- **Public contract break**: input/output shape of any of the twelve plugin tools (`notion_*` / `swagger_*` / `journal_*`), `rocky` routing, or the usage rules of the two skills (`notion-context`, `openapi-client`).
+- **Lockstep drift**: `agent-toolkit.json` shape changed but `agent-toolkit.schema.json` and `lib/toolkit-config.ts` are not both updated in sync.
+- **Doc-sync miss**: a user-facing surface (tools / env vars / handle format) changed but `README.md` / `.opencode/INSTALL.md` did not follow; a new env var that was not added to the plugin's `readEnv()`; a plugin tool contract change without the matching update in the relevant skill or `agents/rocky.md`.
+- **Runtime safety violation**: `__dirname` (forbidden under ESM — use `import.meta.url` / `import.meta.dir`), `.js` / `.ts` extensions on imports, or any Node-only API that breaks the Bun-only runtime assumption.
+- **Errors and secrets**: secrets / tokens / Notion auth-flow data leaking into logs; error messages missing identifying context (input value, timeout, status code, pageId mismatch, …); fs paths built from external input without normalization / sanitization.
+- **Journal integrity**: any change that breaks the append-only / corruption-tolerant contract — read throwing on a malformed line, mutating existing lines, introducing TTL, etc.
+- **Dependency add**: a new runtime dep in `package.json` when the standard library or a Bun built-in would do, or an add without justification.
 
-## 🟡 Nit (한 리뷰당 최대 5 개)
+## 🟡 Nit (cap 5 per review)
 
-스타일 / 네이밍 / 소소한 JSDoc 누락 / 테스트 파일 위치 (`*.test.ts` 가 소스 옆에 있어야 함) / fs 의존 테스트의 `mkdtempSync` 격리 누락 / 가독성 개선은 모두 Nit. inline 은 5 개까지만 달고, 나머지는 summary 끝에 `유사 항목 N 개 더` 로 집계만.
+Style, naming, minor JSDoc gaps, test-file location (`*.test.ts` must sit next to the source it covers), missing `mkdtempSync` isolation in fs-touching tests, and small readability improvements are all Nit. Post at most five inline; collapse the rest into the summary as `유사 항목 N 개 더`.
 
-## 보고하지 않는다
+## Do not report
 
-- `bun.lock`, `node_modules/`, `dist/`, `*.tsbuildinfo`, `.env*` (gitignore 대상).
-- `bun run typecheck` / `bun test` 로 이미 잡히는 타입·테스트 실패 — CI 가 처리한다. 단, 새 lib 모듈에 인접 `*.test.ts` 자체가 빠진 경우는 Nit 으로 보고.
-- `ROADMAP.md` 의 phase 항목을 MVP 로 끌어들이는 PR 이 *명시적으로 그렇게 요청된* 경우, 스코프 확장 그 자체는 Important 가 아니다 (요청 범위 안의 변경).
+- gitignored files: `bun.lock`, `node_modules/`, `dist/`, `*.tsbuildinfo`, `.env*`.
+- Type errors and test failures already caught by `bun run typecheck` / `bun test` — CI handles those. Exception: if a new module under `lib/` ships without an adjacent `*.test.ts`, report that as a Nit.
+- A PR that *was explicitly asked* to pull in a `ROADMAP.md` phase item is not, by that fact alone, an MVP-scope violation — the scope expansion is part of the request.
 
-## 항상 확인
+## Always check
 
-- `AGENTS.md` "Change checklist" 6 개 항목과 PR 변경 표면이 일치하는가.
-- 새 export 함수 / 클래스에 JSDoc 이 붙었는가.
-- 에러 메시지에 식별 가능한 컨텍스트가 포함됐는가.
-- 사용자 노출 텍스트 (`README.md`, `.opencode/INSTALL.md`, `skills/*/SKILL.md`, `agents/rocky.md`) 가 변경된 도구 / 환경변수 / handle 형식과 일치하는가.
+- Each item in `AGENTS.md` "Change checklist" is satisfied for the surfaces this PR touches.
+- New exported functions / classes carry JSDoc.
+- Error messages include identifying context.
+- User-facing text (`README.md`, `.opencode/INSTALL.md`, `skills/*/SKILL.md`, `agents/rocky.md`) matches the changed tools / env vars / handle formats.
 
-## 인용 기준
+## Citation bar
 
-"이 코드가 X 한다" 류의 행동 단정은 추정이 아니라 `파일경로:라인` 인용으로 뒷받침한다. 네이밍에서 추론한 행동만으로 Important 를 올리지 않는다.
+Behavior claims ("this code does X") need a `path:line` citation in the source, not an inference from naming. Do not raise an Important finding from naming alone.
 
-## 재리뷰 수렴
+## Re-review convergence
 
-같은 PR 의 두 번째 리뷰부터는 새 Nit 을 올리지 않는다 — Important 와 새로 도입된 Pre-existing 만 올린다. 이전 리뷰에서 지적된 항목이 고쳐지면 thread 가 자동 resolve 된다는 점을 신뢰한다.
+From the second review of the same PR onward, do not post new Nits — only Important and any newly introduced Pre-existing findings. Trust that resolved threads from the previous review auto-close when the underlying code is fixed.


### PR DESCRIPTION
## 요약

Anthropic 관리형 Claude Code [Code Review](https://code.claude.com/docs/en/code-review#set-up-code-review) 가 PR 검토 시 system prompt 최우선 블록으로 읽는 `REVIEW.md` 를 repo 루트에 추가했다. 관리자 측 GitHub App 설치 / 리뷰 트리거 설정은 admin console 작업이므로 이 PR 의 범위 밖.

## REVIEW.md 가 정하는 것

- **언어**: 모든 리뷰 코멘트 한국어 (코드 식별자 / 경로 / 명령어는 영어). `AGENTS.md` "Output / communication" 정책 + 기존 `.github/copilot-instructions.md` 톤 계승.
- **🔴 Important 재정의** (이 repo 한정): MVP 스코프 위반, 12 개 plugin 도구 / `rocky` / 두 skill 의 공개 contract 깨짐, `agent-toolkit.json` schema ↔ `lib/toolkit-config.ts` lockstep 드리프트, 사용자 노출 표면 ↔ `README.md` / `INSTALL.md` / `readEnv()` 동기화 누락, ESM 안전 위반 (`__dirname` / `.js`·`.ts` import 확장자), 에러·민감 정보 누설, 저널 append-only / corruption-tolerant 계약 깨짐, 정당화 없는 dep 추가.
- **🟡 Nit**: 한 리뷰당 최대 5 개. 나머지는 summary 끝에 집계만.
- **skip**: gitignore 대상 (`bun.lock` / `dist/` / `.env*` …) + CI 가 처리하는 typecheck / 테스트 실패 (단, 새 lib 모듈에 인접 `*.test.ts` 누락은 Nit 으로 보고).
- **재리뷰 수렴**: 두 번째 리뷰부터 새 Nit 금지 — Important / 새로 도입된 Pre-existing 만.
- **인용 기준**: 행동 단정은 `파일경로:라인` 인용 필수, 네이밍 추론으로 Important 금지.

## 설계 메모

- doc 권고 ("Keep it focused") 따라 길이를 룰 본문에 한정.
- `CLAUDE.md` / `AGENTS.md` 는 손대지 않음 — 리뷰 전용 규칙은 `REVIEW.md` 로 격리해서 일반 Claude Code 세션에는 영향이 없게 한다.

## 테스트 플랜

- [x] `bun run typecheck` 통과
- [x] `bun test` 통과 (103/103)
- [ ] 머지 후 다음 PR 에서 Code Review 가 본 파일을 읽고 한국어·재정의된 severity·Nit cap 으로 동작하는지 확인 (관리자 측 GitHub App 활성화 전제)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qe2Pux3gEGMVePCZsHbDKa)_