### PR TITLE
fix: MVP audit 정합성과 Biome check 정리

### DIFF
--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from "node:url";
 import {
   type NotionCache,
   resolveCacheKey,
-  notionToMarkdown,
   createCacheFromEnv,
   type RawNotionPage,
   type NotionPageResult,
@@ -55,7 +54,6 @@ import {
   listTables as mysqlListTables,
   pingHandle as mysqlPingHandle,
   runReadonlyQuery as mysqlRunReadonlyQuery,
-  type MysqlExecutor,
   type MysqlQueryResult,
   type RunReadonlyQueryOptions,
 } from "../../lib/mysql-context";
@@ -275,7 +273,7 @@ export async function downloadOpenapiSpec(
     let data: unknown;
     try {
       data = JSON.parse(text);
-    } catch (parseErr) {
+    } catch {
       throw new Error(
         `OpenAPI download from ${specUrl} returned non-JSON body (first 120 chars: ${text.slice(0, 120)})`,
       );

--- a/biome.json
+++ b/biome.json
@@ -4,6 +4,9 @@
     "indentStyle": "space",
     "indentWidth": 2
   },
+  "files": {
+    "includes": ["**", "!.sisyphus"]
+  },
   "assist": {
     "enabled": false
   },

--- a/lib/agent-journal.test.ts
+++ b/lib/agent-journal.test.ts
@@ -7,7 +7,6 @@ import { AgentJournal, JOURNAL_FILE } from "./agent-journal";
 const PAGE = "1234abcd1234abcd1234abcd1234abcd";
 const PAGE_DASHED = "1234abcd-1234-abcd-1234-abcd1234abcd";
 const OTHER_PAGE = "abcd1234abcd1234abcd1234abcd1234";
-const OTHER_PAGE_DASHED = "abcd1234-abcd-1234-abcd-1234abcd1234";
 
 let dir: string;
 let journal: AgentJournal;

--- a/lib/agent-journal.ts
+++ b/lib/agent-journal.ts
@@ -351,7 +351,7 @@ function capOrDefault(limit: unknown): number {
 function entryMatchesNeedle(entry: JournalEntry, needle: string): boolean {
   if (entry.content.toLowerCase().includes(needle)) return true;
   if (entry.kind.toLowerCase().includes(needle)) return true;
-  if (entry.pageId && entry.pageId.toLowerCase().includes(needle)) return true;
+  if (entry.pageId?.toLowerCase().includes(needle)) return true;
   for (const t of entry.tags) {
     if (t.toLowerCase().includes(needle)) return true;
   }


### PR DESCRIPTION
## Summary
- MVP verification audit 결과에 맞춰 문서/스키마/skill 계약 정합성을 동기화합니다.
- Biome check 실패를 막기 위해 `.sisyphus` 산출물을 검사 대상에서 제외하고 unused lint를 정리합니다.
- `bun run check`, `bun run typecheck`, `bun test` 통과를 확인했습니다.

## Verification
- `bun run check`
- `bun run typecheck`
- `bun test` (248 pass)

모든 리뷰 코멘트는 한국어로 작성해 주세요.

---
_Generated by [OPENCODE] Sisyphus (openai/gpt-5.5)_