### PR TITLE
ci: GitHub Actions 워크플로 추가 (typecheck + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
         run: bun run typecheck
 
       - name: Test
-        run: bun test
+        run: bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: typecheck + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test


### PR DESCRIPTION
## 요약

- GitHub Actions 워크플로 (`.github/workflows/ci.yml`) 추가 — `pull_request` / `main` push 시 `bun run typecheck` + `bun test` 자동 실행.
- 그동안 CI 가 없어서 PR 의 typecheck / test 결과를 수동으로만 확인했던 상태를 해소.

## 구성

```yaml
name: CI
on:
  pull_request:
  push:
    branches: [main]
permissions:
  contents: read
jobs:
  check:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: oven-sh/setup-bun@v2
        with:
          bun-version: latest
      - run: bun install --frozen-lockfile
      - run: bun run typecheck
      - run: bun test
```

- **runner**: `ubuntu-latest`
- **Bun**: `latest` (오픈소스 / 개인 프로젝트 단계라 단일 버전이면 충분 — 호환성 매트릭스 필요해지면 `engines.bun: >=1.0.0` 의 lower bound 와 latest 로 매트릭스 추가)
- **권한**: `contents: read` 만 (워크플로가 read-only 라 명시적으로 좁힘)
- **lockfile 일관성**: `bun install --frozen-lockfile` 로 `bun.lock` drift 가 PR 단계에서 잡힘

## #7 (lint 단 검증) 와의 관계

이슈 [#7](https://github.com/minjun0219/coding-agent-toolkit/issues/7) 본문에 *"CI 흐름에 추가 (현재 CI 없음 — 별도 issue 후보)"* 라고 박혀 있던 인프라 갭을 이 PR 이 해소합니다. lint 자체 (Biome / 자체 스크립트) 는 #7 에서 결정 후, 본 워크플로에 `bun run lint` 같은 step 한 줄 추가하는 형태로 확장 예정.

## 검증

- [x] 로컬 `bun install --frozen-lockfile`
- [x] 로컬 `bun run typecheck` 통과
- [x] 로컬 `bun test` 통과 (103 pass / 0 fail)
- [ ] PR 생성 후 GitHub Actions 첫 실행 결과 (이 PR 이 머지되기 전 자체 실행이 그대로 검증)

https://claude.ai/code/session_017ra9TcdtrzY2nUq2TZMwAk

---
_Generated by [Claude Code](https://claude.ai/code/session_017ra9TcdtrzY2nUq2TZMwAk)_