### PR TITLE
chore: Sisyphus 작업 디렉터리 ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 *.log
 .DS_Store
 .agent-cache/
+.sisyphus/
 .env
 .env.local
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
- `.sisyphus/` 작업 디렉터리를 git ignore 대상에 추가합니다.
- 로컬 계획/작업 메모가 PR diff에 섞이지 않도록 합니다.

## Verification
- `.gitignore` diff 확인
- LSP diagnostics: `.gitignore` 확장자용 LSP 서버 없음

---
_Generated by [OPENCODE] Sisyphus (openai/gpt-5.5)_