### PR TITLE
feat(lint): JSDoc + 한글 주석 정책 lint 단 검증 (#7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check:
-    name: typecheck + test
+    name: typecheck + test + lint:comments
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,3 +27,6 @@ jobs:
 
       - name: Test
         run: bun run test
+
+      - name: Lint comments (JSDoc + 한글 정책)
+        run: bun run lint:comments

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -180,6 +180,7 @@ export async function handleNotionGet(
   return fetchAndCache(cache, input);
 }
 
+/** 도구 핸들러: 캐시 무시하고 항상 remote 다시 가져와 갱신. */
 export async function handleNotionRefresh(
   cache: NotionCache,
   input: string,
@@ -187,6 +188,7 @@ export async function handleNotionRefresh(
   return fetchAndCache(cache, input);
 }
 
+/** 도구 핸들러: 캐시 메타 + 만료 여부 조회. remote 호출 없음. */
 export async function handleNotionStatus(
   cache: NotionCache,
   input: string,
@@ -307,6 +309,7 @@ export async function handleSwaggerGet(
   return fetchAndCacheSpec(cache, url);
 }
 
+/** 도구 핸들러: 캐시 무시하고 spec 을 다시 다운로드해 덮어쓴다. */
 export async function handleSwaggerRefresh(
   cache: OpenapiCache,
   input: string,
@@ -316,6 +319,7 @@ export async function handleSwaggerRefresh(
   return fetchAndCacheSpec(cache, url);
 }
 
+/** 도구 핸들러: 캐시된 spec 의 메타 + 만료 여부 조회. remote 호출 없음. */
 export async function handleSwaggerStatus(
   cache: OpenapiCache,
   input: string,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ opencode-only plugin. Three Notion cache tools + five OpenAPI tools (cache, sear
 - `lib/toolkit-config.ts` — `agent-toolkit.json` loader (project `./.opencode/agent-toolkit.json` overrides user `~/.config/opencode/agent-toolkit/agent-toolkit.json`) with runtime shape validation.
 - `lib/agent-journal.ts` — append-only JSONL agent journal (decisions / blockers / answers / notes). No TTL; corruption-tolerant on read.
 - `agent-toolkit.schema.json` — JSON Schema for `agent-toolkit.json` (IDE autocomplete; runtime validation lives in `toolkit-config.ts`).
+- `lib/check-comments.ts` — JSDoc 누락 / 한글 주석 부재를 잡아내는 lint-단 검증기 (단위 테스트는 `check-comments.test.ts`, 통합 테스트는 `check-comments.integration.test.ts` 가 repo 전체를 훑는다).
+- `tools/check-comments.ts` — `bun run lint:comments` 진입점. `lib/check-comments.ts` 의 `checkSource` 를 `lib/`, `.opencode/plugins/`, `tools/` 의 모든 `*.ts` 에 적용하고 위반 시 exit 1.
 - `skills/notion-context/SKILL.md` — Notion cache-first read + Korean-language spec extraction skill.
 - `skills/openapi-client/SKILL.md` — cached OpenAPI spec → `fetch` or `axios` call snippet skill.
 - `skills/spec-pact/SKILL.md` — SPEC-합의 lifecycle (DRAFT / VERIFY / DRIFT-CHECK / AMEND) on top of an LLM-wiki-inspired entry point at `<spec.dir>/<spec.indexFile>` (default `.agent/specs/INDEX.md`) and per-page SPEC files at `<spec.dir>/<slug>.md` (default `.agent/specs/<slug>.md`, slug 모드) or `**/SPEC.md` (directory 모드). Conducted exclusively by `agents/grace.md`.
@@ -26,8 +28,9 @@ opencode-only plugin. Three Notion cache tools + five OpenAPI tools (cache, sear
 
 ```bash
 bun install
-bun test           # unit tests under lib/ + .opencode/plugins/
-bun run typecheck  # tsc --noEmit
+bun test                # unit tests under lib/ + .opencode/plugins/
+bun run typecheck       # tsc --noEmit
+bun run lint:comments   # JSDoc + 한글 주석 정책 검증 (tools/check-comments.ts)
 ```
 
 Only `AGENT_TOOLKIT_NOTION_MCP_URL` is required. See the README env-var table for the optional ones.
@@ -53,7 +56,7 @@ The longer-term capability targets (auto memory, GitHub-issue tracking, OpenAPI 
 ## Change checklist
 
 1. `bun run typecheck` passes
-2. `bun test` passes
+2. `bun test` passes (통합 테스트 `lib/check-comments.integration.test.ts` 가 한글 주석 / JSDoc 정책을 자동으로 검증한다 — 별도로 `bun run lint:comments` 로도 호출 가능)
 3. If the user-facing surface (tools / env vars) changes, sync `README.md` and `.opencode/INSTALL.md`
 4. If a new env var is added, also update the plugin's `readEnv()`
 5. If the plugin's tool contract changes, update the tool-usage rules in the relevant skill (`skills/notion-context/SKILL.md` for `notion_*`, `skills/openapi-client/SKILL.md` for `swagger_*`, `skills/spec-pact/SKILL.md` for the lifecycle modes that touch `notion_*` / `journal_*` / file IO) **and** the corresponding routing / tool rules in `agents/rocky.md` (Rocky conducts the two cache-first skills + journal and routes the lifecycle, so changes on either side propagate to it; `journal_*` is owned by `rocky` directly — no separate skill) **and** `agents/grace.md` (Grace conducts `spec-pact` end-to-end and is the single finalize/lock authority over `.agent/specs/INDEX.md` + SPEC files)

--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ apps/web/orders/
 
 ```bash
 bun install
-bun test          # lib/ + .opencode/plugins/ 단위 테스트
+bun test               # lib/ + .opencode/plugins/ 단위 + 통합 테스트
 bun run typecheck
+bun run lint:comments  # JSDoc + 한글 주석 정책 검증 (tools/check-comments.ts)
 ```
 
 ## Roadmap

--- a/lib/check-comments.integration.test.ts
+++ b/lib/check-comments.integration.test.ts
@@ -2,19 +2,24 @@ import { test, expect } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { checkSource, type Violation } from "./check-comments";
+import {
+  COMMENT_LINT_TARGET_DIRS,
+  checkSource,
+  type Violation,
+} from "./check-comments";
 
 /**
  * 통합 테스트: repo 의 검사 대상 디렉터리에 있는 `.ts` 파일이 전부 통과해야 한다.
  *
  * 단위 테스트 (`check-comments.test.ts`) 가 규칙 자체의 정확성을 보증한다면, 이
  * 테스트는 "기존 코드는 정책 위반 없이 통과" 를 회귀 테스트 단에서 강제한다 —
- * `bun test` 만 돌려도 lint 가 자동으로 따라온다.
+ * `bun test` 만 돌려도 lint 가 자동으로 따라온다. 검사 대상 디렉터리 목록은
+ * CLI 와 같은 `COMMENT_LINT_TARGET_DIRS` 를 import 해 두 진입점이 갈라지지
+ * 않도록 한다.
  */
 
 const SELF_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SELF_DIR, "..");
-const TARGET_DIRS = ["lib", ".opencode/plugins", "tools"];
 
 function collectTsFiles(dir: string, out: string[] = []): string[] {
   let entries;
@@ -37,7 +42,7 @@ function collectTsFiles(dir: string, out: string[] = []): string[] {
 
 test("repo 의 모든 검사 대상 .ts 파일이 코드 주석 정책을 통과한다", () => {
   const files: string[] = [];
-  for (const d of TARGET_DIRS) {
+  for (const d of COMMENT_LINT_TARGET_DIRS) {
     collectTsFiles(resolve(ROOT, d), files);
   }
   files.sort();

--- a/lib/check-comments.integration.test.ts
+++ b/lib/check-comments.integration.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { checkSource, type Violation } from "./check-comments";
+
+/**
+ * 통합 테스트: repo 의 검사 대상 디렉터리에 있는 `.ts` 파일이 전부 통과해야 한다.
+ *
+ * 단위 테스트 (`check-comments.test.ts`) 가 규칙 자체의 정확성을 보증한다면, 이
+ * 테스트는 "기존 코드는 정책 위반 없이 통과" 를 회귀 테스트 단에서 강제한다 —
+ * `bun test` 만 돌려도 lint 가 자동으로 따라온다.
+ */
+
+const SELF_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SELF_DIR, "..");
+const TARGET_DIRS = ["lib", ".opencode/plugins", "tools"];
+
+function collectTsFiles(dir: string, out: string[] = []): string[] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const name = entry.name as string;
+    const full = join(dir, name);
+    if (entry.isDirectory()) {
+      collectTsFiles(full, out);
+    } else if (entry.isFile() && name.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test("repo 의 모든 검사 대상 .ts 파일이 코드 주석 정책을 통과한다", () => {
+  const files: string[] = [];
+  for (const d of TARGET_DIRS) {
+    collectTsFiles(resolve(ROOT, d), files);
+  }
+  files.sort();
+  expect(files.length).toBeGreaterThan(0);
+
+  const violations: Violation[] = [];
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    violations.push(...checkSource(relative(ROOT, file), source));
+  }
+  // 실패 시 어떤 파일/라인이 잘못됐는지 메시지에 노출되도록.
+  expect(
+    violations.map(
+      (v) => `${v.file}:${v.line}: [${v.rule}] ${v.message}`,
+    ),
+  ).toEqual([]);
+});

--- a/lib/check-comments.test.ts
+++ b/lib/check-comments.test.ts
@@ -135,6 +135,66 @@ describe("checkSource — hangul-required", () => {
   });
 });
 
+describe("checkSource — URL-only 주석 면제", () => {
+  test("URL 만 있는 // 주석은 통과", () => {
+    const cases = [
+      `// https://developer.mozilla.org/en-US/docs/Web\n`,
+      `// http://example.com/foo/bar\n`,
+      `// 참고 https://x.test\n`,
+      `// ftp://files.example.com/spec.json\n`,
+    ];
+    for (const c of cases) {
+      const v = checkSource("a.ts", `${c}const x = 1;\n`);
+      expect(v.filter((x) => x.rule === "hangul-required")).toHaveLength(0);
+    }
+  });
+
+  test("URL + 영어 prose 가 섞이면 여전히 위반", () => {
+    const src = `// see https://example.com/foo for details\nconst x = 1;\n`;
+    const v = checkSource("a.ts", src);
+    expect(v.some((x) => x.rule === "hangul-required")).toBe(true);
+  });
+
+  test("URL + 한글 설명이 섞이면 통과", () => {
+    const src = `// 참고 자료: https://example.com/foo\nconst x = 1;\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+});
+
+describe("checkSource — template expression 안의 주석", () => {
+  test("`${ ... /* english only */ ... }` 안의 영어 전용 주석도 잡아낸다", () => {
+    const src =
+      "const fn = (_x: number) => 1;\n" +
+      "const x = `${fn(/* english only here */ 1)}`;\n";
+    const v = checkSource("a.ts", src);
+    expect(v.some((x) => x.rule === "hangul-required")).toBe(true);
+    const hit = v.find((x) => x.rule === "hangul-required");
+    expect(hit?.line).toBe(2);
+  });
+
+  test("`${ ... // english only }` single-line 도 잡아낸다", () => {
+    const src =
+      "const x = `prefix ${(() => {\n" +
+      "  // english only inside template expression\n" +
+      "  return 1;\n" +
+      "})()}`;\n";
+    const v = checkSource("a.ts", src);
+    expect(v.some((x) => x.rule === "hangul-required" && x.line === 2)).toBe(true);
+  });
+
+  test("template expression 안에서도 한글이 있으면 통과", () => {
+    const src =
+      "const fn = (_x: number) => 1;\n" +
+      "const x = `${fn(/* 한글 주석 */ 1)}`;\n";
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+
+  test("template literal 본문 (substitution 밖) 의 영어 단어는 검출 대상이 아니다", () => {
+    const src = "const x = `http://${host}:${port}`;\n";
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+});
+
 describe("checkSource — 위치 / 보고", () => {
   test("위반 line 은 1-based", () => {
     const src = `\n\nexport function f() {}\n`;

--- a/lib/check-comments.test.ts
+++ b/lib/check-comments.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { checkSource } from "./check-comments";
+
+describe("checkSource — jsdoc-missing", () => {
+  test("export function 직전에 JSDoc 이 없으면 위반", () => {
+    const src = `export function foo(): number {\n  return 1;\n}\n`;
+    const v = checkSource("a.ts", src);
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("jsdoc-missing");
+    expect(v[0]?.line).toBe(1);
+    expect(v[0]?.message).toContain("foo");
+  });
+
+  test("export function 위에 JSDoc 이 있으면 통과", () => {
+    const src =
+      `/** 더할 나위 없는 함수. */\nexport function foo(): number {\n  return 1;\n}\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+
+  test("export async function / export class 도 동일하게 본다", () => {
+    const src =
+      `export async function bar(): Promise<void> {}\n` +
+      `export class Baz {}\n`;
+    const v = checkSource("a.ts", src);
+    expect(v).toHaveLength(2);
+    expect(v.map((x) => x.rule)).toEqual([
+      "jsdoc-missing",
+      "jsdoc-missing",
+    ]);
+    expect(v[0]?.message).toContain("bar");
+    expect(v[1]?.message).toContain("Baz");
+  });
+
+  test("export default function 도 검사 대상", () => {
+    const src = `export default function entry() {}\n`;
+    const v = checkSource("a.ts", src);
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("jsdoc-missing");
+  });
+
+  test("일반 // 주석은 JSDoc 으로 인정하지 않는다", () => {
+    const src = `// 그냥 주석.\nexport function f() {}\n`;
+    const v = checkSource("a.ts", src);
+    expect(v.some((x) => x.rule === "jsdoc-missing")).toBe(true);
+  });
+
+  test("`/* ... */` 일반 블록 주석도 JSDoc 으로 인정하지 않는다", () => {
+    const src = `/* 일반 블록 주석. */\nexport function f() {}\n`;
+    expect(checkSource("a.ts", src).some((x) => x.rule === "jsdoc-missing")).toBe(true);
+  });
+
+  test("export 가 아닌 function / class 는 검사하지 않는다", () => {
+    const src = `function priv() {}\nclass Priv {}\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+
+  test("export interface / type / const 는 정책 대상이 아니다", () => {
+    const src =
+      `export interface I { x: number }\n` +
+      `export type T = number;\n` +
+      `export const C = 1;\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+
+  test("빈 JSDoc(`/**/`) 은 통과로 인정하지 않는다", () => {
+    const src = `/**/\nexport function f() {}\n`;
+    expect(checkSource("a.ts", src).some((x) => x.rule === "jsdoc-missing")).toBe(true);
+  });
+
+  test("JSDoc 과 함수 사이에 빈 줄이 있어도 leading comment 로 인정", () => {
+    const src =
+      `/** 위에 있는 JSDoc. */\n\nexport function f() {}\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+});
+
+describe("checkSource — hangul-required", () => {
+  test("영어 단어만 있는 // 주석은 위반", () => {
+    const src = `// status now reports miss.\nconst x = 1;\n`;
+    const v = checkSource("a.ts", src);
+    expect(v).toHaveLength(1);
+    expect(v[0]?.rule).toBe("hangul-required");
+    expect(v[0]?.line).toBe(1);
+  });
+
+  test("한글이 단 한 글자라도 있으면 통과", () => {
+    const src = `// status 를 갱신.\nconst x = 1;\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+
+  test("Latin 단어가 4자 미만이면 검사하지 않는다 (URL fragment / 짧은 식별자 보호)", () => {
+    const src = `// id ok\nconst x = 1;\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+
+  test("pragma directive 는 면제", () => {
+    const cases = [
+      `// @ts-ignore\n`,
+      `// @ts-expect-error reason\n`,
+      `// eslint-disable-next-line no-console\n`,
+      `// biome-ignore lint/style/useTemplate: explanation\n`,
+      `// TODO refactor later\n`,
+      `// FIXME unstable\n`,
+    ];
+    for (const c of cases) {
+      const v = checkSource("a.ts", `${c}const x = 1;\n`);
+      expect(v.filter((x) => x.rule === "hangul-required")).toHaveLength(0);
+    }
+  });
+
+  test("영어로만 작성된 블록 주석도 위반", () => {
+    const src =
+      `/* status now reports miss. */\nconst x = 1;\n`;
+    const v = checkSource("a.ts", src);
+    expect(v.some((x) => x.rule === "hangul-required")).toBe(true);
+  });
+
+  test("JSDoc 본문에 한글이 있으면 통과", () => {
+    const src =
+      `/**\n * status 를 다시 계산한다.\n */\nexport function f() {}\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+
+  test("JSDoc 본문이 영어뿐이면 hangul-required 위반", () => {
+    const src =
+      `/**\n * Recompute the status field.\n */\nexport function f() {}\n`;
+    const v = checkSource("a.ts", src);
+    expect(v.some((x) => x.rule === "hangul-required")).toBe(true);
+    expect(v.some((x) => x.rule === "jsdoc-missing")).toBe(false);
+  });
+
+  test("쉼표 / 숫자만 있는 짧은 주석은 통과", () => {
+    const src = `// 1, 2, 3\nconst x = 1;\n`;
+    expect(checkSource("a.ts", src)).toHaveLength(0);
+  });
+});
+
+describe("checkSource — 위치 / 보고", () => {
+  test("위반 line 은 1-based", () => {
+    const src = `\n\nexport function f() {}\n`;
+    const v = checkSource("path/to/a.ts", src);
+    expect(v[0]?.file).toBe("path/to/a.ts");
+    expect(v[0]?.line).toBe(3);
+  });
+
+  test("문법 오류가 있어도 throw 하지 않고 가능한 한 위반을 모은다", () => {
+    const src = `// english only comment here\nexport function f( {\n`;
+    const v = checkSource("a.ts", src);
+    expect(v.some((x) => x.rule === "hangul-required")).toBe(true);
+  });
+});

--- a/lib/check-comments.ts
+++ b/lib/check-comments.ts
@@ -1,0 +1,288 @@
+import * as ts from "typescript";
+
+/**
+ * 코드 주석 정책 검증기.
+ *
+ * `AGENTS.md` 의 두 정책을 lint 단으로 끌어올려, 새 위반이 들어오면 `bun test` /
+ * `bun run lint:comments` 가 실패하도록 한다.
+ *
+ * - **jsdoc-missing**: top-level `export function` / `export class` (default export 포함)
+ *   직전에 `/** ... *\/` 블록이 없으면 위반. interface / type / const 는 정책 대상이
+ *   아니므로 검사하지 않는다.
+ * - **hangul-required**: 한 줄(`//`) / 블록(`/* *\/`) 주석 본문에 영어 단어 (Latin 4자
+ *   이상 연속) 가 들어 있는데 한글이 한 글자도 없으면 위반. URL 만 있는 주석, pragma
+ *   directive (`@ts-ignore`, `eslint-disable*`, `biome-ignore` 등) 는 통과.
+ *
+ * "검증 규칙은 정책과 1:1 매칭" 을 유지하기 위해, 추가 규칙 (라이센스 헤더,
+ * 상세도 평가 등) 은 별도 phase 로 분리하고 이 모듈은 두 규칙만 다룬다.
+ */
+
+const HANGUL_RE = /[ᄀ-ᇿ㄰-㆏가-힯]/;
+const ENGLISH_WORD_RE = /[A-Za-z]{4,}/;
+
+/**
+ * pragma 성격이 강해 의미적으로 한글로 옮길 수 없는 주석 prefix.
+ * 첫 비공백 라인이 이 패턴이면 hangul-required 검사를 면제한다.
+ */
+const PRAGMA_RE =
+  /^(?:@ts-|eslint-|biome-ignore|prettier-ignore|c8 ignore|istanbul ignore|tslint:|TODO\b|FIXME\b)/;
+
+export type ViolationRule = "jsdoc-missing" | "hangul-required";
+
+export interface Violation {
+  /** 보고용 파일 경로 (호출자가 넘긴 그대로). */
+  file: string;
+  /** 1부터 시작하는 라인 번호. */
+  line: number;
+  rule: ViolationRule;
+  message: string;
+}
+
+/**
+ * 단일 TypeScript 소스를 검사한다.
+ *
+ * `file` 은 메시지에 그대로 들어가며 — 절대 / 상대 경로 결정은 호출자 책임이다.
+ * 파싱 실패시에도 throw 하지 않고 가능한 만큼 위반을 모은다.
+ */
+export function checkSource(file: string, source: string): Violation[] {
+  const sf = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes 인자*/ true,
+  );
+  return [...checkJSDoc(file, sf, source), ...checkHangul(file, sf, source)];
+}
+
+function checkJSDoc(
+  file: string,
+  sf: ts.SourceFile,
+  source: string,
+): Violation[] {
+  const out: Violation[] = [];
+  ts.forEachChild(sf, (node) => {
+    if (!isExportedFunctionOrClass(node)) return;
+    const start = node.getStart(sf, /*includeJsDocComment 인자*/ false);
+    if (hasJSDocAbove(source, node.pos)) return;
+    const line = sf.getLineAndCharacterOfPosition(start).line + 1;
+    const kind = ts.isClassDeclaration(node) ? "class" : "function";
+    const name =
+      (node as ts.FunctionDeclaration | ts.ClassDeclaration).name?.text ??
+      "(anonymous)";
+    out.push({
+      file,
+      line,
+      rule: "jsdoc-missing",
+      message: `export ${kind} \`${name}\` 직전에 JSDoc(/** ... */)이 없습니다.`,
+    });
+  });
+  return out;
+}
+
+function isExportedFunctionOrClass(
+  node: ts.Node,
+): node is ts.FunctionDeclaration | ts.ClassDeclaration {
+  if (!ts.isFunctionDeclaration(node) && !ts.isClassDeclaration(node)) {
+    return false;
+  }
+  const mods = ts.getModifiers(node);
+  if (!mods) return false;
+  return mods.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+}
+
+function hasJSDocAbove(source: string, pos: number): boolean {
+  const ranges = ts.getLeadingCommentRanges(source, pos) ?? [];
+  for (const r of ranges) {
+    if (r.kind !== ts.SyntaxKind.MultiLineCommentTrivia) continue;
+    const text = source.slice(r.pos, r.end);
+    // `/**` 로 시작하지만 `/**/` (빈 블록 주석) 는 제외.
+    if (text.startsWith("/**") && !text.startsWith("/**/")) return true;
+  }
+  return false;
+}
+
+function checkHangul(
+  file: string,
+  sf: ts.SourceFile,
+  source: string,
+): Violation[] {
+  const out: Violation[] = [];
+  for (const c of extractComments(source)) {
+    const inner = stripCommentMarkers(c.text);
+    if (!shouldCheckComment(inner)) continue;
+    if (!ENGLISH_WORD_RE.test(inner)) continue;
+    if (HANGUL_RE.test(inner)) continue;
+    const line = sf.getLineAndCharacterOfPosition(c.start).line + 1;
+    out.push({
+      file,
+      line,
+      rule: "hangul-required",
+      message:
+        "주석에 영어 단어가 있지만 한글이 한 글자도 없습니다 (AGENTS.md 한글 주석 정책).",
+    });
+  }
+  return out;
+}
+
+interface RawComment {
+  start: number;
+  text: string;
+}
+
+/**
+ * 소스에서 `//` 와 `/* *\/` 주석을 모두 뽑는다.
+ *
+ * `ts.createScanner` 는 template literal 의 `${...}` 와 backtick 짝을 자체적으로
+ * 추적하지 못해, 큰 파일에서 backtick 안의 `//` 를 single-line comment 로 잘못
+ * 잡는 경우가 있어 (`reScanTemplateToken` 호출이 필요하다) 직접 상태를 tracking
+ * 하는 작은 lexer 로 대체했다. 정규식 리터럴은 단순화를 위해 division 으로
+ * 취급한다 — `// ` 가 정규식 안에 들어가는 건 매우 드물고, 들어가더라도 escape
+ * 가 들어가야 하므로 false positive 가능성은 낮다.
+ */
+function extractComments(source: string): RawComment[] {
+  const out: RawComment[] = [];
+  const n = source.length;
+  let i = 0;
+  while (i < n) {
+    const c = source[i]!;
+    if (c === "/" && i + 1 < n) {
+      const next = source[i + 1];
+      if (next === "/") {
+        const start = i;
+        i += 2;
+        while (i < n && source[i] !== "\n") i++;
+        out.push({ start, text: source.slice(start, i) });
+        continue;
+      }
+      if (next === "*") {
+        const start = i;
+        i += 2;
+        while (i < n - 1 && !(source[i] === "*" && source[i + 1] === "/")) i++;
+        if (i < n - 1) i += 2;
+        else i = n;
+        out.push({ start, text: source.slice(start, i) });
+        continue;
+      }
+    }
+    if (c === '"' || c === "'") {
+      i = skipQuotedString(source, i, c);
+      continue;
+    }
+    if (c === "`") {
+      i = skipTemplateLiteral(source, i);
+      continue;
+    }
+    i++;
+  }
+  return out;
+}
+
+/** `'...'` 또는 `"..."` 를 건너뛰고 닫는 quote 다음 위치를 반환한다. */
+function skipQuotedString(s: string, start: number, quote: string): number {
+  let i = start + 1;
+  const n = s.length;
+  while (i < n) {
+    const c = s[i];
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (c === quote) return i + 1;
+    if (c === "\n") return i + 1;
+    i++;
+  }
+  return i;
+}
+
+/**
+ * `\`...\`` 를 건너뛰는데, `${...}` 안에서는 다시 일반 코드 lexer 로 들어가
+ * 중첩된 string / template / comment 는 무시하고 brace depth 만 추적한다.
+ *
+ * 닫는 backtick 다음 위치를 반환한다 — 닫히지 않으면 EOF.
+ */
+function skipTemplateLiteral(s: string, start: number): number {
+  let i = start + 1;
+  const n = s.length;
+  while (i < n) {
+    const c = s[i];
+    if (c === "\\") {
+      i += 2;
+      continue;
+    }
+    if (c === "`") return i + 1;
+    if (c === "$" && s[i + 1] === "{") {
+      i = skipTemplateExpression(s, i + 2);
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+/** template literal 의 `${...}` 본문을 건너뛴다 — brace depth 가 0 이 되면 종료. */
+function skipTemplateExpression(s: string, start: number): number {
+  let i = start;
+  const n = s.length;
+  let depth = 1;
+  while (i < n && depth > 0) {
+    const c = s[i]!;
+    if (c === '"' || c === "'") {
+      i = skipQuotedString(s, i, c);
+      continue;
+    }
+    if (c === "`") {
+      i = skipTemplateLiteral(s, i);
+      continue;
+    }
+    if (c === "{") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (c === "}") {
+      depth--;
+      i++;
+      continue;
+    }
+    if (c === "/" && i + 1 < n) {
+      const next = s[i + 1];
+      if (next === "/") {
+        while (i < n && s[i] !== "\n") i++;
+        continue;
+      }
+      if (next === "*") {
+        i += 2;
+        while (i < n - 1 && !(s[i] === "*" && s[i + 1] === "/")) i++;
+        if (i < n - 1) i += 2;
+        else i = n;
+        continue;
+      }
+    }
+    i++;
+  }
+  return i;
+}
+
+function stripCommentMarkers(raw: string): string {
+  if (raw.startsWith("//")) return raw.slice(2).trim();
+  if (raw.startsWith("/*")) {
+    let body = raw.slice(2);
+    if (body.endsWith("*/")) body = body.slice(0, -2);
+    return body
+      .split(/\r?\n/)
+      .map((l) => l.replace(/^\s*\*\s?/, ""))
+      .join("\n")
+      .trim();
+  }
+  return raw.trim();
+}
+
+function shouldCheckComment(inner: string): boolean {
+  if (!inner) return false;
+  for (const line of inner.split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t) continue;
+    return !PRAGMA_RE.test(t);
+  }
+  return false;
+}

--- a/lib/check-comments.ts
+++ b/lib/check-comments.ts
@@ -39,6 +39,18 @@ export interface Violation {
 }
 
 /**
+ * lint 가 훑는 디렉터리 단일 소스 — CLI (`tools/check-comments.ts`) 와 통합
+ * 테스트 (`check-comments.integration.test.ts`) 가 이 상수를 import 해 같은
+ * 검사 대상을 공유한다. 둘이 갈라지면 `bun test` 와 `bun run lint:comments`
+ * 결과가 어긋날 수 있어 하나로 모은다.
+ */
+export const COMMENT_LINT_TARGET_DIRS = [
+  "lib",
+  ".opencode/plugins",
+  "tools",
+] as const;
+
+/**
  * 단일 TypeScript 소스를 검사한다.
  *
  * `file` 은 메시지에 그대로 들어가며 — 절대 / 상대 경로 결정은 호출자 책임이다.
@@ -110,7 +122,10 @@ function checkHangul(
   for (const c of extractComments(source)) {
     const inner = stripCommentMarkers(c.text);
     if (!shouldCheckComment(inner)) continue;
-    if (!ENGLISH_WORD_RE.test(inner)) continue;
+    // URL 자체는 영어 단어로 치지 않는다 — 제거 후에도 영어 단어가 남아 있는
+    // 경우에만 한글 부재를 위반으로 본다 (예: `// see https://...` 의 "see").
+    const withoutUrls = stripUrls(inner);
+    if (!ENGLISH_WORD_RE.test(withoutUrls)) continue;
     if (HANGUL_RE.test(inner)) continue;
     const line = sf.getLineAndCharacterOfPosition(c.start).line + 1;
     out.push({
@@ -124,6 +139,11 @@ function checkHangul(
   return out;
 }
 
+/** 흔한 scheme (http/https/ftp/file/git/ssh) URL 토큰을 공백으로 치환. */
+function stripUrls(text: string): string {
+  return text.replace(/\b(?:https?|ftp|file|git|ssh):\/\/\S+/gi, " ");
+}
+
 interface RawComment {
   start: number;
   text: string;
@@ -135,46 +155,79 @@ interface RawComment {
  * `ts.createScanner` 는 template literal 의 `${...}` 와 backtick 짝을 자체적으로
  * 추적하지 못해, 큰 파일에서 backtick 안의 `//` 를 single-line comment 로 잘못
  * 잡는 경우가 있어 (`reScanTemplateToken` 호출이 필요하다) 직접 상태를 tracking
- * 하는 작은 lexer 로 대체했다. 정규식 리터럴은 단순화를 위해 division 으로
- * 취급한다 — `// ` 가 정규식 안에 들어가는 건 매우 드물고, 들어가더라도 escape
- * 가 들어가야 하므로 false positive 가능성은 낮다.
+ * 하는 작은 lexer 로 대체했다. template expression (`${...}`) 안의 주석도
+ * 정책 우회를 막기 위해 똑같이 수집한다 — `scanCode` 가 재귀 호출로 brace
+ * 깊이를 추적하며 한 lexer 가 모든 컨텍스트를 처리한다. 정규식 리터럴은
+ * 단순화를 위해 division 으로 취급한다 — `// ` 가 정규식 안에 들어가는 건
+ * 매우 드물고, 들어가더라도 escape 가 필요하므로 false positive 가능성은 낮다.
  */
 function extractComments(source: string): RawComment[] {
   const out: RawComment[] = [];
-  const n = source.length;
-  let i = 0;
+  scanCode(source, 0, /*tracksClosingBrace 인자*/ false, out);
+  return out;
+}
+
+/**
+ * 코드 본문을 lexing 하면서 만나는 모든 주석을 `out` 에 push 한다.
+ *
+ * `tracksClosingBrace` 가 true 면 brace depth 가 0 이 되는 닫는 `}` 위치 +1
+ * 을 반환해 호출자 (template expression) 가 이어 받게 한다. false 면 EOF
+ * 까지 진행 후 `source.length` 반환.
+ */
+function scanCode(
+  s: string,
+  start: number,
+  tracksClosingBrace: boolean,
+  out: RawComment[],
+): number {
+  const n = s.length;
+  let i = start;
+  let depth = tracksClosingBrace ? 1 : 0;
   while (i < n) {
-    const c = source[i]!;
-    if (c === "/" && i + 1 < n) {
-      const next = source[i + 1];
-      if (next === "/") {
-        const start = i;
-        i += 2;
-        while (i < n && source[i] !== "\n") i++;
-        out.push({ start, text: source.slice(start, i) });
-        continue;
-      }
-      if (next === "*") {
-        const start = i;
-        i += 2;
-        while (i < n - 1 && !(source[i] === "*" && source[i + 1] === "/")) i++;
-        if (i < n - 1) i += 2;
-        else i = n;
-        out.push({ start, text: source.slice(start, i) });
-        continue;
-      }
-    }
+    const c = s[i]!;
     if (c === '"' || c === "'") {
-      i = skipQuotedString(source, i, c);
+      i = skipQuotedString(s, i, c);
       continue;
     }
     if (c === "`") {
-      i = skipTemplateLiteral(source, i);
+      i = scanTemplateLiteral(s, i, out);
       continue;
+    }
+    if (tracksClosingBrace) {
+      if (c === "{") {
+        depth++;
+        i++;
+        continue;
+      }
+      if (c === "}") {
+        depth--;
+        i++;
+        if (depth === 0) return i;
+        continue;
+      }
+    }
+    if (c === "/" && i + 1 < n) {
+      const next = s[i + 1];
+      if (next === "/") {
+        const cstart = i;
+        i += 2;
+        while (i < n && s[i] !== "\n") i++;
+        out.push({ start: cstart, text: s.slice(cstart, i) });
+        continue;
+      }
+      if (next === "*") {
+        const cstart = i;
+        i += 2;
+        while (i < n - 1 && !(s[i] === "*" && s[i + 1] === "/")) i++;
+        if (i < n - 1) i += 2;
+        else i = n;
+        out.push({ start: cstart, text: s.slice(cstart, i) });
+        continue;
+      }
     }
     i++;
   }
-  return out;
+  return i;
 }
 
 /** `'...'` 또는 `"..."` 를 건너뛰고 닫는 quote 다음 위치를 반환한다. */
@@ -195,12 +248,14 @@ function skipQuotedString(s: string, start: number, quote: string): number {
 }
 
 /**
- * `\`...\`` 를 건너뛰는데, `${...}` 안에서는 다시 일반 코드 lexer 로 들어가
- * 중첩된 string / template / comment 는 무시하고 brace depth 만 추적한다.
- *
- * 닫는 backtick 다음 위치를 반환한다 — 닫히지 않으면 EOF.
+ * `\`...\`` 를 건너뛰며 — `${...}` 본문은 `scanCode` 로 재귀 들어가 그 안의
+ * 주석도 동일하게 수집한다. 닫는 backtick 다음 위치를 반환한다.
  */
-function skipTemplateLiteral(s: string, start: number): number {
+function scanTemplateLiteral(
+  s: string,
+  start: number,
+  out: RawComment[],
+): number {
   let i = start + 1;
   const n = s.length;
   while (i < n) {
@@ -211,52 +266,8 @@ function skipTemplateLiteral(s: string, start: number): number {
     }
     if (c === "`") return i + 1;
     if (c === "$" && s[i + 1] === "{") {
-      i = skipTemplateExpression(s, i + 2);
+      i = scanCode(s, i + 2, /*tracksClosingBrace 인자*/ true, out);
       continue;
-    }
-    i++;
-  }
-  return i;
-}
-
-/** template literal 의 `${...}` 본문을 건너뛴다 — brace depth 가 0 이 되면 종료. */
-function skipTemplateExpression(s: string, start: number): number {
-  let i = start;
-  const n = s.length;
-  let depth = 1;
-  while (i < n && depth > 0) {
-    const c = s[i]!;
-    if (c === '"' || c === "'") {
-      i = skipQuotedString(s, i, c);
-      continue;
-    }
-    if (c === "`") {
-      i = skipTemplateLiteral(s, i);
-      continue;
-    }
-    if (c === "{") {
-      depth++;
-      i++;
-      continue;
-    }
-    if (c === "}") {
-      depth--;
-      i++;
-      continue;
-    }
-    if (c === "/" && i + 1 < n) {
-      const next = s[i + 1];
-      if (next === "/") {
-        while (i < n && s[i] !== "\n") i++;
-        continue;
-      }
-      if (next === "*") {
-        i += 2;
-        while (i < n - 1 && !(s[i] === "*" && s[i + 1] === "/")) i++;
-        if (i < n - 1) i += 2;
-        else i = n;
-        continue;
-      }
     }
     i++;
   }

--- a/lib/notion-context.ts
+++ b/lib/notion-context.ts
@@ -275,6 +275,10 @@ export class NotionCache {
   }
 }
 
+/**
+ * 환경변수 (`AGENT_TOOLKIT_CACHE_DIR` / `AGENT_TOOLKIT_CACHE_TTL`) 를 읽어
+ * `NotionCache` 인스턴스를 만든다. 값이 비어 있거나 잘못된 정수면 클래스 기본값으로 폴백.
+ */
 export function createCacheFromEnv(): NotionCache {
   const baseDir = process.env.AGENT_TOOLKIT_CACHE_DIR;
   const ttlRaw = process.env.AGENT_TOOLKIT_CACHE_TTL;

--- a/lib/openapi-context.test.ts
+++ b/lib/openapi-context.test.ts
@@ -253,7 +253,7 @@ describe("OpenapiCache", () => {
     const cache = new OpenapiCache({ baseDir: dir, defaultTtlSeconds: 60 });
     const w = await cache.write(SPEC_URL, SAMPLE_SPEC);
     rmSync(join(dir, `${w.entry.key}.spec.json`));
-    // status now reports miss, but the meta is still on disk.
+    // status 는 miss 로 보고하지만 메타 파일은 디스크에 그대로 남아 있어야 한다.
     expect((await cache.status(SPEC_URL)).exists).toBe(false);
     expect(await cache.peekSpecUrl(SPEC_URL)).toBe(SPEC_URL);
     expect(await cache.peekSpecUrl(w.entry.key)).toBe(SPEC_URL);

--- a/lib/openapi-context.ts
+++ b/lib/openapi-context.ts
@@ -178,6 +178,10 @@ const HTTP_METHODS = [
   "trace",
 ] as const;
 
+/**
+ * spec 의 paths × HTTP method 조합 수를 센다. paths 가 없거나 객체가 아니면 0.
+ * 표준 외 method 키는 제외 — `HTTP_METHODS` 화이트리스트만 본다.
+ */
 export function countEndpoints(spec: OpenapiSpec): number {
   if (!spec.paths || typeof spec.paths !== "object") return 0;
   let total = 0;

--- a/lib/toolkit-config.test.ts
+++ b/lib/toolkit-config.test.ts
@@ -220,7 +220,7 @@ describe("mergeConfigs", () => {
     expect(merged.openapi?.registry?.acme?.dev?.users).toBe(
       "https://project/u.json",
     );
-    // user-only spec survives.
+    // user 단에만 있던 spec 도 살아남아야 한다.
     expect(merged.openapi?.registry?.acme?.dev?.orders).toBe(
       "https://user/o.json",
     );

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "test": "bun test ./lib ./.opencode",
-    "typecheck": "bun x tsc --noEmit -p tsconfig.json"
+    "typecheck": "bun x tsc --noEmit -p tsconfig.json",
+    "lint:comments": "bun tools/check-comments.ts"
   },
   "devDependencies": {
     "typescript": "^5.4.5",

--- a/tools/check-comments.ts
+++ b/tools/check-comments.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative, resolve } from "node:path";
+import { checkSource, type Violation } from "../lib/check-comments";
+
+/**
+ * `bun run lint:comments` 진입점.
+ *
+ * 정책 검증 자체는 `lib/check-comments.ts` 의 순수 함수에 모여 있고, 이 파일은
+ * 디스크 walking + 보고 + exit code 만 담당한다 (단위 테스트는 lib 쪽에서 본다).
+ *
+ * 검사 대상은 다음 디렉터리의 `*.ts` 전부:
+ *   - `lib/`
+ *   - `.opencode/plugins/`
+ *   - `tools/`
+ *
+ * 위반 0 건이면 exit 0, 그 외에는 라인 단위 보고 후 exit 1.
+ */
+
+const SELF_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SELF_DIR, "..");
+const TARGET_DIRS = ["lib", ".opencode/plugins", "tools"];
+
+function collectFiles(rootDir: string, out: string[] = []): string[] {
+  let stat: ReturnType<typeof statSync>;
+  try {
+    stat = statSync(rootDir);
+  } catch {
+    return out;
+  }
+  if (!stat.isDirectory()) return out;
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    const full = join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      collectFiles(full, out);
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function main(): number {
+  const files: string[] = [];
+  for (const d of TARGET_DIRS) {
+    collectFiles(resolve(ROOT, d), files);
+  }
+  files.sort();
+
+  const violations: Violation[] = [];
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    const rel = relative(ROOT, file);
+    violations.push(...checkSource(rel, source));
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `[check-comments] OK — ${files.length} 파일, 위반 0 건`,
+    );
+    return 0;
+  }
+
+  for (const v of violations) {
+    console.error(`${v.file}:${v.line}: [${v.rule}] ${v.message}`);
+  }
+  const jsdoc = violations.filter((v) => v.rule === "jsdoc-missing").length;
+  const hangul = violations.filter((v) => v.rule === "hangul-required").length;
+  console.error(
+    `\n[check-comments] 위반 ${violations.length} 건 — jsdoc-missing=${jsdoc}, hangul-required=${hangul}`,
+  );
+  return 1;
+}
+
+process.exit(main());

--- a/tools/check-comments.ts
+++ b/tools/check-comments.ts
@@ -2,7 +2,11 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, relative, resolve } from "node:path";
-import { checkSource, type Violation } from "../lib/check-comments";
+import {
+  COMMENT_LINT_TARGET_DIRS,
+  checkSource,
+  type Violation,
+} from "../lib/check-comments";
 
 /**
  * `bun run lint:comments` 진입점.
@@ -10,17 +14,13 @@ import { checkSource, type Violation } from "../lib/check-comments";
  * 정책 검증 자체는 `lib/check-comments.ts` 의 순수 함수에 모여 있고, 이 파일은
  * 디스크 walking + 보고 + exit code 만 담당한다 (단위 테스트는 lib 쪽에서 본다).
  *
- * 검사 대상은 다음 디렉터리의 `*.ts` 전부:
- *   - `lib/`
- *   - `.opencode/plugins/`
- *   - `tools/`
- *
- * 위반 0 건이면 exit 0, 그 외에는 라인 단위 보고 후 exit 1.
+ * 검사 대상 디렉터리는 `COMMENT_LINT_TARGET_DIRS` 한 곳에서만 정의 — 통합
+ * 테스트와 같은 소스를 공유한다. 위반 0 건이면 exit 0, 그 외에는 라인 단위
+ * 보고 후 exit 1.
  */
 
 const SELF_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(SELF_DIR, "..");
-const TARGET_DIRS = ["lib", ".opencode/plugins", "tools"];
 
 function collectFiles(rootDir: string, out: string[] = []): string[] {
   let stat: ReturnType<typeof statSync>;
@@ -43,7 +43,7 @@ function collectFiles(rootDir: string, out: string[] = []): string[] {
 
 function main(): number {
   const files: string[] = [];
-  for (const d of TARGET_DIRS) {
+  for (const d of COMMENT_LINT_TARGET_DIRS) {
     collectFiles(resolve(ROOT, d), files);
   }
   files.sort();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   },
   "include": [
     "lib/**/*.ts",
-    ".opencode/plugins/**/*.ts"
+    ".opencode/plugins/**/*.ts",
+    "tools/**/*.ts"
   ]
 }


### PR DESCRIPTION
closes #7

## 요약

`AGENTS.md` 의 두 정책 — export 함수/클래스 JSDoc, 한글 주석 — 을 단순 규칙에서 lint 단 검증으로 끌어올렸다. 자체 검증 스크립트 (`tools/check-comments.ts`) + 통합 테스트로 `bun test` / CI 둘 다 자동으로 정책을 강제한다.

## 결정 사항

- **layer**: ESLint / Biome 의존 없이 자체 스크립트 + TypeScript compiler API. 의존성 추가 회피 (이미 `typescript` 가 devDep) + 두 규칙만 1:1 로 다루는 단순함이 우선.
- **에러 vs 경고**: 모두 **error** (exit 1). 새 위반은 막고 정리하는 게 정책의 본래 취지.
- **한글 비율 임계치**: "비율" 대신 **존재 검사**. 영어 단어 (Latin 4자 이상) 가 본문에 있는데 한글이 한 글자도 없으면 위반. URL fragment, pragma directive (`@ts-ignore`, `eslint-disable*`, `biome-ignore`, `TODO`/`FIXME` 등) 는 면제. 비율 기반은 false positive 가 많고 임계치가 임의적이어서 제외.

## 변경

- `lib/check-comments.ts` — 두 규칙을 가진 순수 함수 `checkSource`. TS 의 `forEachChild` + 직접 작성한 string/template 안전 lexer (TS scanner 가 backtick 안의 `//` 를 single-line comment 로 잘못 잡는 케이스가 있어 우회).
- `tools/check-comments.ts` — `bun run lint:comments` CLI. `lib/`, `.opencode/plugins/`, `tools/` 의 `*.ts` 를 훑어 위반 시 exit 1.
- `lib/check-comments.test.ts` — 단위 테스트 20 케이스 (JSDoc / Hangul / pragma / inline parameter / 위치 보고).
- `lib/check-comments.integration.test.ts` — repo 전체 회귀 테스트. `bun test` 만 돌려도 정책이 자동 강제된다.
- `.github/workflows/ci.yml` — 명시적 `lint:comments` step 추가.
- `package.json` / `tsconfig.json` — 스크립트 + `tools/` include 동기화.
- `AGENTS.md` / `README.md` — common commands + change checklist + 새 파일 항목 동기화.
- 기존 위반 정리: 영어 전용 테스트 주석 2 건 한글화, 누락된 export 함수 6 개 (`handleNotionRefresh/Status`, `handleSwaggerRefresh/Status`, `createCacheFromEnv`, `countEndpoints`) 에 JSDoc 보충.

## Acceptance criteria

- [x] 새 export 함수에 JSDoc 누락 시 검증이 실패한다 (단위 테스트)
- [x] 영어로만 작성된 새 주석을 잡아낸다 (단위 테스트)
- [x] 기존 코드는 정책 위반 없이 통과 (통합 테스트 + `lint:comments` 0 violations)
- [x] `AGENTS.md` 의 정책 항목과 1:1 매칭되는 검증 규칙

## Test plan

- [x] `bun run typecheck` 통과
- [x] `bun test` 통과 (134 pass, 통합 테스트 포함)
- [x] `bun run lint:comments` 0 violations
- [ ] CI green (typecheck + test + lint:comments)

모든 리뷰 코멘트는 한국어로 작성해 주세요.

https://claude.ai/code/session_01KWsx7zf2vMgomGywLoZmSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWsx7zf2vMgomGywLoZmSi)_