### PR TITLE
fix(plugin): Notion MCP OAuth 캐시 호출 지원

### DIFF
--- a/.opencode/plugins/agent-toolkit.test.ts
+++ b/.opencode/plugins/agent-toolkit.test.ts
@@ -57,12 +57,14 @@ let cache: NotionCache;
 let server: ReturnType<typeof Bun.serve>;
 let calls: number;
 let respondWithWrongId: boolean;
+let mcpOmitIdentifier: boolean;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "plugin-"));
   cache = new NotionCache({ baseDir: dir, defaultTtlSeconds: 60 });
   calls = 0;
   respondWithWrongId = false;
+  mcpOmitIdentifier = false;
   server = Bun.serve({
     port: 0,
     hostname: "127.0.0.1",
@@ -78,8 +80,21 @@ beforeEach(() => {
         });
       }
       if (url.pathname === "/mcp" && req.method === "POST") {
+        if (req.headers.get("authorization") !== "Bearer test-token") {
+          return new Response("missing authorization", { status: 401 });
+        }
         const sessionHeaders = { "mcp-session-id": "test-session" };
         return req.json().then((body: any) => {
+          if (body.method !== "initialize") {
+            if (req.headers.get("mcp-session-id") !== "test-session") {
+              return new Response("missing mcp-session-id", { status: 400 });
+            }
+            if (req.headers.get("mcp-protocol-version") !== "2025-06-18") {
+              return new Response("missing mcp-protocol-version", {
+                status: 400,
+              });
+            }
+          }
           if (body.method === "initialize") {
             return new Response(
               `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "Mock Notion MCP", version: "1.0.0" } } })}\n\n`,
@@ -96,8 +111,15 @@ beforeEach(() => {
           }
           if (body.method === "tools/call") {
             calls += 1;
+            const payload = mcpOmitIdentifier
+              ? { title: "Hello MCP", text: "# Hello MCP\n\nworld" }
+              : {
+                  title: "Hello MCP",
+                  url: `https://www.notion.so/${PAGE}`,
+                  text: "# Hello MCP\n\nworld",
+                };
             return new Response(
-              `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { content: [{ type: "text", text: JSON.stringify({ title: "Hello MCP", url: `https://www.notion.so/${PAGE}`, text: "# Hello MCP\n\nworld" }) }] } })}\n\n`,
+              `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { content: [{ type: "text", text: JSON.stringify(payload) }] } })}\n\n`,
               { headers: { "content-type": "text/event-stream" } },
             );
           }
@@ -199,6 +221,28 @@ describe("plugin handlers", () => {
     const second = await handleNotionGet(cache, PAGE);
     expect(second.fromCache).toBe(true);
     expect(calls).toBe(1);
+  });
+
+  it("rejects OAuth MCP response without a remote identifier and does not cache", async () => {
+    const authFile = join(dir, "mcp-auth.json");
+    process.env.AGENT_TOOLKIT_NOTION_MCP_URL = `http://${server.hostname}:${server.port}/mcp`;
+    process.env.AGENT_TOOLKIT_MCP_AUTH_FILE = authFile;
+    writeFileSync(
+      authFile,
+      JSON.stringify({
+        notion: {
+          serverUrl: process.env.AGENT_TOOLKIT_NOTION_MCP_URL,
+          tokens: { accessToken: "test-token" },
+        },
+      }),
+    );
+    mcpOmitIdentifier = true;
+
+    await expect(handleNotionGet(cache, PAGE)).rejects.toThrow(
+      /missing remote page identifier/i,
+    );
+    const s = await handleNotionStatus(cache, PAGE);
+    expect(s.exists).toBe(false);
   });
 
   it("rejects remote response with mismatched page id and does not cache", async () => {

--- a/.opencode/plugins/agent-toolkit.test.ts
+++ b/.opencode/plugins/agent-toolkit.test.ts
@@ -77,6 +77,37 @@ beforeEach(() => {
             "# Hello\n\nworld\n\n## TODO\n\n- [ ] 주문 목록 API 연동\n\n## API\n\n- GET /api/orders",
         });
       }
+      if (url.pathname === "/mcp" && req.method === "POST") {
+        const sessionHeaders = { "mcp-session-id": "test-session" };
+        return req.json().then((body: any) => {
+          if (body.method === "initialize") {
+            return new Response(
+              `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocolVersion: "2025-06-18", capabilities: {}, serverInfo: { name: "Mock Notion MCP", version: "1.0.0" } } })}\n\n`,
+              {
+                headers: {
+                  ...sessionHeaders,
+                  "content-type": "text/event-stream",
+                },
+              },
+            );
+          }
+          if (body.method === "notifications/initialized") {
+            return new Response(null, { status: 202, headers: sessionHeaders });
+          }
+          if (body.method === "tools/call") {
+            calls += 1;
+            return new Response(
+              `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { content: [{ type: "text", text: JSON.stringify({ title: "Hello MCP", url: `https://www.notion.so/${PAGE}`, text: "# Hello MCP\n\nworld" }) }] } })}\n\n`,
+              { headers: { "content-type": "text/event-stream" } },
+            );
+          }
+          return Response.json({
+            jsonrpc: "2.0",
+            id: body.id,
+            error: { code: -32601, message: "not found" },
+          });
+        });
+      }
       return new Response("not found", { status: 404 });
     },
   });
@@ -86,6 +117,8 @@ beforeEach(() => {
 afterEach(() => {
   server.stop(true);
   delete process.env.AGENT_TOOLKIT_NOTION_MCP_URL;
+  delete process.env.AGENT_TOOLKIT_MCP_AUTH_FILE;
+  delete process.env.AGENT_TOOLKIT_NOTION_MCP_AUTH_KEY;
 });
 
 describe("plugin handlers", () => {
@@ -136,6 +169,34 @@ describe("plugin handlers", () => {
     ).toBe(true);
 
     const second = await handleNotionExtract(cache, PAGE);
+    expect(second.fromCache).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it("notion_get: uses opencode MCP OAuth auth file when it matches the remote MCP URL", async () => {
+    const authFile = join(dir, "mcp-auth.json");
+    process.env.AGENT_TOOLKIT_NOTION_MCP_URL = `http://${server.hostname}:${server.port}/mcp`;
+    process.env.AGENT_TOOLKIT_MCP_AUTH_FILE = authFile;
+    writeFileSync(
+      authFile,
+      JSON.stringify({
+        notion: {
+          serverUrl: process.env.AGENT_TOOLKIT_NOTION_MCP_URL,
+          tokens: {
+            accessToken: "test-token",
+            expiresAt: Date.now() / 1000 + 3600,
+          },
+        },
+      }),
+    );
+
+    const first = await handleNotionGet(cache, PAGE);
+    expect(first.fromCache).toBe(false);
+    expect(first.entry.title).toBe("Hello MCP");
+    expect(first.markdown).toBe("# Hello MCP\n\nworld");
+    expect(calls).toBe(1);
+
+    const second = await handleNotionGet(cache, PAGE);
     expect(second.fromCache).toBe(true);
     expect(calls).toBe(1);
   });

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -1,7 +1,8 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tool as defineTool } from "@opencode-ai/plugin";
-import { resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   type NotionCache,
@@ -253,10 +254,18 @@ const AGENTS_DIR = resolve(REPO_ROOT, "agents");
 
 /**
  * remote Notion MCP base URL 기본값.
- * Notion 공식 remote MCP 가 OAuth 로 인증을 처리하므로 이 plugin 은 토큰을 다루지 않는다.
+ * 실제 Notion remote MCP 는 opencode 의 OAuth auth cache 를 읽어 Streamable HTTP JSON-RPC 로 호출한다.
  * 로컬 게이트웨이를 쓰거나 다른 endpoint 로 보내려면 `AGENT_TOOLKIT_NOTION_MCP_URL` 로 덮어쓴다.
  */
 export const DEFAULT_NOTION_MCP_URL = "https://mcp.notion.com/mcp";
+const DEFAULT_MCP_AUTH_FILE = join(
+  homedir(),
+  ".local",
+  "share",
+  "opencode",
+  "mcp-auth.json",
+);
+const DEFAULT_NOTION_MCP_KEY = "notion";
 
 /**
  * OpenAPI / Swagger spec 다운로드 timeout 기본값.
@@ -268,14 +277,178 @@ export const DEFAULT_OPENAPI_DOWNLOAD_TIMEOUT_MS = 30_000;
 function readEnv() {
   const url =
     process.env.AGENT_TOOLKIT_NOTION_MCP_URL ?? DEFAULT_NOTION_MCP_URL;
+  const authFile =
+    process.env.AGENT_TOOLKIT_MCP_AUTH_FILE ?? DEFAULT_MCP_AUTH_FILE;
+  const authKey =
+    process.env.AGENT_TOOLKIT_NOTION_MCP_AUTH_KEY ?? DEFAULT_NOTION_MCP_KEY;
   const timeoutMs = Number.parseInt(
     process.env.AGENT_TOOLKIT_NOTION_MCP_TIMEOUT_MS ?? "15000",
     10,
   );
   return {
     url: url.replace(/\/$/, ""),
+    authFile,
+    authKey,
     timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 15_000,
   };
+}
+
+interface McpAuthEntry {
+  serverUrl?: string;
+  tokens?: {
+    accessToken?: string;
+    expiresAt?: number;
+  };
+}
+
+function readMcpAuth(): McpAuthEntry | null {
+  const { authFile, authKey } = readEnv();
+  if (!existsSync(authFile)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(authFile, "utf8")) as Record<
+      string,
+      McpAuthEntry
+    >;
+    return parsed[authKey] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function parseMcpSse(text: string): unknown {
+  const dataLines = text
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.replace(/^data:\s?/, ""));
+  const payload = dataLines.length > 0 ? dataLines.join("\n") : text;
+  return JSON.parse(payload);
+}
+
+async function postNotionMcpJsonRpc(
+  body: unknown,
+  options: { sessionId?: string; signal: AbortSignal; accessToken: string },
+): Promise<{ payload: any; sessionId?: string }> {
+  const { url } = readEnv();
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${options.accessToken}`,
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+  };
+  if (options.sessionId) headers["mcp-session-id"] = options.sessionId;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+    signal: options.signal,
+  });
+  const text = await res.text().catch(() => "");
+  if (!res.ok) {
+    throw new Error(
+      `Remote Notion MCP error ${res.status} ${res.statusText}: ${text.slice(0, 200)}`,
+    );
+  }
+  if (res.status === 202 || text.trim().length === 0) {
+    return {
+      payload: null,
+      sessionId: res.headers.get("mcp-session-id") ?? options.sessionId,
+    };
+  }
+  return {
+    payload: parseMcpSse(text),
+    sessionId: res.headers.get("mcp-session-id") ?? options.sessionId,
+  };
+}
+
+function normalizeMcpToolResult(pageId: string, payload: any): RawNotionPage {
+  if (payload?.error) {
+    throw new Error(
+      `Remote Notion MCP error ${payload.error.code ?? "unknown"}: ${payload.error.message ?? "unknown error"}`,
+    );
+  }
+
+  const text = payload?.result?.content?.find?.(
+    (item: { type?: string; text?: string }) =>
+      item?.type === "text" && typeof item.text === "string",
+  )?.text;
+  if (typeof text !== "string" || text.trim().length === 0) {
+    throw new Error(
+      "Remote Notion MCP returned malformed payload (missing text content)",
+    );
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = { text };
+  }
+
+  const url = typeof parsed.url === "string" ? parsed.url : pageId;
+  const id = resolveCacheKey(url).pageId;
+  return {
+    id,
+    title: typeof parsed.title === "string" ? parsed.title : "(untitled)",
+    markdown: typeof parsed.text === "string" ? parsed.text : text,
+  };
+}
+
+async function callAuthenticatedNotionMcp(
+  pageId: string,
+  input?: string,
+): Promise<RawNotionPage> {
+  const auth = readMcpAuth();
+  const accessToken = auth?.tokens?.accessToken;
+  if (!accessToken) {
+    throw new Error(
+      "Remote Notion MCP OAuth token not found. Run `opencode mcp list` / reconnect the Notion MCP, or set AGENT_TOOLKIT_MCP_AUTH_FILE.",
+    );
+  }
+
+  const { timeoutMs } = readEnv();
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const init = await postNotionMcpJsonRpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "agent-toolkit", version: "0.1.0" },
+        },
+      },
+      { signal: ac.signal, accessToken },
+    );
+    const sessionId = init.sessionId;
+    await postNotionMcpJsonRpc(
+      { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
+      { signal: ac.signal, accessToken, sessionId },
+    );
+    const fetched = await postNotionMcpJsonRpc(
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "notion-fetch",
+          arguments: { id: input ?? pageId },
+        },
+      },
+      { signal: ac.signal, accessToken, sessionId },
+    );
+    return normalizeMcpToolResult(pageId, fetched.payload);
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error(
+        `Remote Notion MCP request timed out after ${timeoutMs}ms (pageId=${pageId})`,
+      );
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -302,12 +475,20 @@ function readOpenapiEnv() {
  */
 export async function callRemoteNotionMcp(
   pageId: string,
+  input?: string,
 ): Promise<RawNotionPage> {
   const { url, timeoutMs } = readEnv();
+  const auth = readMcpAuth();
+  if (
+    auth?.tokens?.accessToken &&
+    (auth.serverUrl ?? "").replace(/\/$/, "") === url
+  ) {
+    return callAuthenticatedNotionMcp(pageId, input);
+  }
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), timeoutMs);
   try {
-    // 인증은 remote MCP 측 OAuth 가 처리. 이 plugin 은 헤더에 자격증명을 붙이지 않는다.
+    // 테스트/로컬 게이트웨이용 legacy endpoint. 실제 Notion remote MCP 는 위의 OAuth JSON-RPC 경로를 탄다.
     const headers: Record<string, string> = {
       "content-type": "application/json",
       accept: "application/json",
@@ -352,7 +533,7 @@ async function fetchAndCache(
   input: string,
 ): Promise<NotionPageResult> {
   const { pageId } = resolveCacheKey(input);
-  const raw = await callRemoteNotionMcp(pageId);
+  const raw = await callRemoteNotionMcp(pageId, input);
   const rawNormalized = resolveCacheKey(raw.id).pageId;
   if (rawNormalized !== pageId) {
     throw new Error(

--- a/.opencode/plugins/agent-toolkit.ts
+++ b/.opencode/plugins/agent-toolkit.ts
@@ -326,7 +326,12 @@ function parseMcpSse(text: string): unknown {
 
 async function postNotionMcpJsonRpc(
   body: unknown,
-  options: { sessionId?: string; signal: AbortSignal; accessToken: string },
+  options: {
+    sessionId?: string;
+    signal: AbortSignal;
+    accessToken: string;
+    protocolVersion?: string;
+  },
 ): Promise<{ payload: any; sessionId?: string }> {
   const { url } = readEnv();
   const headers: Record<string, string> = {
@@ -335,6 +340,9 @@ async function postNotionMcpJsonRpc(
     accept: "application/json, text/event-stream",
   };
   if (options.sessionId) headers["mcp-session-id"] = options.sessionId;
+  if (options.protocolVersion) {
+    headers["mcp-protocol-version"] = options.protocolVersion;
+  }
   const res = await fetch(url, {
     method: "POST",
     headers,
@@ -359,7 +367,7 @@ async function postNotionMcpJsonRpc(
   };
 }
 
-function normalizeMcpToolResult(pageId: string, payload: any): RawNotionPage {
+function normalizeMcpToolResult(payload: any): RawNotionPage {
   if (payload?.error) {
     throw new Error(
       `Remote Notion MCP error ${payload.error.code ?? "unknown"}: ${payload.error.message ?? "unknown error"}`,
@@ -383,8 +391,18 @@ function normalizeMcpToolResult(pageId: string, payload: any): RawNotionPage {
     parsed = { text };
   }
 
-  const url = typeof parsed.url === "string" ? parsed.url : pageId;
-  const id = resolveCacheKey(url).pageId;
+  const remoteIdentifier =
+    typeof parsed.url === "string"
+      ? parsed.url
+      : typeof parsed.id === "string"
+        ? parsed.id
+        : null;
+  if (!remoteIdentifier) {
+    throw new Error(
+      "Remote Notion MCP returned malformed payload (missing remote page identifier)",
+    );
+  }
+  const id = resolveCacheKey(remoteIdentifier).pageId;
   return {
     id,
     title: typeof parsed.title === "string" ? parsed.title : "(untitled)",
@@ -422,9 +440,13 @@ async function callAuthenticatedNotionMcp(
       { signal: ac.signal, accessToken },
     );
     const sessionId = init.sessionId;
+    const protocolVersion =
+      typeof init.payload?.result?.protocolVersion === "string"
+        ? init.payload.result.protocolVersion
+        : "2025-06-18";
     await postNotionMcpJsonRpc(
       { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
-      { signal: ac.signal, accessToken, sessionId },
+      { signal: ac.signal, accessToken, sessionId, protocolVersion },
     );
     const fetched = await postNotionMcpJsonRpc(
       {
@@ -436,9 +458,9 @@ async function callAuthenticatedNotionMcp(
           arguments: { id: input ?? pageId },
         },
       },
-      { signal: ac.signal, accessToken, sessionId },
+      { signal: ac.signal, accessToken, sessionId, protocolVersion },
     );
-    return normalizeMcpToolResult(pageId, fetched.payload);
+    return normalizeMcpToolResult(fetched.payload);
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
       throw new Error(
@@ -470,8 +492,10 @@ function readOpenapiEnv() {
 
 /**
  * remote Notion MCP 단일 호출.
- * wire format: POST `${url}/getPage` { pageId } -> RawNotionPage
- * 다른 wire 가 필요해지면 이 함수만 교체.
+ * 기본 Notion remote MCP 는 opencode OAuth auth cache 가 있으면 Streamable HTTP JSON-RPC 로
+ * `notion-fetch` tool 을 호출한다. 이때 `input` 은 tool argument 의 `id` 로 전달된다.
+ * auth cache 가 없거나 URL 이 일치하지 않으면 테스트/로컬 게이트웨이용 legacy
+ * POST `${url}/getPage` { pageId } -> RawNotionPage wire format 으로 fallback 한다.
  */
 export async function callRemoteNotionMcp(
   pageId: string,


### PR DESCRIPTION
## 요약
- `notion_get` cache miss 시 opencode MCP OAuth auth cache를 읽어 Notion remote MCP를 Streamable HTTP JSON-RPC로 호출하도록 수정
- `initialize` → `notifications/initialized` → `tools/call`(`notion-fetch`) 순서를 구현하고 `Mcp-Session-Id`를 전달
- legacy `/getPage` mock 경로는 로컬 테스트/게이트웨이 fallback으로 유지
- OAuth MCP mock 테스트를 추가해 1차 fetch + 2차 cache hit를 검증

## 검증
- `bun run typecheck`
- `bun test ./lib ./.opencode`
- `bun run check`
- 실제 `agent-toolkit notion_get` smoke: `fromCache:false` 후 cache 파일 생성, 2차 `fromCache:true` 확인 (`🧾 [테스트] 기획서 템플릿`)

## 메모
- 토큰 값은 로그/PR 본문에 노출하지 않았습니다.
- Notion 문서 변경 감지는 후속으로 `last_edited_time`/metadata preflight + content hash confirm 조합을 검토하면 좋겠습니다.

---
_Generated by 똥글이 (OpenClaw, openai-codex/gpt-5.5)_
