### PR TITLE
docs(readme): 개인 프로젝트 / 유지보수 의무 없음 명시 + 요구사항 섹션

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Minjun Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 
 구조는 [obra/superpowers](https://github.com/obra/superpowers) 형식을 따른다 — 단일 plugin 파일이 `skills/` / `agents/` 디렉터리를 opencode 탐색 경로에 등록하고 도구를 노출한다. `rocky` 의 캐릭터/네이밍 컨벤션은 [code-yeongyu/oh-my-openagent (OmO)](https://github.com/code-yeongyu/oh-my-openagent) 의 named-specialist 패턴에서 빌렸지만, 책임은 agent-toolkit 1차 지휘 + 필요 시 외부 sub-agent / skill 위임 한 줄로 한정한다.
 
+> **개인 프로젝트입니다.** 자유롭게 가져다 쓰거나 fork 해도 되지만, 유지보수 / 이슈 응답 / 호환성 보장 의무는 없습니다. 자세한 내용은 아래 [Status / 라이선스](#status--라이선스) 참고.
+
+## 요구사항
+
+- [Bun](https://bun.sh) `>=1.0` (Node.js 미지원 — Bun 이 TS 를 직접 실행하므로 별도 빌드 단계가 없다)
+- [opencode](https://opencode.ai) (다른 host — Claude Code / Cursor / Codex CLI — 는 MVP scope 밖)
+- (선택) Notion 페이지를 다룰 경우 opencode 에 [Notion remote MCP](https://developers.notion.com/docs/mcp) 가 OAuth 로 연결되어 있어야 한다
+
 ## 디렉터리
 
 ```
@@ -187,3 +195,10 @@ bun run typecheck
 ## Roadmap
 
 MVP 너머의 능력 목표 (자동 기억, GitHub Issue 동기화, OpenAPI client 작성 등) 는 [`ROADMAP.md`](./ROADMAP.md) 참고. 한 번에 한 phase 씩 별도 PR 로.
+
+## Status / 라이선스
+
+- **개인 프로젝트** — 코드는 자유롭게 가져다 쓰거나 fork·수정·재배포해도 됩니다. 별도 `LICENSE` 파일은 두지 않으며, "as-is" 로 제공되고 어떤 종류의 보증(warranty) 도 하지 않습니다.
+- **유지보수 의무 없음** — 이슈 / PR / 호환성 / 보안 패치 / 외부 의존성(Notion API, opencode plugin API, Bun) 변경 추종을 약속하지 않습니다. 응답은 best-effort 이며, 운영에 의존할 계획이라면 fork 를 권장합니다.
+- 사용 중 발견한 문제는 [issue tracker](https://github.com/minjun0219/coding-agent-toolkit/issues) 로 남겨도 됩니다 — 다만 답변·수정 시점은 보장하지 않습니다.
+- 캐시 / 저널 데이터는 모두 **로컬 디스크에만** 저장됩니다 (`AGENT_TOOLKIT_*_DIR` 변수로 위치 변경 가능). Notion 페이지 본문이나 OpenAPI spec, 저널의 결정 / 사용자 답변이 외부로 송신되지 않으니 민감한 페이지를 다루기 전에 한 번 확인할 것.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 
 구조는 [obra/superpowers](https://github.com/obra/superpowers) 형식을 따른다 — 단일 plugin 파일이 `skills/` / `agents/` 디렉터리를 opencode 탐색 경로에 등록하고 도구를 노출한다. `rocky` 의 캐릭터/네이밍 컨벤션은 [code-yeongyu/oh-my-openagent (OmO)](https://github.com/code-yeongyu/oh-my-openagent) 의 named-specialist 패턴에서 빌렸지만, 책임은 agent-toolkit 1차 지휘 + 필요 시 외부 sub-agent / skill 위임 한 줄로 한정한다.
 
-> 개인 프로젝트라 유지보수가 꾸준하지 않을 수 있다. 자유롭게 가져다 쓰거나 fork 해도 되며, 라이선스는 [MIT](./LICENSE).
+> 개인 프로젝트라 유지보수가 꾸준하지 않을 수 있다.
 
 ## 요구사항
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ opencode 전용 plugin. Notion 페이지를 캐시 우선으로 읽는 도구 3 
 
 구조는 [obra/superpowers](https://github.com/obra/superpowers) 형식을 따른다 — 단일 plugin 파일이 `skills/` / `agents/` 디렉터리를 opencode 탐색 경로에 등록하고 도구를 노출한다. `rocky` 의 캐릭터/네이밍 컨벤션은 [code-yeongyu/oh-my-openagent (OmO)](https://github.com/code-yeongyu/oh-my-openagent) 의 named-specialist 패턴에서 빌렸지만, 책임은 agent-toolkit 1차 지휘 + 필요 시 외부 sub-agent / skill 위임 한 줄로 한정한다.
 
-> **개인 프로젝트입니다.** 자유롭게 가져다 쓰거나 fork 해도 되지만, 유지보수 / 이슈 응답 / 호환성 보장 의무는 없습니다. 자세한 내용은 아래 [Status / 라이선스](#status--라이선스) 참고.
+> 개인 프로젝트라 유지보수가 꾸준하지 않을 수 있다. 자유롭게 가져다 쓰거나 fork 해도 되며, 라이선스는 [MIT](./LICENSE).
 
 ## 요구사항
 
@@ -195,10 +195,3 @@ bun run typecheck
 ## Roadmap
 
 MVP 너머의 능력 목표 (자동 기억, GitHub Issue 동기화, OpenAPI client 작성 등) 는 [`ROADMAP.md`](./ROADMAP.md) 참고. 한 번에 한 phase 씩 별도 PR 로.
-
-## Status / 라이선스
-
-- **라이선스** — [MIT](./LICENSE). 사용 / 수정 / 재배포 / 상업적 이용 모두 자유, 단 copyright + 라이선스 고지를 함께 담아야 한다. 보증(warranty) 은 제공하지 않으며 "AS IS" 로 배포된다.
-- **개인 프로젝트 — 유지보수 의무 없음** — 이슈 / PR / 호환성 / 보안 패치 / 외부 의존성(Notion API, opencode plugin API, Bun) 변경 추종을 약속하지 않습니다. 응답은 best-effort 이며, 운영에 의존할 계획이라면 fork 를 권장합니다.
-- 사용 중 발견한 문제는 [issue tracker](https://github.com/minjun0219/coding-agent-toolkit/issues) 로 남겨도 됩니다 — 다만 답변·수정 시점은 보장하지 않습니다.
-- 캐시 / 저널 데이터는 모두 **로컬 디스크에만** 저장됩니다 (`AGENT_TOOLKIT_*_DIR` 변수로 위치 변경 가능). Notion 페이지 본문이나 OpenAPI spec, 저널의 결정 / 사용자 답변이 외부로 송신되지 않으니 민감한 페이지를 다루기 전에 한 번 확인할 것.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ MVP 너머의 능력 목표 (자동 기억, GitHub Issue 동기화, OpenAPI clie
 
 ## Status / 라이선스
 
-- **개인 프로젝트** — 코드는 자유롭게 가져다 쓰거나 fork·수정·재배포해도 됩니다. 별도 `LICENSE` 파일은 두지 않으며, "as-is" 로 제공되고 어떤 종류의 보증(warranty) 도 하지 않습니다.
-- **유지보수 의무 없음** — 이슈 / PR / 호환성 / 보안 패치 / 외부 의존성(Notion API, opencode plugin API, Bun) 변경 추종을 약속하지 않습니다. 응답은 best-effort 이며, 운영에 의존할 계획이라면 fork 를 권장합니다.
+- **라이선스** — [MIT](./LICENSE). 사용 / 수정 / 재배포 / 상업적 이용 모두 자유, 단 copyright + 라이선스 고지를 함께 담아야 한다. 보증(warranty) 은 제공하지 않으며 "AS IS" 로 배포된다.
+- **개인 프로젝트 — 유지보수 의무 없음** — 이슈 / PR / 호환성 / 보안 패치 / 외부 의존성(Notion API, opencode plugin API, Bun) 변경 추종을 약속하지 않습니다. 응답은 best-effort 이며, 운영에 의존할 계획이라면 fork 를 권장합니다.
 - 사용 중 발견한 문제는 [issue tracker](https://github.com/minjun0219/coding-agent-toolkit/issues) 로 남겨도 됩니다 — 다만 답변·수정 시점은 보장하지 않습니다.
 - 캐시 / 저널 데이터는 모두 **로컬 디스크에만** 저장됩니다 (`AGENT_TOOLKIT_*_DIR` 변수로 위치 변경 가능). Notion 페이지 본문이나 OpenAPI spec, 저널의 결정 / 사용자 답변이 외부로 송신되지 않으니 민감한 페이지를 다루기 전에 한 번 확인할 것.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "agent-toolkit",
   "version": "0.1.0",
   "description": "opencode plugin: Notion page cache + skill (Bun)",
+  "license": "MIT",
+  "author": "Minjun Kim",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
## 요약

- 개인 프로젝트라는 점, 자유롭게 가져다 써도 되지만 유지보수 / 호환성 / 이슈 응답 의무가 없다는 점을 README 에 명시.
- 함께 보강할 만한 부분을 한 번 더 훑어 **요구사항** 섹션 (Bun >=1.0, opencode, 옵션 Notion remote MCP) 을 추가.

## 변경 내용

1. **상단 callout** — 첫 두 단락 직후에 "개인 프로젝트입니다. 자유롭게 사용 OK, 유지보수 의무 없음" 한 줄 안내 (`Status / 라이선스` 앵커로 점프).
2. **`## 요구사항` 섹션 신설** — 설치 시도 전에 사용자가 가장 먼저 알아야 하는 전제 (Bun, opencode, Notion remote MCP) 를 디렉터리 트리 위에 명시.
3. **`## Status / 라이선스` 섹션 신설** — 문서 끝에 다음 4 줄 추가:
   - 자유 사용 / fork / 수정 / 재배포 OK, `LICENSE` 파일 없음, "as-is" 보증 없음
   - 유지보수 / 보안 패치 / 외부 의존성 추종 의무 없음, best-effort 응답
   - 이슈 트래커 활용은 환영하나 답변 / 수정 시점 보장 없음
   - 캐시 / 저널 데이터는 **로컬 디스크에만** 저장된다는 사실 환기 (민감 페이지 다루기 전 확인용)

기능 / 도구 surface 에는 변화 없음 — 문서 변경뿐.

## 검증

- [x] `bun install`
- [x] `bun run typecheck` 통과
- [x] `bun test` 통과 (103 pass / 0 fail)

https://claude.ai/code/session_017ra9TcdtrzY2nUq2TZMwAk

---
_Generated by [Claude Code](https://claude.ai/code/session_017ra9TcdtrzY2nUq2TZMwAk)_