### PR TITLE
chore(biome): 공용 @minjun0219/biome-config extends 로 전환

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,6 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "formatter": {
-    "indentStyle": "space",
-    "indentWidth": 2
-  },
+  "extends": ["@minjun0219/biome-config"],
   "files": {
     "includes": ["**", "!.sisyphus", "!.claude", "!.archive"]
   },
@@ -12,7 +9,6 @@
   },
   "linter": {
     "rules": {
-      "recommended": true,
       "complexity": {
         "noUselessSwitchCase": "off"
       },

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,8 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@biomejs/biome": "2.4.14",
+        "@biomejs/biome": "^2.5.3",
+        "@minjun0219/biome-config": "2.1.0",
         "@types/bun": "^1.1.0",
         "@types/js-yaml": "^4.0.9",
         "@types/swagger2openapi": "^7.0.4",
@@ -31,29 +32,31 @@
 
     "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@10.1.1", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "11.7.2", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "@jsdevtools/ono": "^7.1.3", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.14", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.14", "@biomejs/cli-darwin-x64": "2.4.14", "@biomejs/cli-linux-arm64": "2.4.14", "@biomejs/cli-linux-arm64-musl": "2.4.14", "@biomejs/cli-linux-x64": "2.4.14", "@biomejs/cli-linux-x64-musl": "2.4.14", "@biomejs/cli-win32-arm64": "2.4.14", "@biomejs/cli-win32-x64": "2.4.14" }, "bin": { "biome": "bin/biome" } }, "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.3", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.3", "@biomejs/cli-darwin-x64": "2.5.3", "@biomejs/cli-linux-arm64": "2.5.3", "@biomejs/cli-linux-arm64-musl": "2.5.3", "@biomejs/cli-linux-x64": "2.5.3", "@biomejs/cli-linux-x64-musl": "2.5.3", "@biomejs/cli-win32-arm64": "2.5.3", "@biomejs/cli-win32-x64": "2.5.3" }, "bin": { "biome": "bin/biome" } }, "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.14", "", { "os": "linux", "cpu": "x64" }, "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.14", "", { "os": "win32", "cpu": "arm64" }, "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.3", "", { "os": "win32", "cpu": "x64" }, "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q=="],
 
     "@exodus/schemasafe": ["@exodus/schemasafe@1.3.0", "", {}, "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@jsdevtools/ono": ["@jsdevtools/ono@7.1.3", "", {}, "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="],
+
+    "@minjun0219/biome-config": ["@minjun0219/biome-config@2.1.0", "", { "peerDependencies": { "@biomejs/biome": ">=2.5.0" } }, "sha512-9qdgVd/YCLaBfIjvXPpCVhHAfj73S5OP3cKD3eCm1kL48D8XU21oPUCXl+uNaaELcrOXrHVeX/tH3x/3DeJd3Q=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.14",
+    "@biomejs/biome": "^2.5.3",
+    "@minjun0219/biome-config": "2.1.0",
     "@types/bun": "^1.1.0",
     "@types/js-yaml": "^4.0.9",
     "@types/swagger2openapi": "^7.0.4",

--- a/src/core/adapter.test.ts
+++ b/src/core/adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect } from 'bun:test';
 import {
   buildCombinedConfig,
   buildEphemeralSpec,
@@ -7,119 +7,109 @@ import {
   flattenRegistry,
   parseFlatHandle,
   registryToOpenApiMcpConfig,
-} from "./adapter";
-import type { OpenapiRegistry } from "./toolkit-config";
+} from './adapter';
+import type { OpenapiRegistry } from './toolkit-config';
 
-describe("flatten / parse handle", () => {
+describe('flatten / parse handle', () => {
   it("round-trips host:env:spec via ':' separator", () => {
-    expect(flattenHandle("acme", "dev", "users")).toBe("acme:dev:users");
-    expect(parseFlatHandle("acme:dev:users")).toEqual({
-      host: "acme",
-      env: "dev",
-      spec: "users",
+    expect(flattenHandle('acme', 'dev', 'users')).toBe('acme:dev:users');
+    expect(parseFlatHandle('acme:dev:users')).toEqual({
+      host: 'acme',
+      env: 'dev',
+      spec: 'users',
     });
   });
   it("rejects shapes that aren't exactly three parts", () => {
-    expect(parseFlatHandle("acme:dev")).toBeNull();
-    expect(parseFlatHandle("acme:dev:users:extra")).toBeNull();
+    expect(parseFlatHandle('acme:dev')).toBeNull();
+    expect(parseFlatHandle('acme:dev:users:extra')).toBeNull();
   });
-  it("does not collide on identifiers that contain underscores", () => {
+  it('does not collide on identifiers that contain underscores', () => {
     // ID_BODY 가 `_` 를 허용하므로 구 separator (`__`) 였다면 충돌했을 두 핸들이
     // 새 separator (`:`) 에선 서로 다른 specName 으로 떨어진다.
-    expect(flattenHandle("a", "b__c", "d")).not.toBe(
-      flattenHandle("a__b", "c", "d"),
-    );
+    expect(flattenHandle('a', 'b__c', 'd')).not.toBe(flattenHandle('a__b', 'c', 'd'));
   });
 });
 
-describe("registryToOpenApiMcpConfig", () => {
-  it("flattens host:env:spec into specs.<host:env:spec>", () => {
+describe('registryToOpenApiMcpConfig', () => {
+  it('flattens host:env:spec into specs.<host:env:spec>', () => {
     const reg: OpenapiRegistry = {
       acme: {
         dev: {
-          users: "https://example.com/u.json",
+          users: 'https://example.com/u.json',
           orders: {
-            url: "https://example.com/o.json",
-            baseUrl: "https://api.dev/o",
+            url: 'https://example.com/o.json',
+            baseUrl: 'https://api.dev/o',
           },
         },
       },
     };
     const cfg = registryToOpenApiMcpConfig(reg);
-    expect(Object.keys(cfg.specs).sort()).toEqual([
-      "acme:dev:orders",
-      "acme:dev:users",
-    ]);
-    expect(cfg.specs["acme:dev:users"]?.environments.default?.baseUrl).toBe("");
-    expect(cfg.specs["acme:dev:orders"]?.environments.default?.baseUrl).toBe(
-      "https://api.dev/o",
-    );
+    expect(Object.keys(cfg.specs).sort()).toEqual(['acme:dev:orders', 'acme:dev:users']);
+    expect(cfg.specs['acme:dev:users']?.environments.default?.baseUrl).toBe('');
+    expect(cfg.specs['acme:dev:orders']?.environments.default?.baseUrl).toBe('https://api.dev/o');
   });
 
-  it("returns empty specs map when registry is undefined", () => {
+  it('returns empty specs map when registry is undefined', () => {
     expect(registryToOpenApiMcpConfig(undefined)).toEqual({ specs: {} });
   });
 
-  it("injects defaultCacheTtlSeconds into each spec when provided", () => {
+  it('injects defaultCacheTtlSeconds into each spec when provided', () => {
     const reg: OpenapiRegistry = {
-      h: { e: { s: "https://example.com/x.json" } },
+      h: { e: { s: 'https://example.com/x.json' } },
     };
     const cfg = registryToOpenApiMcpConfig(reg, 42);
-    expect(cfg.specs["h:e:s"]?.cacheTtlSeconds).toBe(42);
+    expect(cfg.specs['h:e:s']?.cacheTtlSeconds).toBe(42);
   });
 });
 
-describe("ephemeral spec helpers", () => {
-  it("ephemeralSpecName uses url:<sha1-16> shape", () => {
-    const n = ephemeralSpecName("https://example.com/a.json");
-    expect(n.startsWith("url:")).toBe(true);
-    expect(n.length).toBe("url:".length + 16);
+describe('ephemeral spec helpers', () => {
+  it('ephemeralSpecName uses url:<sha1-16> shape', () => {
+    const n = ephemeralSpecName('https://example.com/a.json');
+    expect(n.startsWith('url:')).toBe(true);
+    expect(n.length).toBe('url:'.length + 16);
   });
-  it("buildEphemeralSpec attaches an empty-baseUrl environment", () => {
-    const { name, spec } = buildEphemeralSpec("https://example.com/a.json");
-    expect(name.startsWith("url:")).toBe(true);
-    expect(spec.environments.default?.baseUrl).toBe("");
+  it('buildEphemeralSpec attaches an empty-baseUrl environment', () => {
+    const { name, spec } = buildEphemeralSpec('https://example.com/a.json');
+    expect(name.startsWith('url:')).toBe(true);
+    expect(spec.environments.default?.baseUrl).toBe('');
   });
-  it("buildEphemeralSpec applies defaultCacheTtlSeconds when provided", () => {
-    const { spec } = buildEphemeralSpec("https://example.com/a.json", 99);
+  it('buildEphemeralSpec applies defaultCacheTtlSeconds when provided', () => {
+    const { spec } = buildEphemeralSpec('https://example.com/a.json', 99);
     expect(spec.cacheTtlSeconds).toBe(99);
   });
 });
 
-describe("buildCombinedConfig + flattenRegistry", () => {
-  it("merges registry-derived specs with ad-hoc URL specs and dedupes URLs", () => {
+describe('buildCombinedConfig + flattenRegistry', () => {
+  it('merges registry-derived specs with ad-hoc URL specs and dedupes URLs', () => {
     const reg: OpenapiRegistry = {
-      acme: { dev: { u: "https://example.com/u.json" } },
+      acme: { dev: { u: 'https://example.com/u.json' } },
     };
     const combined = buildCombinedConfig({
       registry: reg,
-      ephemeralUrls: [
-        "https://example.com/x.json",
-        "https://example.com/x.json",
-      ],
+      ephemeralUrls: ['https://example.com/x.json', 'https://example.com/x.json'],
     });
     expect(Object.keys(combined.specs).length).toBe(2);
   });
 
-  it("flattenRegistry includes baseUrl/format only when present", () => {
+  it('flattenRegistry includes baseUrl/format only when present', () => {
     const reg: OpenapiRegistry = {
       acme: {
         dev: {
-          a: "https://example.com/a.json",
+          a: 'https://example.com/a.json',
           b: {
-            url: "https://example.com/b.json",
-            baseUrl: "https://api/b",
-            format: "swagger2",
+            url: 'https://example.com/b.json',
+            baseUrl: 'https://api/b',
+            format: 'swagger2',
           },
         },
       },
     };
     const rows = flattenRegistry(reg);
-    const a = rows.find((r) => r.spec === "a");
-    const b = rows.find((r) => r.spec === "b");
+    const a = rows.find((r) => r.spec === 'a');
+    const b = rows.find((r) => r.spec === 'b');
     expect(a?.baseUrl).toBeUndefined();
     expect(a?.format).toBeUndefined();
-    expect(b?.baseUrl).toBe("https://api/b");
-    expect(b?.format).toBe("swagger2");
+    expect(b?.baseUrl).toBe('https://api/b');
+    expect(b?.format).toBe('swagger2');
   });
 });

--- a/src/core/adapter.ts
+++ b/src/core/adapter.ts
@@ -1,17 +1,17 @@
-import { createHash } from "node:crypto";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import {
   type OpenapiRegistry,
   type OpenapiRegistryLeaf,
   getRegistryUrl,
   getRegistryBaseUrl,
   getRegistryFormat,
-} from "./toolkit-config";
-import type { EnvironmentConfig, OpenApiMcpConfig, SpecConfig } from "./schema";
-import { createDiskCache, createNoopDiskCache, type DiskCache } from "./cache";
-import { createFetcher, type FetcherOptions } from "./fetcher";
-import { createSpecRegistry, type SpecRegistry } from "./registry";
+} from './toolkit-config';
+import type { EnvironmentConfig, OpenApiMcpConfig, SpecConfig } from './schema';
+import { createDiskCache, createNoopDiskCache, type DiskCache } from './cache';
+import { createFetcher, type FetcherOptions } from './fetcher';
+import { createSpecRegistry, type SpecRegistry } from './registry';
 
 /**
  * agent-toolkit 의 `openapi.registry` 트리를 SpecRegistry 가 받는 `OpenApiMcpConfig`
@@ -35,7 +35,7 @@ import { createSpecRegistry, type SpecRegistry } from "./registry";
  */
 
 /** flat handle (`host:env:spec`) 과 원래 host/env/spec 을 양방향 변환. */
-export const HANDLE_SEPARATOR = ":";
+export const HANDLE_SEPARATOR = ':';
 
 export function flattenHandle(host: string, env: string, spec: string): string {
   return `${host}${HANDLE_SEPARATOR}${env}${HANDLE_SEPARATOR}${spec}`;
@@ -49,13 +49,17 @@ export interface ParsedFlatHandle {
 
 export function parseFlatHandle(flat: string): ParsedFlatHandle | null {
   const parts = flat.split(HANDLE_SEPARATOR);
-  if (parts.length !== 3) return null;
+  if (parts.length !== 3) {
+    return null;
+  }
   const [host, env, spec] = parts as [string, string, string];
-  if (!host || !env || !spec) return null;
+  if (!host || !env || !spec) {
+    return null;
+  }
   return { host, env, spec };
 }
 
-export const DEFAULT_ENVIRONMENT = "default";
+export const DEFAULT_ENVIRONMENT = 'default';
 
 /**
  * registry 트리 → OpenApiMcpConfig.specs 변환. registry 가 비어 있거나 undefined 면
@@ -82,11 +86,11 @@ export function registryToOpenApiMcpConfig(
         const format = getRegistryFormat(leaf);
         const name = flattenHandle(host, env, spec);
         const environment: EnvironmentConfig = {
-          baseUrl: baseUrl ?? "",
+          baseUrl: baseUrl ?? '',
         };
         const source = format
-          ? { type: "url" as const, url, format }
-          : { type: "url" as const, url };
+          ? { type: 'url' as const, url, format }
+          : { type: 'url' as const, url };
         specs[name] = {
           source,
           environments: { [DEFAULT_ENVIRONMENT]: environment },
@@ -109,7 +113,7 @@ export function registryToOpenApiMcpConfig(
  * 달라서 (2 vs 3) 충돌하지 않는다.
  */
 export function ephemeralSpecName(url: string): string {
-  const hash = createHash("sha1").update(url).digest("hex").slice(0, 16);
+  const hash = createHash('sha1').update(url).digest('hex').slice(0, 16);
   return `url${HANDLE_SEPARATOR}${hash}`;
 }
 
@@ -122,13 +126,11 @@ export function buildEphemeralSpec(
 } {
   const name = ephemeralSpecName(url);
   const spec: SpecConfig = {
-    source: { type: "url", url },
+    source: { type: 'url', url },
     environments: {
-      [DEFAULT_ENVIRONMENT]: { baseUrl: "" },
+      [DEFAULT_ENVIRONMENT]: { baseUrl: '' },
     },
-    ...(defaultCacheTtlSeconds !== undefined
-      ? { cacheTtlSeconds: defaultCacheTtlSeconds }
-      : {}),
+    ...(defaultCacheTtlSeconds !== undefined ? { cacheTtlSeconds: defaultCacheTtlSeconds } : {}),
   };
   return { name, spec };
 }
@@ -152,22 +154,16 @@ export interface CombinedConfigOptions {
   defaultCacheTtlSeconds?: number;
 }
 
-export function buildCombinedConfig(
-  options: CombinedConfigOptions,
-): OpenApiMcpConfig {
-  const base = registryToOpenApiMcpConfig(
-    options.registry,
-    options.defaultCacheTtlSeconds,
-  );
+export function buildCombinedConfig(options: CombinedConfigOptions): OpenApiMcpConfig {
+  const base = registryToOpenApiMcpConfig(options.registry, options.defaultCacheTtlSeconds);
   if (options.ephemeralUrls) {
     const seen = new Set<string>();
     for (const url of options.ephemeralUrls) {
-      if (seen.has(url)) continue;
+      if (seen.has(url)) {
+        continue;
+      }
       seen.add(url);
-      const { name, spec } = buildEphemeralSpec(
-        url,
-        options.defaultCacheTtlSeconds,
-      );
+      const { name, spec } = buildEphemeralSpec(url, options.defaultCacheTtlSeconds);
       base.specs[name] = spec;
     }
   }
@@ -200,9 +196,7 @@ export function createAgentToolkitRegistry(
   const ttl = resolveOpenapiTtlSecondsFromEnv();
   const config = buildCombinedConfig({
     ...(options.registry !== undefined ? { registry: options.registry } : {}),
-    ...(options.ephemeralUrls !== undefined
-      ? { ephemeralUrls: options.ephemeralUrls }
-      : {}),
+    ...(options.ephemeralUrls !== undefined ? { ephemeralUrls: options.ephemeralUrls } : {}),
     ...(ttl !== undefined ? { defaultCacheTtlSeconds: ttl } : {}),
   });
   // SpecRegistry 의 zod 스키마는 specs 가 1개 이상이어야 통과하지만, 우린 zod 검증을
@@ -225,16 +219,12 @@ export function createAgentToolkitRegistry(
 
 function resolveOpenapiCacheDir(): string {
   const override = process.env.AGENT_TOOLKIT_OPENAPI_CACHE_DIR;
-  if (override && override.trim().length > 0) return override;
+  if (override && override.trim().length > 0) {
+    return override;
+  }
   // 구 `lib/openapi-context.ts` 의 default 와 동일한 위치로 통일.
   // (.config/opencode/agent-toolkit/openapi-specs)
-  return join(
-    homedir(),
-    ".config",
-    "opencode",
-    "agent-toolkit",
-    "openapi-specs",
-  );
+  return join(homedir(), '.config', 'opencode', 'agent-toolkit', 'openapi-specs');
 }
 
 /**
@@ -245,9 +235,13 @@ function resolveOpenapiCacheDir(): string {
  */
 export function resolveOpenapiTtlSecondsFromEnv(): number | undefined {
   const raw = process.env.AGENT_TOOLKIT_OPENAPI_CACHE_TTL;
-  if (raw === undefined) return undefined;
+  if (raw === undefined) {
+    return undefined;
+  }
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
   return parsed;
 }
 
@@ -268,16 +262,18 @@ export function resolveFetcherOptionsFromEnv(): FetcherOptions {
   const timeoutRaw = process.env.AGENT_TOOLKIT_OPENAPI_DOWNLOAD_TIMEOUT_MS;
   if (timeoutRaw !== undefined) {
     const parsed = Number.parseInt(timeoutRaw, 10);
-    if (Number.isFinite(parsed) && parsed > 0) out.timeoutMs = parsed;
+    if (Number.isFinite(parsed) && parsed > 0) {
+      out.timeoutMs = parsed;
+    }
   }
   const insecureRaw = process.env.AGENT_TOOLKIT_OPENAPI_INSECURE_TLS;
-  if (insecureRaw === "1" || insecureRaw === "true") {
+  if (insecureRaw === '1' || insecureRaw === 'true') {
     out.insecureTls = true;
   }
   const cas = process.env.AGENT_TOOLKIT_OPENAPI_EXTRA_CA_CERTS;
   if (cas !== undefined && cas.trim().length > 0) {
     out.extraCaCerts = cas
-      .split(":")
+      .split(':')
       .map((s) => s.trim())
       .filter((s) => s.length > 0);
   }
@@ -291,16 +287,16 @@ export interface FlatRegistryRow {
   spec: string;
   url: string;
   baseUrl?: string;
-  format?: "openapi3" | "swagger2" | "auto";
+  format?: 'openapi3' | 'swagger2' | 'auto';
   /** flatten 된 SpecRegistry 등록 이름 (`host:env:spec`). 디버깅용. */
   registryName: string;
 }
 
-export function flattenRegistry(
-  registry: OpenapiRegistry | undefined,
-): FlatRegistryRow[] {
+export function flattenRegistry(registry: OpenapiRegistry | undefined): FlatRegistryRow[] {
   const out: FlatRegistryRow[] = [];
-  if (!registry) return out;
+  if (!registry) {
+    return out;
+  }
   for (const [host, envs] of Object.entries(registry)) {
     for (const [env, leafSpecs] of Object.entries(envs)) {
       for (const [spec, leaf] of Object.entries(leafSpecs)) {
@@ -314,8 +310,12 @@ export function flattenRegistry(
           url,
           registryName: flattenHandle(host, env, spec),
         };
-        if (baseUrl !== undefined) row.baseUrl = baseUrl;
-        if (format !== undefined) row.format = format;
+        if (baseUrl !== undefined) {
+          row.baseUrl = baseUrl;
+        }
+        if (format !== undefined) {
+          row.format = format;
+        }
         out.push(row);
       }
     }

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,8 +1,8 @@
-import { createHash } from "node:crypto";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import path from "node:path";
-import type { SpecSource } from "./schema";
-import { getLogger } from "./logger";
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { SpecSource } from './schema';
+import { getLogger } from './logger';
 
 /**
  * SpecRegistry 가 사용하는 디스크 캐시. 한 spec source 당 한 파일을 둔다 — JSON 으로
@@ -19,7 +19,7 @@ export interface DiskCacheEntry {
   etag?: string;
   lastModified?: string;
   source: SpecSource;
-  detectedFormat: "openapi3" | "swagger2";
+  detectedFormat: 'openapi3' | 'swagger2';
   document: object;
 }
 
@@ -55,19 +55,18 @@ class FsDiskCache implements DiskCache {
   async read(cacheKey: string): Promise<DiskCacheEntry | null> {
     const file = this.fileFor(cacheKey);
     try {
-      const raw = await readFile(file, "utf8");
+      const raw = await readFile(file, 'utf8');
       const parsed = JSON.parse(raw) as DiskCacheEntry;
       if (parsed.schemaVersion !== 1) {
-        getLogger().debug(
-          { cacheKey, file },
-          "disk cache schemaVersion mismatch; ignoring",
-        );
+        getLogger().debug({ cacheKey, file }, 'disk cache schemaVersion mismatch; ignoring');
         return null;
       }
       return parsed;
     } catch (err) {
-      if (isNotFoundError(err)) return null;
-      getLogger().warn({ err, file }, "failed to read disk cache entry");
+      if (isNotFoundError(err)) {
+        return null;
+      }
+      getLogger().warn({ err, file }, 'failed to read disk cache entry');
       return null;
     }
   }
@@ -77,11 +76,11 @@ class FsDiskCache implements DiskCache {
     try {
       await mkdir(path.dirname(file), { recursive: true });
       const tmp = `${file}.tmp-${process.pid}-${Date.now()}`;
-      await writeFile(tmp, JSON.stringify(entry), "utf8");
-      const { rename } = await import("node:fs/promises");
+      await writeFile(tmp, JSON.stringify(entry), 'utf8');
+      const { rename } = await import('node:fs/promises');
       await rename(tmp, file);
     } catch (err) {
-      getLogger().warn({ err, file }, "failed to persist disk cache entry");
+      getLogger().warn({ err, file }, 'failed to persist disk cache entry');
     }
   }
 
@@ -90,21 +89,21 @@ class FsDiskCache implements DiskCache {
     try {
       await rm(file, { force: true });
     } catch (err) {
-      getLogger().debug({ err, file }, "failed to delete disk cache entry");
+      getLogger().debug({ err, file }, 'failed to delete disk cache entry');
     }
   }
 
   private fileFor(cacheKey: string): string {
-    const hash = createHash("sha1").update(cacheKey).digest("hex").slice(0, 16);
+    const hash = createHash('sha1').update(cacheKey).digest('hex').slice(0, 16);
     return path.join(this.dir, `${hash}.json`);
   }
 }
 
 function isNotFoundError(err: unknown): boolean {
   return (
-    typeof err === "object" &&
+    typeof err === 'object' &&
     err !== null &&
-    "code" in err &&
-    (err as { code?: string }).code === "ENOENT"
+    'code' in err &&
+    (err as { code?: string }).code === 'ENOENT'
   );
 }

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -1,9 +1,9 @@
-import os from "node:os";
-import path from "node:path";
-import { readFile } from "node:fs/promises";
-import yaml from "js-yaml";
-import { ZodError } from "zod";
-import { OpenApiMcpConfigSchema, type OpenApiMcpConfig } from "./schema";
+import os from 'node:os';
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import yaml from 'js-yaml';
+import { ZodError } from 'zod';
+import { OpenApiMcpConfigSchema, type OpenApiMcpConfig } from './schema';
 
 /**
  * `bin/openapi-mcp` 단독 진입점이 받는 config 파일 (`openapi-mcp.json` /
@@ -17,7 +17,7 @@ export class ConfigError extends Error {
     public override readonly cause?: unknown,
   ) {
     super(message);
-    this.name = "ConfigError";
+    this.name = 'ConfigError';
   }
 }
 
@@ -29,28 +29,25 @@ export interface LoadedConfig {
 /** XDG 우선 기본 config 경로. CLI `--config` 가 없을 때 사용. */
 export function defaultConfigPath(): string {
   const xdg = process.env.XDG_CONFIG_HOME;
-  const base = xdg && xdg.length > 0 ? xdg : path.join(os.homedir(), ".config");
-  return path.join(base, "openapi-mcp", "openapi-mcp.json");
+  const base = xdg && xdg.length > 0 ? xdg : path.join(os.homedir(), '.config');
+  return path.join(base, 'openapi-mcp', 'openapi-mcp.json');
 }
 
 /** XDG 우선 기본 디스크 캐시 디렉토리. config.cache.diskCachePath 가 없을 때 사용. */
 export function defaultDiskCacheDir(): string {
   const xdg = process.env.XDG_CACHE_HOME;
-  const base = xdg && xdg.length > 0 ? xdg : path.join(os.homedir(), ".cache");
-  return path.join(base, "openapi-mcp");
+  const base = xdg && xdg.length > 0 ? xdg : path.join(os.homedir(), '.cache');
+  return path.join(base, 'openapi-mcp');
 }
 
 export async function loadConfig(configPath: string): Promise<LoadedConfig> {
   const absolute = path.resolve(configPath);
   let raw: string;
   try {
-    raw = await readFile(absolute, "utf8");
+    raw = await readFile(absolute, 'utf8');
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    throw new ConfigError(
-      `failed to read config file at ${absolute}: ${reason}`,
-      err,
-    );
+    throw new ConfigError(`failed to read config file at ${absolute}: ${reason}`, err);
   }
 
   const parsed = parseByExtension(absolute, raw);
@@ -67,14 +64,14 @@ export async function loadConfig(configPath: string): Promise<LoadedConfig> {
 
 function parseByExtension(filePath: string, raw: string): unknown {
   const ext = path.extname(filePath).toLowerCase();
-  if (ext === ".json") {
+  if (ext === '.json') {
     try {
       return JSON.parse(raw);
     } catch (err) {
       throw new ConfigError(`failed to parse JSON config at ${filePath}`, err);
     }
   }
-  if (ext === ".yaml" || ext === ".yml") {
+  if (ext === '.yaml' || ext === '.yml') {
     try {
       return yaml.load(raw);
     } catch (err) {
@@ -88,8 +85,8 @@ function parseByExtension(filePath: string, raw: string): unknown {
 
 function formatZodError(filePath: string, err: ZodError): string {
   const lines = err.issues.map((issue) => {
-    const where = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+    const where = issue.path.length > 0 ? issue.path.join('.') : '<root>';
     return `  - ${where}: ${issue.message}`;
   });
-  return `invalid config at ${filePath}:\n${lines.join("\n")}`;
+  return `invalid config at ${filePath}:\n${lines.join('\n')}`;
 }

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -1,6 +1,6 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import type { SpecSource } from "./schema";
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { SpecSource } from './schema';
 
 /**
  * spec 소스 (URL 또는 file path) 에서 raw 본문을 가져온다. URL 모드에서는 etag /
@@ -32,7 +32,7 @@ export class SpecFetchError extends Error {
     public override readonly cause?: unknown,
   ) {
     super(message);
-    this.name = "SpecFetchError";
+    this.name = 'SpecFetchError';
   }
 }
 
@@ -65,10 +65,7 @@ export interface FetcherOptions {
 }
 
 export interface SpecFetcher {
-  fetch(
-    source: SpecSource,
-    conditional?: ConditionalHeaders,
-  ): Promise<FetchOutcome>;
+  fetch(source: SpecSource, conditional?: ConditionalHeaders): Promise<FetchOutcome>;
 }
 
 export function createFetcher(options: FetcherOptions = {}): SpecFetcher {
@@ -77,27 +74,22 @@ export function createFetcher(options: FetcherOptions = {}): SpecFetcher {
 
 class DefaultSpecFetcher implements SpecFetcher {
   /** TLS 옵션이 한 번 빌드되면 캐시 — extraCaCerts 의 파일 read 를 매 요청마다 하지 않음. */
-  private tlsInitCache: BunRequestInit["tls"] | undefined;
+  private tlsInitCache: BunRequestInit['tls'] | undefined;
   private tlsInitResolved = false;
 
   constructor(private readonly options: FetcherOptions) {}
 
-  async fetch(
-    source: SpecSource,
-    conditional?: ConditionalHeaders,
-  ): Promise<FetchOutcome> {
-    if (source.type === "file") {
+  async fetch(source: SpecSource, conditional?: ConditionalHeaders): Promise<FetchOutcome> {
+    if (source.type === 'file') {
       return this.fetchFile(source);
     }
     return this.fetchUrl(source, conditional);
   }
 
-  private async fetchFile(
-    source: Extract<SpecSource, { type: "file" }>,
-  ): Promise<FetchResult> {
+  private async fetchFile(source: Extract<SpecSource, { type: 'file' }>): Promise<FetchResult> {
     const absolute = path.resolve(source.path);
     try {
-      const body = await readFile(absolute, "utf8");
+      const body = await readFile(absolute, 'utf8');
       return {
         body,
         fetchedAt: new Date().toISOString(),
@@ -106,40 +98,35 @@ class DefaultSpecFetcher implements SpecFetcher {
       };
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
-      throw new SpecFetchError(
-        `failed to read spec file ${absolute}: ${reason}`,
-        undefined,
-        err,
-      );
+      throw new SpecFetchError(`failed to read spec file ${absolute}: ${reason}`, undefined, err);
     }
   }
 
   private async fetchUrl(
-    source: Extract<SpecSource, { type: "url" }>,
+    source: Extract<SpecSource, { type: 'url' }>,
     conditional?: ConditionalHeaders,
   ): Promise<FetchOutcome> {
     const headers: Record<string, string> = {
-      Accept:
-        "application/json, application/yaml;q=0.9, text/yaml;q=0.9, */*;q=0.1",
+      Accept: 'application/json, application/yaml;q=0.9, text/yaml;q=0.9, */*;q=0.1',
     };
-    if (conditional?.etag) headers["If-None-Match"] = conditional.etag;
-    if (conditional?.lastModified)
-      headers["If-Modified-Since"] = conditional.lastModified;
+    if (conditional?.etag) {
+      headers['If-None-Match'] = conditional.etag;
+    }
+    if (conditional?.lastModified) {
+      headers['If-Modified-Since'] = conditional.lastModified;
+    }
 
     const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(),
-      this.options.timeoutMs ?? 10_000,
-    );
+    const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs ?? 10_000);
 
     try {
       const tls = await this.resolveTlsInit();
       const init: BunRequestInit = {
-        method: "GET",
+        method: 'GET',
         headers,
         signal: controller.signal,
         // redirect 는 follow (기본) — spec serve 가 흔히 redirect 를 끼므로.
-        redirect: "follow",
+        redirect: 'follow',
         ...(tls ? { tls } : {}),
       };
       const response = await fetch(source.url, init);
@@ -158,8 +145,8 @@ class DefaultSpecFetcher implements SpecFetcher {
       }
 
       const body = await response.text();
-      const etag = response.headers.get("etag") ?? undefined;
-      const lastModified = response.headers.get("last-modified") ?? undefined;
+      const etag = response.headers.get('etag') ?? undefined;
+      const lastModified = response.headers.get('last-modified') ?? undefined;
       return {
         body,
         ...(etag !== undefined ? { etag } : {}),
@@ -169,13 +156,11 @@ class DefaultSpecFetcher implements SpecFetcher {
         source,
       };
     } catch (err) {
-      if (err instanceof SpecFetchError) throw err;
+      if (err instanceof SpecFetchError) {
+        throw err;
+      }
       const reason = err instanceof Error ? err.message : String(err);
-      throw new SpecFetchError(
-        `failed to fetch ${source.url}: ${reason}`,
-        undefined,
-        err,
-      );
+      throw new SpecFetchError(`failed to fetch ${source.url}: ${reason}`, undefined, err);
     } finally {
       clearTimeout(timeout);
     }
@@ -189,18 +174,17 @@ class DefaultSpecFetcher implements SpecFetcher {
    *
    * `extraCaCerts` 의 파일 read 는 첫 호출에서만 일어나고 결과 객체를 캐시한다.
    */
-  private async resolveTlsInit(): Promise<BunRequestInit["tls"] | undefined> {
-    if (this.tlsInitResolved) return this.tlsInitCache;
+  private async resolveTlsInit(): Promise<BunRequestInit['tls'] | undefined> {
+    if (this.tlsInitResolved) {
+      return this.tlsInitCache;
+    }
     if (this.options.insecureTls === true) {
       this.tlsInitCache = { rejectUnauthorized: false };
-    } else if (
-      this.options.extraCaCerts !== undefined &&
-      this.options.extraCaCerts.length > 0
-    ) {
+    } else if (this.options.extraCaCerts !== undefined && this.options.extraCaCerts.length > 0) {
       const cas = await Promise.all(
         this.options.extraCaCerts.map(async (p) => {
           try {
-            return await readFile(p, "utf8");
+            return await readFile(p, 'utf8');
           } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
             throw new SpecFetchError(

--- a/src/core/filter.test.ts
+++ b/src/core/filter.test.ts
@@ -1,49 +1,43 @@
-import { describe, it, expect } from "bun:test";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { parseSpecText } from "./parser";
-import { indexSpec } from "./indexer";
-import { filterEndpoints } from "./filter";
+import { describe, it, expect } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseSpecText } from './parser';
+import { indexSpec } from './indexer';
+import { filterEndpoints } from './filter';
 
-const FIX = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "__fixtures__",
-);
-const PETSTORE_3 = path.join(FIX, "petstore-3.0.json");
+const FIX = path.join(path.dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+const PETSTORE_3 = path.join(FIX, 'petstore-3.0.json');
 
 async function loadEndpoints() {
-  const raw = await readFile(PETSTORE_3, "utf8");
+  const raw = await readFile(PETSTORE_3, 'utf8');
   const { document } = await parseSpecText(raw);
-  return indexSpec("petstore", document).endpoints;
+  return indexSpec('petstore', document).endpoints;
 }
 
-describe("filterEndpoints", () => {
-  it("filters by tag", async () => {
+describe('filterEndpoints', () => {
+  it('filters by tag', async () => {
     const endpoints = await loadEndpoints();
-    const tagFiltered = filterEndpoints(endpoints, { tag: "store" });
-    expect(tagFiltered.map((e) => e.path).sort()).toEqual([
-      "/store/inventory",
-      "/store/order",
-    ]);
+    const tagFiltered = filterEndpoints(endpoints, { tag: 'store' });
+    expect(tagFiltered.map((e) => e.path).sort()).toEqual(['/store/inventory', '/store/order']);
   });
 
-  it("filters by HTTP method", async () => {
+  it('filters by HTTP method', async () => {
     const endpoints = await loadEndpoints();
-    const posts = filterEndpoints(endpoints, { method: "POST" });
-    expect(posts.map((e) => e.path).sort()).toEqual(["/pet", "/store/order"]);
+    const posts = filterEndpoints(endpoints, { method: 'POST' });
+    expect(posts.map((e) => e.path).sort()).toEqual(['/pet', '/store/order']);
   });
 
-  it("keyword matches operationId, path, summary, description", async () => {
+  it('keyword matches operationId, path, summary, description', async () => {
     const endpoints = await loadEndpoints();
-    const hits = filterEndpoints(endpoints, { keyword: "inventory" });
-    expect(hits.map((e) => e.path)).toEqual(["/store/inventory"]);
+    const hits = filterEndpoints(endpoints, { keyword: 'inventory' });
+    expect(hits.map((e) => e.path)).toEqual(['/store/inventory']);
   });
 
-  it("orders matches by where the keyword hits (operationId > path > summary)", async () => {
+  it('orders matches by where the keyword hits (operationId > path > summary)', async () => {
     const endpoints = await loadEndpoints();
-    const ranked = filterEndpoints(endpoints, { keyword: "pet" });
+    const ranked = filterEndpoints(endpoints, { keyword: 'pet' });
     expect(ranked[0]).toBeDefined();
-    expect(ranked[0]?.operationId?.toLowerCase().includes("pet")).toBe(true);
+    expect(ranked[0]?.operationId?.toLowerCase().includes('pet')).toBe(true);
   });
 });

--- a/src/core/filter.ts
+++ b/src/core/filter.ts
@@ -1,4 +1,4 @@
-import type { HttpMethod, IndexedEndpoint } from "./indexer";
+import type { HttpMethod, IndexedEndpoint } from './indexer';
 
 /**
  * `openapi_search` / `list_endpoints` 에서 쓰는 필터 + 점수화 검색.
@@ -32,16 +32,24 @@ export function filterEndpoints(
   const scored: ScoredEndpoint[] = [];
 
   for (const ep of endpoints) {
-    if (filter.spec && ep.specName !== filter.spec) continue;
-    if (filter.tag && !ep.tags.includes(filter.tag)) continue;
-    if (filter.method && ep.method !== filter.method) continue;
+    if (filter.spec && ep.specName !== filter.spec) {
+      continue;
+    }
+    if (filter.tag && !ep.tags.includes(filter.tag)) {
+      continue;
+    }
+    if (filter.method && ep.method !== filter.method) {
+      continue;
+    }
 
     if (!keyword) {
       scored.push({ endpoint: ep, score: 0 });
       continue;
     }
     const score = scoreKeyword(ep, keyword);
-    if (score > 0) scored.push({ endpoint: ep, score });
+    if (score > 0) {
+      scored.push({ endpoint: ep, score });
+    }
   }
 
   if (keyword) {
@@ -52,11 +60,17 @@ export function filterEndpoints(
 
 function scoreKeyword(ep: IndexedEndpoint, keyword: string): number {
   let score = 0;
-  if (ep.operationId?.toLowerCase().includes(keyword))
+  if (ep.operationId?.toLowerCase().includes(keyword)) {
     score += SCORE_OPERATION_ID;
-  if (ep.path.toLowerCase().includes(keyword)) score += SCORE_PATH;
-  if (ep.summary?.toLowerCase().includes(keyword)) score += SCORE_SUMMARY;
-  if (ep.description?.toLowerCase().includes(keyword))
+  }
+  if (ep.path.toLowerCase().includes(keyword)) {
+    score += SCORE_PATH;
+  }
+  if (ep.summary?.toLowerCase().includes(keyword)) {
+    score += SCORE_SUMMARY;
+  }
+  if (ep.description?.toLowerCase().includes(keyword)) {
     score += SCORE_DESCRIPTION;
+  }
   return score;
 }

--- a/src/core/handlers.test.ts
+++ b/src/core/handlers.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach } from "bun:test";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { createAgentToolkitRegistry } from "./adapter";
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createAgentToolkitRegistry } from './adapter';
 import {
   handleSwaggerEndpoint,
   handleSwaggerEnvs,
@@ -10,39 +10,34 @@ import {
   handleSwaggerSearch,
   handleSwaggerStatus,
   handleSwaggerTags,
-} from "./handlers";
-import type { OpenapiRegistry } from "./toolkit-config";
+} from './handlers';
+import type { OpenapiRegistry } from './toolkit-config';
 
-const FIXTURE_DIR = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "__fixtures__",
-);
-const PETSTORE_3 = `file://${join(FIXTURE_DIR, "petstore-3.0.json")}`;
-const PETSTORE_2 = `file://${join(FIXTURE_DIR, "petstore-2.0.json")}`;
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+const PETSTORE_3 = `file://${join(FIXTURE_DIR, 'petstore-3.0.json')}`;
+const PETSTORE_2 = `file://${join(FIXTURE_DIR, 'petstore-2.0.json')}`;
 
-describe("openapi handlers — file URL inputs", () => {
-  it("openapi_get: file URL input gets parsed + dereferenced + cached", async () => {
+describe('openapi handlers — file URL inputs', () => {
+  it('openapi_get: file URL input gets parsed + dereferenced + cached', async () => {
     const reg = createAgentToolkitRegistry({ diskCacheDisabled: true });
     const r = await handleSwaggerGet(reg, PETSTORE_3);
     expect(r.fromCache).toBe(false);
-    expect(r.document.openapi?.startsWith("3.")).toBe(true);
-    expect(r.document.info?.title).toBe("Swagger Petstore");
+    expect(r.document.openapi?.startsWith('3.')).toBe(true);
+    expect(r.document.info?.title).toBe('Swagger Petstore');
     // 두 번째 호출은 메모리 캐시 hit.
     const r2 = await handleSwaggerGet(reg, PETSTORE_3);
     expect(r2.fromCache).toBe(true);
   });
 
-  it("openapi_get: swagger 2.0 fixture is auto-converted to OpenAPI 3", async () => {
+  it('openapi_get: swagger 2.0 fixture is auto-converted to OpenAPI 3', async () => {
     const reg = createAgentToolkitRegistry({ diskCacheDisabled: true });
     const r = await handleSwaggerGet(reg, PETSTORE_2);
-    expect(r.document.openapi?.startsWith("3.")).toBe(true);
+    expect(r.document.openapi?.startsWith('3.')).toBe(true);
     // swagger 본문엔 swagger 필드가 있었지만 변환 후엔 openapi 만 있어야 한다.
-    expect(
-      (r.document as unknown as Record<string, unknown>).swagger,
-    ).toBeUndefined();
+    expect((r.document as unknown as Record<string, unknown>).swagger).toBeUndefined();
   });
 
-  it("openapi_status / openapi_refresh: cache lifecycle", async () => {
+  it('openapi_status / openapi_refresh: cache lifecycle', async () => {
     const reg = createAgentToolkitRegistry({ diskCacheDisabled: true });
     const before = await handleSwaggerStatus(reg, PETSTORE_3);
     expect(before.cacheStatus.cached).toBe(false);
@@ -56,10 +51,10 @@ describe("openapi handlers — file URL inputs", () => {
     expect(refreshed[0]?.success).toBe(true);
   });
 
-  it("openapi_search: scored keyword across loaded specs", async () => {
+  it('openapi_search: scored keyword across loaded specs', async () => {
     const reg = createAgentToolkitRegistry({ diskCacheDisabled: true });
     await handleSwaggerGet(reg, PETSTORE_3);
-    const matches = await handleSwaggerSearch(reg, "pet");
+    const matches = await handleSwaggerSearch(reg, 'pet');
     expect(matches.length).toBeGreaterThan(0);
     // 점수화 검색은 operationId / path / summary / description 모두를 본다 — petstore
     // 의 store / user 도메인도 summary 에 "pet" 단어가 있으면 매칭될 수 있다. 핵심은
@@ -67,45 +62,42 @@ describe("openapi handlers — file URL inputs", () => {
     const top = matches[0];
     expect(top).toBeDefined();
     expect(
-      top!.path.toLowerCase().includes("pet") ||
-        top!.operationId.toLowerCase().includes("pet"),
+      top!.path.toLowerCase().includes('pet') || top!.operationId.toLowerCase().includes('pet'),
     ).toBe(true);
 
-    const limited = await handleSwaggerSearch(reg, "", { limit: 2 });
+    const limited = await handleSwaggerSearch(reg, '', { limit: 2 });
     expect(limited.length).toBe(2);
   });
 
-  it("openapi_endpoint: returns full detail with fullUrl", async () => {
+  it('openapi_endpoint: returns full detail with fullUrl', async () => {
     const reg = createAgentToolkitRegistry({ diskCacheDisabled: true });
     const detail = await handleSwaggerEndpoint(reg, PETSTORE_3, {
-      method: "GET",
-      path: "/pet/{petId}",
+      method: 'GET',
+      path: '/pet/{petId}',
     });
-    expect(detail.endpoint.method).toBe("GET");
-    expect(detail.endpoint.path).toBe("/pet/{petId}");
-    expect(detail.endpoint.parameters.some((p) => p.name === "petId")).toBe(
-      true,
-    );
+    expect(detail.endpoint.method).toBe('GET');
+    expect(detail.endpoint.path).toBe('/pet/{petId}');
+    expect(detail.endpoint.parameters.some((p) => p.name === 'petId')).toBe(true);
     // baseUrl 미선언이라 fullUrl 은 path 자체.
-    expect(detail.endpoint.fullUrl).toBe("/pet/{petId}");
+    expect(detail.endpoint.fullUrl).toBe('/pet/{petId}');
   });
 
-  it("openapi_tags: returns tag summaries", async () => {
+  it('openapi_tags: returns tag summaries', async () => {
     const reg = createAgentToolkitRegistry({ diskCacheDisabled: true });
     const r = await handleSwaggerTags(reg, PETSTORE_3);
     expect(r.tags.length).toBeGreaterThan(0);
-    expect(r.tags[0]).toHaveProperty("endpointCount");
+    expect(r.tags[0]).toHaveProperty('endpointCount');
   });
 
-  it("rejects non-URL non-handle inputs clearly", async () => {
+  it('rejects non-URL non-handle inputs clearly', async () => {
     const reg = createAgentToolkitRegistry({ diskCacheDisabled: true });
-    await expect(handleSwaggerGet(reg, "not-a-url")).rejects.toThrow(
+    await expect(handleSwaggerGet(reg, 'not-a-url')).rejects.toThrow(
       /not a host:env:spec handle or http\(s\)\/file URL/,
     );
   });
 });
 
-describe("openapi handlers — registry handles", () => {
+describe('openapi handlers — registry handles', () => {
   let registry: OpenapiRegistry;
 
   beforeEach(() => {
@@ -115,7 +107,7 @@ describe("openapi handlers — registry handles", () => {
         dev: {
           users: PETSTORE_3,
           // object leaf — baseUrl 합성을 검증.
-          orders: { url: PETSTORE_3, baseUrl: "https://api.dev/orders" },
+          orders: { url: PETSTORE_3, baseUrl: 'https://api.dev/orders' },
         },
         prod: {
           users: PETSTORE_3,
@@ -124,50 +116,50 @@ describe("openapi handlers — registry handles", () => {
     };
   });
 
-  it("openapi_get accepts a host:env:spec handle and returns flat spec name", async () => {
+  it('openapi_get accepts a host:env:spec handle and returns flat spec name', async () => {
     const reg = createAgentToolkitRegistry({
       registry,
       diskCacheDisabled: true,
     });
-    const r = await handleSwaggerGet(reg, "acme:dev:users", registry);
-    expect(r.spec).toBe("acme:dev:users");
-    expect(r.environment).toBe("default");
+    const r = await handleSwaggerGet(reg, 'acme:dev:users', registry);
+    expect(r.spec).toBe('acme:dev:users');
+    expect(r.environment).toBe('default');
   });
 
-  it("openapi_endpoint with a baseUrl-bearing leaf returns a synthesized fullUrl", async () => {
+  it('openapi_endpoint with a baseUrl-bearing leaf returns a synthesized fullUrl', async () => {
     const reg = createAgentToolkitRegistry({
       registry,
       diskCacheDisabled: true,
     });
     const detail = await handleSwaggerEndpoint(
       reg,
-      "acme:dev:orders",
-      { method: "GET", path: "/pet/{petId}" },
+      'acme:dev:orders',
+      { method: 'GET', path: '/pet/{petId}' },
       registry,
     );
-    expect(detail.endpoint.fullUrl).toBe("https://api.dev/orders/pet/{petId}");
+    expect(detail.endpoint.fullUrl).toBe('https://api.dev/orders/pet/{petId}');
   });
 
-  it("openapi_get throws on unregistered handle", async () => {
+  it('openapi_get throws on unregistered handle', async () => {
     const reg = createAgentToolkitRegistry({
       registry,
       diskCacheDisabled: true,
     });
-    await expect(
-      handleSwaggerGet(reg, "acme:dev:missing", registry),
-    ).rejects.toThrow(/acme:dev:missing/);
+    await expect(handleSwaggerGet(reg, 'acme:dev:missing', registry)).rejects.toThrow(
+      /acme:dev:missing/,
+    );
   });
 
-  it("openapi_envs returns the flat registry list with baseUrl when present", () => {
+  it('openapi_envs returns the flat registry list with baseUrl when present', () => {
     const flat = handleSwaggerEnvs({ openapi: { registry } });
     expect(flat.length).toBe(3);
-    const orders = flat.find((r) => r.spec === "orders");
-    expect(orders?.baseUrl).toBe("https://api.dev/orders");
-    const users = flat.find((r) => r.spec === "users" && r.env === "dev");
+    const orders = flat.find((r) => r.spec === 'orders');
+    expect(orders?.baseUrl).toBe('https://api.dev/orders');
+    const users = flat.find((r) => r.spec === 'users' && r.env === 'dev');
     expect(users?.baseUrl).toBeUndefined();
   });
 
-  it("openapi_envs returns [] for empty config", () => {
+  it('openapi_envs returns [] for empty config', () => {
     expect(handleSwaggerEnvs({})).toEqual([]);
   });
 });

--- a/src/core/handlers.ts
+++ b/src/core/handlers.ts
@@ -1,31 +1,27 @@
-import type { OpenAPIV3 } from "openapi-types";
-import {
-  buildEphemeralSpec,
-  DEFAULT_ENVIRONMENT,
-  ephemeralSpecName,
-} from "./adapter";
+import type { OpenAPIV3 } from 'openapi-types';
+import { buildEphemeralSpec, DEFAULT_ENVIRONMENT, ephemeralSpecName } from './adapter';
 import {
   buildEndpointDetail,
   resolveEndpoint,
   type EndpointDetail,
   type IndexedSpec,
   type TagSummary,
-} from "./indexer";
-import { filterEndpoints } from "./filter";
+} from './indexer';
+import { filterEndpoints } from './filter';
 import {
   type RefreshOutcome,
   type SpecRegistry,
   type SpecSummary,
   UnknownSpecError,
-} from "./registry";
+} from './registry';
 import {
   isFullHandle,
   listRegistry,
   resolveHandleToUrl,
   resolveScopeToHandles,
   type OpenapiRegistryEntry,
-} from "./openapi-registry";
-import type { OpenapiRegistry, ToolkitConfig } from "./toolkit-config";
+} from './openapi-registry';
+import type { OpenapiRegistry, ToolkitConfig } from './toolkit-config';
 
 /**
  * agent-toolkit 의 openapi_* tool 들이 공유하는 handler 묶음.
@@ -59,8 +55,8 @@ function resolveSwaggerInput(
     if (!registry.hasSpec(flat)) {
       // registry 가 toolkit-config 로 만들어지지 않은 (단독 진입점) 경우 ad-hoc 등록.
       registry.registerSpec(flat, {
-        source: { type: "url", url },
-        environments: { [DEFAULT_ENVIRONMENT]: { baseUrl: "" } },
+        source: { type: 'url', url },
+        environments: { [DEFAULT_ENVIRONMENT]: { baseUrl: '' } },
       });
     }
     const baseUrlMaybe = registry
@@ -86,11 +82,7 @@ function resolveSwaggerInput(
 }
 
 function looksLikeUrl(s: string): boolean {
-  return (
-    s.startsWith("http://") ||
-    s.startsWith("https://") ||
-    s.startsWith("file://")
-  );
+  return s.startsWith('http://') || s.startsWith('https://') || s.startsWith('file://');
 }
 
 /** openapi_search 옵션 — `scope` 는 host / host:env / host:env:spec 중 하나. */
@@ -117,11 +109,7 @@ export async function handleSwaggerGet(
   input: string,
   toolkitRegistry?: OpenapiRegistry,
 ): Promise<SwaggerGetResult> {
-  const { specName, environment, baseUrl } = resolveSwaggerInput(
-    registry,
-    input,
-    toolkitRegistry,
-  );
+  const { specName, environment, baseUrl } = resolveSwaggerInput(registry, input, toolkitRegistry);
   // loadSpecDetailed 가 memory / disk / remote 중 어디서 왔는지 알려준다.
   const detailed = await registry.loadSpecDetailed(specName, environment);
   const result: SwaggerGetResult = {
@@ -130,7 +118,9 @@ export async function handleSwaggerGet(
     fromCache: detailed.fromCache,
     document: detailed.indexed.document,
   };
-  if (baseUrl) result.baseUrl = baseUrl;
+  if (baseUrl) {
+    result.baseUrl = baseUrl;
+  }
   return result;
 }
 
@@ -177,8 +167,7 @@ export async function handleSwaggerSearch(
   toolkitRegistry?: OpenapiRegistry,
 ): Promise<SwaggerSearchMatch[]> {
   const { limit, scope } = options;
-  const cap =
-    Number.isFinite(limit) && (limit as number) > 0 ? (limit as number) : 20;
+  const cap = Number.isFinite(limit) && (limit as number) > 0 ? (limit as number) : 20;
 
   const allSpecs = registry.listSpecs();
   let candidates = allSpecs.map((s) => s.name);
@@ -205,10 +194,7 @@ export async function handleSwaggerSearch(
     candidates.map((name) => registry.loadSpecCachedOnly(name)),
   );
   const indexedSpecs: IndexedSpec[] = settled
-    .filter(
-      (r): r is PromiseFulfilledResult<IndexedSpec | null> =>
-        r.status === "fulfilled",
-    )
+    .filter((r): r is PromiseFulfilledResult<IndexedSpec | null> => r.status === 'fulfilled')
     .map((r) => r.value)
     .filter((v): v is IndexedSpec => v !== null);
 
@@ -240,9 +226,7 @@ export interface SwaggerSearchMatch {
 }
 
 /** registry 트리를 평면 (host, env, spec, url, baseUrl?, format?) 리스트로 반환. */
-export function handleSwaggerEnvs(
-  config: ToolkitConfig,
-): OpenapiRegistryEntry[] {
+export function handleSwaggerEnvs(config: ToolkitConfig): OpenapiRegistryEntry[] {
   return listRegistry(config);
 }
 
@@ -271,15 +255,9 @@ export async function handleSwaggerEndpoint(
   toolkitRegistry?: OpenapiRegistry,
 ): Promise<SwaggerEndpointResult> {
   if (!locator.operationId && !(locator.method && locator.path)) {
-    throw new Error(
-      "openapi_endpoint requires either operationId or both method and path",
-    );
+    throw new Error('openapi_endpoint requires either operationId or both method and path');
   }
-  const { specName, environment } = resolveSwaggerInput(
-    registry,
-    input,
-    toolkitRegistry,
-  );
+  const { specName, environment } = resolveSwaggerInput(registry, input, toolkitRegistry);
   const env = registry.getEnvironment(specName, environment);
   const indexed = await registry.loadSpec(specName, environment);
   const ep = resolveEndpoint(indexed, locator);
@@ -306,11 +284,7 @@ export async function handleSwaggerTags(
   input: string,
   toolkitRegistry?: OpenapiRegistry,
 ): Promise<SwaggerTagsResult> {
-  const { specName, environment } = resolveSwaggerInput(
-    registry,
-    input,
-    toolkitRegistry,
-  );
+  const { specName, environment } = resolveSwaggerInput(registry, input, toolkitRegistry);
   const indexed = await registry.loadSpec(specName, environment);
   return { spec: specName, environment, tags: indexed.tags };
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,16 +13,16 @@
 // `loadConfig` from `./toolkit-config`. The standalone openapi-mcp CLI loads the
 // openapi-mcp.json `loadConfig` directly via `./config-loader`, so the barrel
 // intentionally hides that file's same-named symbol to avoid an ambiguous re-export.
-export * from "./adapter";
-export * from "./cache";
-export * from "./fetcher";
-export * from "./filter";
-export * from "./handlers";
-export * from "./indexer";
-export * from "./logger";
-export * from "./openapi-registry";
-export * from "./parser";
-export * from "./registry";
-export * from "./schema";
-export * from "./toolkit-config";
-export * from "./url";
+export * from './adapter';
+export * from './cache';
+export * from './fetcher';
+export * from './filter';
+export * from './handlers';
+export * from './indexer';
+export * from './logger';
+export * from './openapi-registry';
+export * from './parser';
+export * from './registry';
+export * from './schema';
+export * from './toolkit-config';
+export * from './url';

--- a/src/core/indexer.ts
+++ b/src/core/indexer.ts
@@ -1,5 +1,5 @@
-import type { OpenAPIV3 } from "openapi-types";
-import { joinBaseAndPath, syntheticOperationId } from "./url";
+import type { OpenAPIV3 } from 'openapi-types';
+import { joinBaseAndPath, syntheticOperationId } from './url';
 
 /**
  * dereferenced 된 OpenAPI 3.x document 를 받아서 endpoint 인덱스를 만든다.
@@ -8,25 +8,17 @@ import { joinBaseAndPath, syntheticOperationId } from "./url";
  * requestBody, responses, examples, fullUrl) 를 담는다.
  */
 
-export type HttpMethod =
-  | "GET"
-  | "POST"
-  | "PUT"
-  | "PATCH"
-  | "DELETE"
-  | "HEAD"
-  | "OPTIONS"
-  | "TRACE";
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'TRACE';
 
 export const HTTP_METHODS = [
-  "GET",
-  "POST",
-  "PUT",
-  "PATCH",
-  "DELETE",
-  "HEAD",
-  "OPTIONS",
-  "TRACE",
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+  'TRACE',
 ] as const satisfies readonly HttpMethod[];
 
 export interface IndexedEndpoint {
@@ -43,7 +35,7 @@ export interface IndexedEndpoint {
 
 export interface ParameterDetail {
   name: string;
-  in: "query" | "header" | "path" | "cookie";
+  in: 'query' | 'header' | 'path' | 'cookie';
   required: boolean;
   description?: string;
   deprecated: boolean;
@@ -104,10 +96,7 @@ export interface TagSummary {
   endpointCount: number;
 }
 
-export function indexSpec(
-  specName: string,
-  document: OpenAPIV3.Document,
-): IndexedSpec {
+export function indexSpec(specName: string, document: OpenAPIV3.Document): IndexedSpec {
   const endpoints: IndexedEndpoint[] = [];
   const byOperationId = new Map<string, IndexedEndpoint>();
   const byMethodPath = new Map<string, IndexedEndpoint>();
@@ -115,12 +104,16 @@ export function indexSpec(
 
   const paths = document.paths ?? {};
   for (const [pathKey, pathItem] of Object.entries(paths)) {
-    if (!pathItem) continue;
+    if (!pathItem) {
+      continue;
+    }
     for (const method of HTTP_METHODS) {
       const op = (pathItem as Record<string, unknown>)[method.toLowerCase()] as
         | OpenAPIV3.OperationObject
         | undefined;
-      if (!op) continue;
+      if (!op) {
+        continue;
+      }
 
       const synthetic = syntheticOperationId(method, pathKey);
       const tags = Array.isArray(op.tags) ? op.tags.slice() : [];
@@ -152,7 +145,9 @@ export function indexSpec(
   const tagDescriptions = new Map<string, string | undefined>();
   for (const t of declaredTags) {
     tagDescriptions.set(t.name, t.description);
-    if (!tagCounts.has(t.name)) tagCounts.set(t.name, 0);
+    if (!tagCounts.has(t.name)) {
+      tagCounts.set(t.name, 0);
+    }
   }
   const tags: TagSummary[] = Array.from(tagCounts.entries())
     .map(([name, endpointCount]) => ({
@@ -177,9 +172,13 @@ export function resolveEndpoint(
 ): IndexedEndpoint | undefined {
   if (input.operationId) {
     const hit = spec.byOperationId.get(input.operationId);
-    if (hit) return hit;
+    if (hit) {
+      return hit;
+    }
     for (const ep of spec.endpoints) {
-      if (ep.syntheticOperationId === input.operationId) return ep;
+      if (ep.syntheticOperationId === input.operationId) {
+        return ep;
+      }
     }
     return undefined;
   }
@@ -194,24 +193,19 @@ export function buildEndpointDetail(
   endpoint: IndexedEndpoint,
   baseUrl: string,
 ): EndpointDetail {
-  const pathItem = spec.document.paths?.[endpoint.path] as
-    | OpenAPIV3.PathItemObject
+  const pathItem = spec.document.paths?.[endpoint.path] as OpenAPIV3.PathItemObject | undefined;
+  const op = pathItem?.[endpoint.method.toLowerCase() as Lowercase<HttpMethod>] as
+    | OpenAPIV3.OperationObject
     | undefined;
-  const op = pathItem?.[
-    endpoint.method.toLowerCase() as Lowercase<HttpMethod>
-  ] as OpenAPIV3.OperationObject | undefined;
   if (!op) {
     throw new Error(
       `internal: operation ${endpoint.method} ${endpoint.path} disappeared from indexed spec`,
     );
   }
 
-  const pathParams = (pathItem?.parameters ??
-    []) as OpenAPIV3.ParameterObject[];
+  const pathParams = (pathItem?.parameters ?? []) as OpenAPIV3.ParameterObject[];
   const opParams = (op.parameters ?? []) as OpenAPIV3.ParameterObject[];
-  const parameters = mergeParameters(pathParams, opParams).map(
-    toParameterDetail,
-  );
+  const parameters = mergeParameters(pathParams, opParams).map(toParameterDetail);
 
   const requestBody = op.requestBody
     ? toRequestBodyDetail(op.requestBody as OpenAPIV3.RequestBodyObject)
@@ -246,29 +240,29 @@ function mergeParameters(
   opParams: OpenAPIV3.ParameterObject[],
 ): OpenAPIV3.ParameterObject[] {
   const seen = new Map<string, OpenAPIV3.ParameterObject>();
-  for (const p of pathParams) seen.set(`${p.in}:${p.name}`, p);
-  for (const p of opParams) seen.set(`${p.in}:${p.name}`, p);
+  for (const p of pathParams) {
+    seen.set(`${p.in}:${p.name}`, p);
+  }
+  for (const p of opParams) {
+    seen.set(`${p.in}:${p.name}`, p);
+  }
   return Array.from(seen.values());
 }
 
 function toParameterDetail(p: OpenAPIV3.ParameterObject): ParameterDetail {
   return {
     name: p.name,
-    in: p.in as ParameterDetail["in"],
-    required: p.required === true || p.in === "path",
+    in: p.in as ParameterDetail['in'],
+    required: p.required === true || p.in === 'path',
     ...(p.description !== undefined ? { description: p.description } : {}),
     deprecated: p.deprecated === true,
     schema: p.schema,
     example: p.example,
-    examples: extractExamples(
-      p.examples as Record<string, OpenAPIV3.ExampleObject> | undefined,
-    ),
+    examples: extractExamples(p.examples as Record<string, OpenAPIV3.ExampleObject> | undefined),
   };
 }
 
-function toRequestBodyDetail(
-  rb: OpenAPIV3.RequestBodyObject,
-): RequestBodyDetail {
+function toRequestBodyDetail(rb: OpenAPIV3.RequestBodyObject): RequestBodyDetail {
   const content: Record<string, MediaTypeDetail> = {};
   for (const [mediaType, mt] of Object.entries(rb.content ?? {})) {
     content[mediaType] = toMediaTypeDetail(mt as OpenAPIV3.MediaTypeObject);
@@ -290,7 +284,7 @@ function toResponseDetail(r: OpenAPIV3.ResponseObject): ResponseDetail {
       )
     : undefined;
   return {
-    description: r.description ?? "",
+    description: r.description ?? '',
     headers: r.headers as Record<string, unknown> | undefined,
     ...(content !== undefined ? { content } : {}),
   };
@@ -300,16 +294,16 @@ function toMediaTypeDetail(mt: OpenAPIV3.MediaTypeObject): MediaTypeDetail {
   return {
     schema: mt.schema,
     example: mt.example,
-    examples: extractExamples(
-      mt.examples as Record<string, OpenAPIV3.ExampleObject> | undefined,
-    ),
+    examples: extractExamples(mt.examples as Record<string, OpenAPIV3.ExampleObject> | undefined),
   };
 }
 
 function extractExamples(
   examples: Record<string, OpenAPIV3.ExampleObject> | undefined,
 ): Record<string, unknown> | undefined {
-  if (!examples) return undefined;
+  if (!examples) {
+    return undefined;
+  }
   const out: Record<string, unknown> = {};
   for (const [name, ex] of Object.entries(examples)) {
     out[name] = ex.value;
@@ -331,22 +325,29 @@ function collectExamples(
         reqExamples[mt] = body;
       }
     }
-    if (Object.keys(reqExamples).length > 0) set.request = reqExamples;
+    if (Object.keys(reqExamples).length > 0) {
+      set.request = reqExamples;
+    }
   }
 
   const responseExamples: Record<string, Record<string, MediaTypeDetail>> = {};
   for (const [status, response] of Object.entries(responses)) {
-    if (!response.content) continue;
+    if (!response.content) {
+      continue;
+    }
     const perStatus: Record<string, MediaTypeDetail> = {};
     for (const [mt, body] of Object.entries(response.content)) {
       if (body.example !== undefined || body.examples) {
         perStatus[mt] = body;
       }
     }
-    if (Object.keys(perStatus).length > 0) responseExamples[status] = perStatus;
+    if (Object.keys(perStatus).length > 0) {
+      responseExamples[status] = perStatus;
+    }
   }
-  if (Object.keys(responseExamples).length > 0)
+  if (Object.keys(responseExamples).length > 0) {
     set.responses = responseExamples;
+  }
 
   // parameter examples 는 ParameterDetail 안에 그대로 보존된다 — examples 집합엔 따로 안 넣음.
   void parameters;

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,21 +1,14 @@
-import pino from "pino";
+import pino from 'pino';
 
 /**
  * stdio MCP 서버는 stdout 을 JSON-RPC 전용으로 보호해야 하므로 모든 로그는 stderr 로
  * 흘려야 한다. pino 의 destination(2) 가 그 역할 — `console.log` 를 절대 쓰지 않는다.
  */
-export type LogLevel =
-  | "trace"
-  | "debug"
-  | "info"
-  | "warn"
-  | "error"
-  | "fatal"
-  | "silent";
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal' | 'silent';
 
 let logger: pino.Logger | null = null;
 
-export function initLogger(level: LogLevel = "info"): pino.Logger {
+export function initLogger(level: LogLevel = 'info'): pino.Logger {
   logger = pino(
     {
       level,
@@ -29,7 +22,7 @@ export function initLogger(level: LogLevel = "info"): pino.Logger {
 
 export function getLogger(): pino.Logger {
   if (!logger) {
-    logger = initLogger("info");
+    logger = initLogger('info');
   }
   return logger;
 }

--- a/src/core/openapi-registry.test.ts
+++ b/src/core/openapi-registry.test.ts
@@ -1,146 +1,142 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect } from 'bun:test';
 import {
   isFullHandle,
   isScope,
   listRegistry,
   resolveHandleToUrl,
   resolveScopeToUrls,
-} from "./openapi-registry";
-import type { ToolkitConfig } from "./toolkit-config";
+} from './openapi-registry';
+import type { ToolkitConfig } from './toolkit-config';
 
 const CONFIG: ToolkitConfig = {
   openapi: {
     registry: {
       acme: {
         dev: {
-          users: "https://dev.acme/users.json",
-          orders: "https://dev.acme/orders.json",
+          users: 'https://dev.acme/users.json',
+          orders: 'https://dev.acme/orders.json',
         },
         prod: {
-          users: "https://api.acme/users.json",
+          users: 'https://api.acme/users.json',
         },
       },
       beta: {
         dev: {
-          svc: "https://dev.beta/svc.json",
+          svc: 'https://dev.beta/svc.json',
         },
       },
     },
   },
 };
 
-describe("isFullHandle", () => {
-  it("matches host:env:spec", () => {
-    expect(isFullHandle("acme:dev:users")).toBe(true);
+describe('isFullHandle', () => {
+  it('matches host:env:spec', () => {
+    expect(isFullHandle('acme:dev:users')).toBe(true);
   });
-  it("rejects partial / extra colons", () => {
-    expect(isFullHandle("acme:dev")).toBe(false);
-    expect(isFullHandle("acme")).toBe(false);
-    expect(isFullHandle("acme:dev:users:extra")).toBe(false);
+  it('rejects partial / extra colons', () => {
+    expect(isFullHandle('acme:dev')).toBe(false);
+    expect(isFullHandle('acme')).toBe(false);
+    expect(isFullHandle('acme:dev:users:extra')).toBe(false);
   });
-  it("rejects URLs and hex keys", () => {
-    expect(isFullHandle("https://example.com/spec.json")).toBe(false);
-    expect(isFullHandle("0123456789abcdef")).toBe(false);
-  });
-});
-
-describe("isScope", () => {
-  it("accepts host / host:env / host:env:spec", () => {
-    expect(isScope("acme")).toBe(true);
-    expect(isScope("acme:dev")).toBe(true);
-    expect(isScope("acme:dev:users")).toBe(true);
-  });
-  it("rejects URLs, hex keys, empty", () => {
-    expect(isScope("https://example.com/spec.json")).toBe(false);
-    expect(isScope("file:///tmp/spec.json")).toBe(false);
-    expect(isScope("0123456789abcdef")).toBe(false);
-    expect(isScope("")).toBe(false);
-  });
-  it("rejects identifiers with disallowed chars", () => {
-    expect(isScope("ac me")).toBe(false);
-    expect(isScope("acme:de v")).toBe(false);
+  it('rejects URLs and hex keys', () => {
+    expect(isFullHandle('https://example.com/spec.json')).toBe(false);
+    expect(isFullHandle('0123456789abcdef')).toBe(false);
   });
 });
 
-describe("resolveHandleToUrl", () => {
-  it("returns the registered URL for a known handle", () => {
-    expect(resolveHandleToUrl("acme:dev:users", CONFIG.openapi?.registry)).toBe(
-      "https://dev.acme/users.json",
+describe('isScope', () => {
+  it('accepts host / host:env / host:env:spec', () => {
+    expect(isScope('acme')).toBe(true);
+    expect(isScope('acme:dev')).toBe(true);
+    expect(isScope('acme:dev:users')).toBe(true);
+  });
+  it('rejects URLs, hex keys, empty', () => {
+    expect(isScope('https://example.com/spec.json')).toBe(false);
+    expect(isScope('file:///tmp/spec.json')).toBe(false);
+    expect(isScope('0123456789abcdef')).toBe(false);
+    expect(isScope('')).toBe(false);
+  });
+  it('rejects identifiers with disallowed chars', () => {
+    expect(isScope('ac me')).toBe(false);
+    expect(isScope('acme:de v')).toBe(false);
+  });
+});
+
+describe('resolveHandleToUrl', () => {
+  it('returns the registered URL for a known handle', () => {
+    expect(resolveHandleToUrl('acme:dev:users', CONFIG.openapi?.registry)).toBe(
+      'https://dev.acme/users.json',
     );
   });
-  it("throws on unregistered handle, with the handle in the message", () => {
-    expect(() =>
-      resolveHandleToUrl("acme:dev:nope", CONFIG.openapi?.registry),
-    ).toThrow(/acme:dev:nope/);
-  });
-  it("throws on malformed handle", () => {
-    expect(() =>
-      resolveHandleToUrl("acme:dev", CONFIG.openapi?.registry),
-    ).toThrow(/three colon-separated/i);
-  });
-  it("throws when registry is undefined", () => {
-    expect(() => resolveHandleToUrl("acme:dev:users", undefined)).toThrow(
-      /not found/i,
+  it('throws on unregistered handle, with the handle in the message', () => {
+    expect(() => resolveHandleToUrl('acme:dev:nope', CONFIG.openapi?.registry)).toThrow(
+      /acme:dev:nope/,
     );
+  });
+  it('throws on malformed handle', () => {
+    expect(() => resolveHandleToUrl('acme:dev', CONFIG.openapi?.registry)).toThrow(
+      /three colon-separated/i,
+    );
+  });
+  it('throws when registry is undefined', () => {
+    expect(() => resolveHandleToUrl('acme:dev:users', undefined)).toThrow(/not found/i);
   });
 });
 
-describe("resolveScopeToUrls", () => {
+describe('resolveScopeToUrls', () => {
   const reg = CONFIG.openapi?.registry;
 
-  it("expands a host scope to all of its specs", () => {
-    const urls = resolveScopeToUrls("acme", reg);
+  it('expands a host scope to all of its specs', () => {
+    const urls = resolveScopeToUrls('acme', reg);
     expect(urls.sort()).toEqual(
       [
-        "https://api.acme/users.json",
-        "https://dev.acme/orders.json",
-        "https://dev.acme/users.json",
+        'https://api.acme/users.json',
+        'https://dev.acme/orders.json',
+        'https://dev.acme/users.json',
       ].sort(),
     );
   });
 
   it("expands a host:env scope to that env's specs only", () => {
-    const urls = resolveScopeToUrls("acme:dev", reg);
+    const urls = resolveScopeToUrls('acme:dev', reg);
     expect(urls.sort()).toEqual(
-      ["https://dev.acme/orders.json", "https://dev.acme/users.json"].sort(),
+      ['https://dev.acme/orders.json', 'https://dev.acme/users.json'].sort(),
     );
   });
 
-  it("expands a host:env:spec scope to a one-element list", () => {
-    expect(resolveScopeToUrls("acme:prod:users", reg)).toEqual([
-      "https://api.acme/users.json",
-    ]);
+  it('expands a host:env:spec scope to a one-element list', () => {
+    expect(resolveScopeToUrls('acme:prod:users', reg)).toEqual(['https://api.acme/users.json']);
   });
 
-  it("returns an empty array for unknown / malformed scopes", () => {
-    expect(resolveScopeToUrls("nope", reg)).toEqual([]);
-    expect(resolveScopeToUrls("acme:nope", reg)).toEqual([]);
-    expect(resolveScopeToUrls("acme:dev:nope", reg)).toEqual([]);
-    expect(resolveScopeToUrls("not a scope", reg)).toEqual([]);
-    expect(resolveScopeToUrls("", reg)).toEqual([]);
+  it('returns an empty array for unknown / malformed scopes', () => {
+    expect(resolveScopeToUrls('nope', reg)).toEqual([]);
+    expect(resolveScopeToUrls('acme:nope', reg)).toEqual([]);
+    expect(resolveScopeToUrls('acme:dev:nope', reg)).toEqual([]);
+    expect(resolveScopeToUrls('not a scope', reg)).toEqual([]);
+    expect(resolveScopeToUrls('', reg)).toEqual([]);
   });
 
-  it("returns an empty array when the registry is undefined", () => {
-    expect(resolveScopeToUrls("acme:dev:users", undefined)).toEqual([]);
+  it('returns an empty array when the registry is undefined', () => {
+    expect(resolveScopeToUrls('acme:dev:users', undefined)).toEqual([]);
   });
 });
 
-describe("listRegistry", () => {
-  it("flattens host/env/spec/url tree", () => {
+describe('listRegistry', () => {
+  it('flattens host/env/spec/url tree', () => {
     const flat = listRegistry(CONFIG);
     expect(flat.length).toBe(4);
     const got = flat.map((e) => `${e.host}:${e.env}:${e.spec}=${e.url}`).sort();
     expect(got).toEqual(
       [
-        "acme:dev:users=https://dev.acme/users.json",
-        "acme:dev:orders=https://dev.acme/orders.json",
-        "acme:prod:users=https://api.acme/users.json",
-        "beta:dev:svc=https://dev.beta/svc.json",
+        'acme:dev:users=https://dev.acme/users.json',
+        'acme:dev:orders=https://dev.acme/orders.json',
+        'acme:prod:users=https://api.acme/users.json',
+        'beta:dev:svc=https://dev.beta/svc.json',
       ].sort(),
     );
   });
 
-  it("returns [] for empty config", () => {
+  it('returns [] for empty config', () => {
     expect(listRegistry({})).toEqual([]);
     expect(listRegistry({ openapi: {} })).toEqual([]);
     expect(listRegistry({ openapi: { registry: {} } })).toEqual([]);

--- a/src/core/openapi-registry.ts
+++ b/src/core/openapi-registry.ts
@@ -5,7 +5,7 @@ import {
   ID_BODY,
   type OpenapiRegistry,
   type ToolkitConfig,
-} from "./toolkit-config";
+} from './toolkit-config';
 
 /**
  * `agent-toolkit.json` 의 `openapi.registry` 트리를 다루는 helper 모음.
@@ -31,7 +31,7 @@ export interface OpenapiRegistryEntry {
   url: string;
   /** leaf 가 object 형태일 때만 채워진다. */
   baseUrl?: string;
-  format?: "openapi3" | "swagger2" | "auto";
+  format?: 'openapi3' | 'swagger2' | 'auto';
 }
 
 // 식별자 본문은 toolkit-config 의 ID_BODY 와 동일해야 한다 (스키마 / config 검증과 동기).
@@ -48,12 +48,10 @@ export function isFullHandle(s: string): boolean {
 
 /** `host`, `host:env`, `host:env:spec` 중 하나라도 맞는지. 16-hex 키와 URL 은 false. */
 export function isScope(s: string): boolean {
-  if (!s || HEX_KEY.test(s)) return false;
-  if (
-    s.startsWith("http://") ||
-    s.startsWith("https://") ||
-    s.startsWith("file://")
-  ) {
+  if (!s || HEX_KEY.test(s)) {
+    return false;
+  }
+  if (s.startsWith('http://') || s.startsWith('https://') || s.startsWith('file://')) {
     return false;
   }
   return HANDLE_FULL.test(s) || HANDLE_HOST_ENV.test(s) || HANDLE_HOST.test(s);
@@ -63,10 +61,7 @@ export function isScope(s: string): boolean {
  * 정확한 `host:env:spec` handle 을 단일 URL 로 해석.
  * handle 이 형식에 맞지 않거나 등록 안 되어 있으면 throw — 메시지에 handle 을 포함.
  */
-export function resolveHandleToUrl(
-  handle: string,
-  registry: OpenapiRegistry | undefined,
-): string {
+export function resolveHandleToUrl(handle: string, registry: OpenapiRegistry | undefined): string {
   const m = HANDLE_FULL.exec(handle);
   if (!m) {
     throw new Error(
@@ -88,11 +83,10 @@ export function resolveHandleToUrl(
  * 매칭 0 건이면 빈 배열. handle 형식에 안 맞으면 빈 배열 — caller 가 의도하지 않은 스코프를
  * 안전하게 무시한다.
  */
-export function resolveScopeToUrls(
-  scope: string,
-  registry: OpenapiRegistry | undefined,
-): string[] {
-  if (!registry || !scope) return [];
+export function resolveScopeToUrls(scope: string, registry: OpenapiRegistry | undefined): string[] {
+  if (!registry || !scope) {
+    return [];
+  }
   if (HANDLE_FULL.test(scope)) {
     try {
       return [resolveHandleToUrl(scope, registry)];
@@ -108,10 +102,14 @@ export function resolveScopeToUrls(
   }
   if (HANDLE_HOST.test(scope)) {
     const envs = registry[scope];
-    if (!envs) return [];
+    if (!envs) {
+      return [];
+    }
     const out: string[] = [];
     for (const env of Object.values(envs)) {
-      for (const leaf of Object.values(env)) out.push(getRegistryUrl(leaf));
+      for (const leaf of Object.values(env)) {
+        out.push(getRegistryUrl(leaf));
+      }
     }
     return out;
   }
@@ -128,18 +126,13 @@ export function resolveScopeToHandles(
   scope: string,
   registry: OpenapiRegistry | undefined,
 ): string[] {
-  if (!registry || !scope) return [];
+  if (!registry || !scope) {
+    return [];
+  }
   if (HANDLE_FULL.test(scope)) {
-    const m = HANDLE_FULL.exec(scope) as unknown as [
-      string,
-      string,
-      string,
-      string,
-    ];
+    const m = HANDLE_FULL.exec(scope) as unknown as [string, string, string, string];
     const [, host, env, spec] = m;
-    return registry[host]?.[env]?.[spec] !== undefined
-      ? [`${host}:${env}:${spec}`]
-      : [];
+    return registry[host]?.[env]?.[spec] !== undefined ? [`${host}:${env}:${spec}`] : [];
   }
   const fullEnv = HANDLE_HOST_ENV.exec(scope);
   if (fullEnv) {
@@ -149,7 +142,9 @@ export function resolveScopeToHandles(
   }
   if (HANDLE_HOST.test(scope)) {
     const envs = registry[scope];
-    if (!envs) return [];
+    if (!envs) {
+      return [];
+    }
     const out: string[] = [];
     for (const [env, specs] of Object.entries(envs)) {
       for (const spec of Object.keys(specs)) {
@@ -176,8 +171,12 @@ export function listRegistry(config: ToolkitConfig): OpenapiRegistryEntry[] {
           spec,
           url: getRegistryUrl(leaf),
         };
-        if (baseUrl !== undefined) row.baseUrl = baseUrl;
-        if (format !== undefined) row.format = format;
+        if (baseUrl !== undefined) {
+          row.baseUrl = baseUrl;
+        }
+        if (format !== undefined) {
+          row.format = format;
+        }
         out.push(row);
       }
     }

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -1,50 +1,45 @@
-import { describe, it, expect } from "bun:test";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { parseSpecText, SpecParseError } from "./parser";
+import { describe, it, expect } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseSpecText, SpecParseError } from './parser';
 
-const FIX = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "__fixtures__",
-);
+const FIX = path.join(path.dirname(fileURLToPath(import.meta.url)), '__fixtures__');
 
-describe("parseSpecText", () => {
-  it("parses petstore 3.0 JSON with auto detection", async () => {
-    const raw = await readFile(path.join(FIX, "petstore-3.0.json"), "utf8");
+describe('parseSpecText', () => {
+  it('parses petstore 3.0 JSON with auto detection', async () => {
+    const raw = await readFile(path.join(FIX, 'petstore-3.0.json'), 'utf8');
     const { document, detectedFormat } = await parseSpecText(raw);
-    expect(detectedFormat).toBe("openapi3");
-    expect(document.openapi?.startsWith("3.")).toBe(true);
-    expect(document.paths?.["/pet/{petId}"]).toBeDefined();
+    expect(detectedFormat).toBe('openapi3');
+    expect(document.openapi?.startsWith('3.')).toBe(true);
+    expect(document.paths?.['/pet/{petId}']).toBeDefined();
   });
 
-  it("parses petstore 3.0 YAML with auto detection", async () => {
-    const raw = await readFile(path.join(FIX, "petstore-3.0.yaml"), "utf8");
+  it('parses petstore 3.0 YAML with auto detection', async () => {
+    const raw = await readFile(path.join(FIX, 'petstore-3.0.yaml'), 'utf8');
     const { document, detectedFormat } = await parseSpecText(raw);
-    expect(detectedFormat).toBe("openapi3");
-    expect(document.openapi?.startsWith("3.")).toBe(true);
+    expect(detectedFormat).toBe('openapi3');
+    expect(document.openapi?.startsWith('3.')).toBe(true);
   });
 
-  it("auto-converts swagger 2.0 to OpenAPI 3.0", async () => {
-    const raw = await readFile(path.join(FIX, "petstore-2.0.json"), "utf8");
+  it('auto-converts swagger 2.0 to OpenAPI 3.0', async () => {
+    const raw = await readFile(path.join(FIX, 'petstore-2.0.json'), 'utf8');
     const { document, detectedFormat } = await parseSpecText(raw);
-    expect(detectedFormat).toBe("swagger2");
-    expect(document.openapi?.startsWith("3.")).toBe(true);
-    expect(
-      (document as unknown as Record<string, unknown>).swagger,
-    ).toBeUndefined();
+    expect(detectedFormat).toBe('swagger2');
+    expect(document.openapi?.startsWith('3.')).toBe(true);
+    expect((document as unknown as Record<string, unknown>).swagger).toBeUndefined();
   });
 
-  it("throws SpecParseError when neither openapi nor swagger field present", async () => {
-    await expect(
-      parseSpecText(JSON.stringify({ info: {}, paths: {} })),
-    ).rejects.toThrow(SpecParseError);
+  it('throws SpecParseError when neither openapi nor swagger field present', async () => {
+    await expect(parseSpecText(JSON.stringify({ info: {}, paths: {} }))).rejects.toThrow(
+      SpecParseError,
+    );
   });
 
-  it("dereferences $ref pointers", async () => {
-    const raw = await readFile(path.join(FIX, "petstore-3.0.json"), "utf8");
+  it('dereferences $ref pointers', async () => {
+    const raw = await readFile(path.join(FIX, 'petstore-3.0.json'), 'utf8');
     const { document } = await parseSpecText(raw);
-    const op = document.paths?.["/pet/{petId}"]?.get;
+    const op = document.paths?.['/pet/{petId}']?.get;
     // 'parameters' should be inline objects after deref, not $ref placeholders.
     expect(Array.isArray(op?.parameters)).toBe(true);
     for (const p of op?.parameters ?? []) {

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,8 +1,8 @@
-import SwaggerParser from "@apidevtools/swagger-parser";
-import yaml from "js-yaml";
-import type { OpenAPIV3 } from "openapi-types";
-import { type FetcherOptions, createFetcher } from "./fetcher";
-import type { SpecFormat } from "./schema";
+import SwaggerParser from '@apidevtools/swagger-parser';
+import yaml from 'js-yaml';
+import type { OpenAPIV3 } from 'openapi-types';
+import { type FetcherOptions, createFetcher } from './fetcher';
+import type { SpecFormat } from './schema';
 
 /**
  * spec 본문 (raw text 또는 이미 parse 된 object) 을 받아서:
@@ -21,13 +21,13 @@ export class SpecParseError extends Error {
     public override readonly cause?: unknown,
   ) {
     super(message);
-    this.name = "SpecParseError";
+    this.name = 'SpecParseError';
   }
 }
 
 export interface ParsedSpec {
   document: OpenAPIV3.Document;
-  detectedFormat: "openapi3" | "swagger2";
+  detectedFormat: 'openapi3' | 'swagger2';
 }
 
 /**
@@ -53,7 +53,7 @@ export interface ParseSpecOptions {
 
 export async function parseSpecText(
   raw: string,
-  hint: SpecFormat = "auto",
+  hint: SpecFormat = 'auto',
   options: ParseSpecOptions = {},
 ): Promise<ParsedSpec> {
   const parsed = parseStructured(raw);
@@ -62,16 +62,16 @@ export async function parseSpecText(
 
 export async function parseSpecObject(
   input: unknown,
-  hint: SpecFormat = "auto",
+  hint: SpecFormat = 'auto',
   options: ParseSpecOptions = {},
 ): Promise<ParsedSpec> {
-  if (input === null || typeof input !== "object") {
-    throw new SpecParseError("spec root must be an object");
+  if (input === null || typeof input !== 'object') {
+    throw new SpecParseError('spec root must be an object');
   }
   const detected = detectFormat(input, hint);
 
   let openapi3: object;
-  if (detected === "swagger2") {
+  if (detected === 'swagger2') {
     openapi3 = await convertSwagger2(input);
   } else {
     openapi3 = input;
@@ -107,7 +107,7 @@ export async function parseSpecObject(
 
 function parseStructured(raw: string): unknown {
   const trimmed = raw.trimStart();
-  const looksJson = trimmed.startsWith("{") || trimmed.startsWith("[");
+  const looksJson = trimmed.startsWith('{') || trimmed.startsWith('[');
   if (looksJson) {
     try {
       return JSON.parse(raw);
@@ -115,44 +115,44 @@ function parseStructured(raw: string): unknown {
       try {
         return yaml.load(raw);
       } catch {
-        throw new SpecParseError("spec is neither valid JSON nor YAML", err);
+        throw new SpecParseError('spec is neither valid JSON nor YAML', err);
       }
     }
   }
   try {
     return yaml.load(raw);
   } catch (err) {
-    throw new SpecParseError("failed to parse spec as YAML", err);
+    throw new SpecParseError('failed to parse spec as YAML', err);
   }
 }
 
-function detectFormat(doc: object, hint: SpecFormat): "openapi3" | "swagger2" {
+function detectFormat(doc: object, hint: SpecFormat): 'openapi3' | 'swagger2' {
   const hasOpenApi3 =
-    hasStringField(doc, "openapi") &&
+    hasStringField(doc, 'openapi') &&
     /^3\./.test((doc as Record<string, unknown>).openapi as string);
   const hasSwagger2 =
-    hasStringField(doc, "swagger") &&
+    hasStringField(doc, 'swagger') &&
     /^2\./.test((doc as Record<string, unknown>).swagger as string);
 
-  if (hint === "openapi3") {
+  if (hint === 'openapi3') {
     if (!hasOpenApi3) {
-      throw new SpecParseError(
-        "format=openapi3 declared but document is not OpenAPI 3.x",
-      );
+      throw new SpecParseError('format=openapi3 declared but document is not OpenAPI 3.x');
     }
-    return "openapi3";
+    return 'openapi3';
   }
-  if (hint === "swagger2") {
+  if (hint === 'swagger2') {
     if (!hasSwagger2) {
-      throw new SpecParseError(
-        "format=swagger2 declared but document is not Swagger 2.x",
-      );
+      throw new SpecParseError('format=swagger2 declared but document is not Swagger 2.x');
     }
-    return "swagger2";
+    return 'swagger2';
   }
 
-  if (hasOpenApi3) return "openapi3";
-  if (hasSwagger2) return "swagger2";
+  if (hasOpenApi3) {
+    return 'openapi3';
+  }
+  if (hasSwagger2) {
+    return 'swagger2';
+  }
   throw new SpecParseError(
     "spec is missing both 'openapi' and 'swagger' version fields; cannot detect format",
   );
@@ -160,7 +160,7 @@ function detectFormat(doc: object, hint: SpecFormat): "openapi3" | "swagger2" {
 
 function hasStringField(doc: object, field: string): boolean {
   const value = (doc as Record<string, unknown>)[field];
-  return typeof value === "string";
+  return typeof value === 'string';
 }
 
 /**
@@ -174,11 +174,11 @@ function hasStringField(doc: object, field: string): boolean {
  */
 type SwaggerParserOptions = Parameters<typeof SwaggerParser.dereference>[2];
 
-function buildSwaggerParserOptions(
-  options: ParseSpecOptions,
-): SwaggerParserOptions {
+function buildSwaggerParserOptions(options: ParseSpecOptions): SwaggerParserOptions {
   const fetcherOpts = options.fetcherOptions;
-  if (!fetcherOpts) return {} as SwaggerParserOptions;
+  if (!fetcherOpts) {
+    return {} as SwaggerParserOptions;
+  }
   // 한 parse 호출 안에서만 쓰는 fetcher — TLS dispatcher 를 그 호출 범위에 가둔다.
   const fetcher = createFetcher(fetcherOpts);
   return {
@@ -186,7 +186,7 @@ function buildSwaggerParserOptions(
       http: {
         // SwaggerParser 의 read 콜백 — file.url 로 들어오는 외부 ref 를 동일 fetcher 로.
         read: async (file: { url: string }): Promise<string> => {
-          const result = await fetcher.fetch({ type: "url", url: file.url });
+          const result = await fetcher.fetch({ type: 'url', url: file.url });
           if (result.notModified) {
             throw new Error(
               `unexpected 304 fetching external $ref ${file.url} — fetcher should not pass conditional headers here`,
@@ -200,19 +200,14 @@ function buildSwaggerParserOptions(
 }
 
 async function convertSwagger2(input: object): Promise<object> {
-  const { default: converter } = await import("swagger2openapi");
+  const { default: converter } = await import('swagger2openapi');
   return new Promise((resolve, reject) => {
     converter.convertObj(
       input as Parameters<typeof converter.convertObj>[0],
       { patch: true, warnOnly: true },
       (err, result) => {
         if (err) {
-          reject(
-            new SpecParseError(
-              `swagger 2.0 → 3.0 conversion failed: ${err.message}`,
-              err,
-            ),
-          );
+          reject(new SpecParseError(`swagger 2.0 → 3.0 conversion failed: ${err.message}`, err));
           return;
         }
         resolve(result.openapi as object);

--- a/src/core/registry.test.ts
+++ b/src/core/registry.test.ts
@@ -1,25 +1,22 @@
-import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { createDiskCache } from "./cache";
-import { createSpecRegistry, type SpecRegistry } from "./registry";
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createDiskCache } from './cache';
+import { createSpecRegistry, type SpecRegistry } from './registry';
 import {
   createFetcher,
   type ConditionalHeaders,
   type FetchOutcome,
   type SpecFetcher,
-} from "./fetcher";
-import type { OpenApiMcpConfig, SpecSource } from "./schema";
+} from './fetcher';
+import type { OpenApiMcpConfig, SpecSource } from './schema';
 
-const FIX = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "__fixtures__",
-);
-const PETSTORE_3 = path.join(FIX, "petstore-3.0.json");
-const PETSTORE_2 = path.join(FIX, "petstore-2.0.json");
+const FIX = path.join(path.dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+const PETSTORE_3 = path.join(FIX, 'petstore-3.0.json');
+const PETSTORE_2 = path.join(FIX, 'petstore-2.0.json');
 
 class ProgrammableFetcher implements SpecFetcher {
   fetchCount = 0;
@@ -33,10 +30,7 @@ class ProgrammableFetcher implements SpecFetcher {
     this.etag = opts.etag;
   }
 
-  async fetch(
-    _source: unknown,
-    conditional?: ConditionalHeaders,
-  ): Promise<FetchOutcome> {
+  async fetch(_source: unknown, conditional?: ConditionalHeaders): Promise<FetchOutcome> {
     this.fetchCount += 1;
     this.conditionalCalls.push(conditional ?? {});
     if (this.notModifiedNext) {
@@ -44,7 +38,7 @@ class ProgrammableFetcher implements SpecFetcher {
       return {
         notModified: true,
         fetchedAt: new Date().toISOString(),
-        source: { type: "file", path: "inline" },
+        source: { type: 'file', path: 'inline' },
       };
     }
     return {
@@ -52,14 +46,14 @@ class ProgrammableFetcher implements SpecFetcher {
       body: this.body,
       ...(this.etag !== undefined ? { etag: this.etag } : {}),
       fetchedAt: new Date().toISOString(),
-      source: { type: "file", path: "inline" },
+      source: { type: 'file', path: 'inline' },
     };
   }
 }
 
 const tempDirs: string[] = [];
 function makeTempDir(): string {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "openapi-mcp-cache-"));
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'openapi-mcp-cache-'));
   tempDirs.push(dir);
   return dir;
 }
@@ -74,9 +68,9 @@ function makeConfig(opts: { ttl?: number } = {}): OpenApiMcpConfig {
   return {
     specs: {
       petstore: {
-        source: { type: "file", path: PETSTORE_3 },
+        source: { type: 'file', path: PETSTORE_3 },
         environments: {
-          dev: { baseUrl: "https://api.dev.example.com/petstore" },
+          dev: { baseUrl: 'https://api.dev.example.com/petstore' },
         },
         ...(opts.ttl !== undefined ? { cacheTtlSeconds: opts.ttl } : {}),
       },
@@ -85,30 +79,30 @@ function makeConfig(opts: { ttl?: number } = {}): OpenApiMcpConfig {
 }
 
 async function loadAll(reg: SpecRegistry): Promise<void> {
-  await reg.loadSpec("petstore", "dev");
+  await reg.loadSpec('petstore', 'dev');
 }
 
 async function loadBody(): Promise<string> {
-  return readFile(PETSTORE_3, "utf8");
+  return readFile(PETSTORE_3, 'utf8');
 }
 
 async function flushBackground(): Promise<void> {
   await new Promise((r) => setTimeout(r, 100));
 }
 
-describe("caching behaviour", () => {
-  it("persists fetched specs to disk and re-hydrates on a fresh registry", async () => {
+describe('caching behaviour', () => {
+  it('persists fetched specs to disk and re-hydrates on a fresh registry', async () => {
     const dir = makeTempDir();
     const disk = createDiskCache(dir);
     const body = await loadBody();
-    const fetcher1 = new ProgrammableFetcher(body, { etag: "v1" });
+    const fetcher1 = new ProgrammableFetcher(body, { etag: 'v1' });
     const reg1 = createSpecRegistry(makeConfig(), fetcher1, {
       diskCache: disk,
     });
     await loadAll(reg1);
     expect(fetcher1.fetchCount).toBe(1);
 
-    const fetcher2 = new ProgrammableFetcher(body, { etag: "v1" });
+    const fetcher2 = new ProgrammableFetcher(body, { etag: 'v1' });
     const reg2 = createSpecRegistry(makeConfig({ ttl: 3600 }), fetcher2, {
       diskCache: disk,
     });
@@ -116,11 +110,11 @@ describe("caching behaviour", () => {
     expect(fetcher2.fetchCount).toBe(0);
   });
 
-  it("serves stale data and triggers background refresh with conditional headers", async () => {
+  it('serves stale data and triggers background refresh with conditional headers', async () => {
     const dir = makeTempDir();
     const disk = createDiskCache(dir);
     const body = await loadBody();
-    const fetcher = new ProgrammableFetcher(body, { etag: "abc" });
+    const fetcher = new ProgrammableFetcher(body, { etag: 'abc' });
     const reg = createSpecRegistry(makeConfig({ ttl: 1 }), fetcher, {
       diskCache: disk,
     });
@@ -133,19 +127,19 @@ describe("caching behaviour", () => {
     await flushBackground();
 
     expect(fetcher.fetchCount).toBe(2);
-    expect(fetcher.conditionalCalls[1]).toEqual({ etag: "abc" });
+    expect(fetcher.conditionalCalls[1]).toEqual({ etag: 'abc' });
   });
 
-  it("hydrates a swagger2-formatted source from disk without re-fetching", async () => {
+  it('hydrates a swagger2-formatted source from disk without re-fetching', async () => {
     const dir = makeTempDir();
     const disk = createDiskCache(dir);
-    const swaggerBody = await readFile(PETSTORE_2, "utf8");
+    const swaggerBody = await readFile(PETSTORE_2, 'utf8');
     const config: OpenApiMcpConfig = {
       specs: {
         petstore: {
-          source: { type: "file", path: PETSTORE_2, format: "swagger2" },
+          source: { type: 'file', path: PETSTORE_2, format: 'swagger2' },
           environments: {
-            dev: { baseUrl: "https://api.dev.example.com/petstore" },
+            dev: { baseUrl: 'https://api.dev.example.com/petstore' },
           },
           cacheTtlSeconds: 3600,
         },
@@ -153,71 +147,71 @@ describe("caching behaviour", () => {
     };
     const fetcher1 = new ProgrammableFetcher(swaggerBody);
     const reg1 = createSpecRegistry(config, fetcher1, { diskCache: disk });
-    await reg1.loadSpec("petstore", "dev");
+    await reg1.loadSpec('petstore', 'dev');
     expect(fetcher1.fetchCount).toBe(1);
 
     const fetcher2 = new ProgrammableFetcher(swaggerBody);
     const reg2 = createSpecRegistry(config, fetcher2, { diskCache: disk });
-    const indexed = await reg2.loadSpec("petstore", "dev");
+    const indexed = await reg2.loadSpec('petstore', 'dev');
     expect(fetcher2.fetchCount).toBe(0);
     expect(indexed.document.openapi).toMatch(/^3\./);
   });
 
-  it("resolves relative file source paths against configDir", async () => {
+  it('resolves relative file source paths against configDir', async () => {
     const dir = makeTempDir();
-    const subdir = path.join(dir, "specs");
+    const subdir = path.join(dir, 'specs');
     mkdirSync(subdir, { recursive: true });
-    const target = path.join(subdir, "pet.json");
-    const body = await readFile(PETSTORE_3, "utf8");
+    const target = path.join(subdir, 'pet.json');
+    const body = await readFile(PETSTORE_3, 'utf8');
     writeFileSync(target, body);
 
     const relativeSource: SpecSource = {
-      type: "file",
-      path: "./specs/pet.json",
+      type: 'file',
+      path: './specs/pet.json',
     };
     const config: OpenApiMcpConfig = {
       specs: {
         petstore: {
           source: relativeSource,
           environments: {
-            dev: { baseUrl: "https://api.dev.example.com/petstore" },
+            dev: { baseUrl: 'https://api.dev.example.com/petstore' },
           },
         },
       },
     };
     const reg = createSpecRegistry(config, createFetcher(), { configDir: dir });
-    const indexed = await reg.loadSpec("petstore", "dev");
-    expect(indexed.byOperationId.get("addPet")).toBeDefined();
+    const indexed = await reg.loadSpec('petstore', 'dev');
+    expect(indexed.byOperationId.get('addPet')).toBeDefined();
   });
 
-  it("refresh_spec drops cache and re-fetches without conditional headers", async () => {
+  it('refresh_spec drops cache and re-fetches without conditional headers', async () => {
     const dir = makeTempDir();
     const disk = createDiskCache(dir);
     const body = await loadBody();
-    const fetcher = new ProgrammableFetcher(body, { etag: "v1" });
+    const fetcher = new ProgrammableFetcher(body, { etag: 'v1' });
     const reg = createSpecRegistry(makeConfig({ ttl: 3600 }), fetcher, {
       diskCache: disk,
     });
     await loadAll(reg);
     expect(fetcher.fetchCount).toBe(1);
 
-    const result = await reg.refresh("petstore");
+    const result = await reg.refresh('petstore');
     expect(result[0]?.success).toBe(true);
     expect(fetcher.fetchCount).toBe(2);
     expect(fetcher.conditionalCalls[1]).toEqual({});
   });
 
-  it("registerSpec adds a new ad-hoc spec at runtime", async () => {
+  it('registerSpec adds a new ad-hoc spec at runtime', async () => {
     const fetcher = new ProgrammableFetcher(await loadBody());
     const reg = createSpecRegistry(makeConfig(), fetcher, {});
-    expect(reg.hasSpec("petstore")).toBe(true);
-    expect(reg.hasSpec("ad-hoc")).toBe(false);
-    reg.registerSpec("ad-hoc", {
-      source: { type: "file", path: PETSTORE_3 },
-      environments: { default: { baseUrl: "" } },
+    expect(reg.hasSpec('petstore')).toBe(true);
+    expect(reg.hasSpec('ad-hoc')).toBe(false);
+    reg.registerSpec('ad-hoc', {
+      source: { type: 'file', path: PETSTORE_3 },
+      environments: { default: { baseUrl: '' } },
     });
-    expect(reg.hasSpec("ad-hoc")).toBe(true);
-    const ix = await reg.loadSpec("ad-hoc", "default");
+    expect(reg.hasSpec('ad-hoc')).toBe(true);
+    const ix = await reg.loadSpec('ad-hoc', 'default');
     expect(ix.endpoints.length).toBeGreaterThan(0);
   });
 });

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -1,21 +1,17 @@
-import path from "node:path";
-import {
-  createNoopDiskCache,
-  type DiskCache,
-  type DiskCacheEntry,
-} from "./cache";
-import { getLogger } from "./logger";
-import type { FetcherOptions, SpecFetcher } from "./fetcher";
-import type { OpenAPIV3 } from "openapi-types";
-import { indexSpec, type IndexedSpec } from "./indexer";
-import { parseSpecText } from "./parser";
+import path from 'node:path';
+import { createNoopDiskCache, type DiskCache, type DiskCacheEntry } from './cache';
+import { getLogger } from './logger';
+import type { FetcherOptions, SpecFetcher } from './fetcher';
+import type { OpenAPIV3 } from 'openapi-types';
+import { indexSpec, type IndexedSpec } from './indexer';
+import { parseSpecText } from './parser';
 import {
   DEFAULT_CACHE_TTL_SECONDS,
   type EnvironmentConfig,
   type OpenApiMcpConfig,
   type SpecConfig,
   type SpecSource,
-} from "./schema";
+} from './schema';
 
 /**
  * 메모리 + 디스크 캐시를 끼워둔 OpenAPI spec 레지스트리. SpecRegistry 가 caller (tool
@@ -54,7 +50,7 @@ interface CachedSpec {
   fetchedAt: string;
   source: SpecSource;
   document: object;
-  detectedFormat: "openapi3" | "swagger2";
+  detectedFormat: 'openapi3' | 'swagger2';
   etag?: string;
   lastModified?: string;
   ttlSeconds: number;
@@ -64,7 +60,7 @@ interface CachedSpec {
  * loadSpec 결과가 어디서 왔는지. handler 가 사용자에게 "remote 호출 발생 여부"
  * 를 정확히 보고하기 위해 필요 — 디스크 hydrate 도 cache hit 으로 친다.
  */
-export type LoadSource = "memory" | "disk" | "remote";
+export type LoadSource = 'memory' | 'disk' | 'remote';
 
 export interface DetailedLoadResult {
   indexed: IndexedSpec;
@@ -82,19 +78,13 @@ export interface SpecRegistry {
    * remote fetch 를 일으키지 않은 호출인지 (memory / disk hit) 또는 remote
    * 였는지 caller 가 그대로 사용자에게 노출할 수 있다.
    */
-  loadSpecDetailed(
-    specName: string,
-    environment?: string,
-  ): Promise<DetailedLoadResult>;
+  loadSpecDetailed(specName: string, environment?: string): Promise<DetailedLoadResult>;
   /**
    * 메모리 또는 디스크 캐시에서만 spec 을 로드. cache miss 면 null —
    * remote fetch 는 절대 일으키지 않는다. `openapi_search` 처럼 "remote 호출
    * 없음" 을 계약으로 보장해야 하는 경로에서 사용.
    */
-  loadSpecCachedOnly(
-    specName: string,
-    environment?: string,
-  ): Promise<IndexedSpec | null>;
+  loadSpecCachedOnly(specName: string, environment?: string): Promise<IndexedSpec | null>;
   getEnvironment(specName: string, environment: string): EnvironmentConfig;
   refresh(specName?: string): Promise<RefreshOutcome[]>;
   hasSpec(specName: string): boolean;
@@ -116,14 +106,14 @@ export interface RefreshOutcome {
 export class UnknownSpecError extends Error {
   constructor(specName: string) {
     super(`unknown spec '${specName}'`);
-    this.name = "UnknownSpecError";
+    this.name = 'UnknownSpecError';
   }
 }
 
 export class UnknownEnvironmentError extends Error {
   constructor(specName: string, environment: string) {
     super(`unknown environment '${environment}' for spec '${specName}'`);
-    this.name = "UnknownEnvironmentError";
+    this.name = 'UnknownEnvironmentError';
   }
 }
 
@@ -188,9 +178,7 @@ class InMemorySpecRegistry implements SpecRegistry {
   listSpecs(): SpecSummary[] {
     return Object.entries(this.config.specs).map(([name, spec]) => ({
       name,
-      ...(spec.description !== undefined
-        ? { description: spec.description }
-        : {}),
+      ...(spec.description !== undefined ? { description: spec.description } : {}),
       environments: Object.keys(spec.environments),
       cacheStatus: this.cacheStatus(name, spec),
     }));
@@ -201,16 +189,16 @@ class InMemorySpecRegistry implements SpecRegistry {
     return Object.entries(spec.environments).map(([name, env]) => ({
       name,
       baseUrl: env.baseUrl,
-      ...(env.description !== undefined
-        ? { description: env.description }
-        : {}),
+      ...(env.description !== undefined ? { description: env.description } : {}),
     }));
   }
 
   getEnvironment(specName: string, environment: string): EnvironmentConfig {
     const spec = this.requireSpec(specName);
     const env = spec.environments[environment];
-    if (!env) throw new UnknownEnvironmentError(specName, environment);
+    if (!env) {
+      throw new UnknownEnvironmentError(specName, environment);
+    }
     return env;
   }
 
@@ -218,10 +206,7 @@ class InMemorySpecRegistry implements SpecRegistry {
     return (await this.loadSpecDetailed(specName, environment)).indexed;
   }
 
-  async loadSpecDetailed(
-    specName: string,
-    environment?: string,
-  ): Promise<DetailedLoadResult> {
+  async loadSpecDetailed(specName: string, environment?: string): Promise<DetailedLoadResult> {
     const spec = this.requireSpec(specName);
     const source = this.resolveSource(specName, spec, environment);
     const ttlSeconds = spec.cacheTtlSeconds ?? DEFAULT_CACHE_TTL_SECONDS;
@@ -229,34 +214,34 @@ class InMemorySpecRegistry implements SpecRegistry {
 
     const memHit = this.cache.get(key);
     if (memHit) {
-      if (this.isStale(memHit))
+      if (this.isStale(memHit)) {
         this.scheduleBackgroundRefresh(specName, source, ttlSeconds);
-      return { indexed: memHit.indexed, source: "memory", fromCache: true };
+      }
+      return { indexed: memHit.indexed, source: 'memory', fromCache: true };
     }
 
     const inFlight = this.inFlight.get(key);
-    if (inFlight) return inFlight;
+    if (inFlight) {
+      return inFlight;
+    }
 
-    const promise = this.hydrateOrFetch(specName, source, ttlSeconds).finally(
-      () => {
-        this.inFlight.delete(key);
-      },
-    );
+    const promise = this.hydrateOrFetch(specName, source, ttlSeconds).finally(() => {
+      this.inFlight.delete(key);
+    });
     this.inFlight.set(key, promise);
     return promise;
   }
 
-  async loadSpecCachedOnly(
-    specName: string,
-    environment?: string,
-  ): Promise<IndexedSpec | null> {
+  async loadSpecCachedOnly(specName: string, environment?: string): Promise<IndexedSpec | null> {
     const spec = this.requireSpec(specName);
     const source = this.resolveSource(specName, spec, environment);
     const ttlSeconds = spec.cacheTtlSeconds ?? DEFAULT_CACHE_TTL_SECONDS;
     const key = this.cacheKey(specName, source);
 
     const memHit = this.cache.get(key);
-    if (memHit) return memHit.indexed;
+    if (memHit) {
+      return memHit.indexed;
+    }
 
     const hydrated = await this.hydrateFromDisk(specName, source, ttlSeconds);
     return hydrated?.indexed ?? null;
@@ -268,9 +253,7 @@ class InMemorySpecRegistry implements SpecRegistry {
     // source (default + env override) 도 같이 병렬 — 한 spec 의 source 하나가
     // 실패해도 같은 spec 의 다른 source 까지 끌어내리지 않게 try/catch 는 spec
     // 단위로 둔다.
-    const settled = await Promise.all(
-      targets.map((name) => this.refreshOne(name)),
-    );
+    const settled = await Promise.all(targets.map((name) => this.refreshOne(name)));
     return settled;
   }
 
@@ -304,8 +287,7 @@ class InMemorySpecRegistry implements SpecRegistry {
       // fetchedAt 는 sourcesByKey 의 첫 entry 기준 — 보고 용도라 정확성보다 일관성 우선.
       const firstKey = sourcesByKey.keys().next().value;
       const fetchedAt =
-        (firstKey ? this.cache.get(firstKey)?.fetchedAt : undefined) ??
-        new Date().toISOString();
+        (firstKey ? this.cache.get(firstKey)?.fetchedAt : undefined) ?? new Date().toISOString();
       return { spec: name, success: true, fetchedAt };
     } catch (err) {
       return {
@@ -322,10 +304,11 @@ class InMemorySpecRegistry implements SpecRegistry {
     ttlSeconds: number,
   ): Promise<DetailedLoadResult> {
     const hydrated = await this.hydrateFromDisk(specName, source, ttlSeconds);
-    if (hydrated)
-      return { indexed: hydrated.indexed, source: "disk", fromCache: true };
+    if (hydrated) {
+      return { indexed: hydrated.indexed, source: 'disk', fromCache: true };
+    }
     const indexed = await this.fetchAndStore(specName, source, ttlSeconds);
-    return { indexed, source: "remote", fromCache: false };
+    return { indexed, source: 'remote', fromCache: false };
   }
 
   /**
@@ -340,7 +323,9 @@ class InMemorySpecRegistry implements SpecRegistry {
   ): Promise<{ indexed: IndexedSpec } | null> {
     const key = this.cacheKey(specName, source);
     const disk = await this.diskCache.read(key);
-    if (!disk) return null;
+    if (!disk) {
+      return null;
+    }
     try {
       // 디스크 캐시는 이미 deref 된 OpenAPI 3.x document 를 보관하므로, 다시
       // SwaggerParser.dereference 를 돌리지 않고 곧장 indexSpec 으로 넘긴다 —
@@ -354,19 +339,18 @@ class InMemorySpecRegistry implements SpecRegistry {
         document,
         detectedFormat: disk.detectedFormat,
         ...(disk.etag !== undefined ? { etag: disk.etag } : {}),
-        ...(disk.lastModified !== undefined
-          ? { lastModified: disk.lastModified }
-          : {}),
+        ...(disk.lastModified !== undefined ? { lastModified: disk.lastModified } : {}),
         ttlSeconds,
       };
       this.cache.set(key, cached);
-      if (this.isStale(cached))
+      if (this.isStale(cached)) {
         this.scheduleBackgroundRefresh(specName, source, ttlSeconds);
+      }
       return { indexed };
     } catch (err) {
       getLogger().warn(
         { err, spec: specName },
-        "disk cache hydrate failed; falling back to fresh fetch",
+        'disk cache hydrate failed; falling back to fresh fetch',
       );
       await this.diskCache.delete(key);
       return null;
@@ -381,15 +365,11 @@ class InMemorySpecRegistry implements SpecRegistry {
     const key = this.cacheKey(specName, source);
     const fetched = await this.fetcher.fetch(source);
     if (fetched.notModified) {
-      throw new Error(
-        `unexpected 304 response for spec '${specName}' on initial load`,
-      );
+      throw new Error(`unexpected 304 response for spec '${specName}' on initial load`);
     }
     const parsed = await parseSpecText(fetched.body, source.format, {
       sourceLocation: this.sourceLocationOf(source),
-      ...(this.parseFetcherOptions
-        ? { fetcherOptions: this.parseFetcherOptions }
-        : {}),
+      ...(this.parseFetcherOptions ? { fetcherOptions: this.parseFetcherOptions } : {}),
     });
     const indexed = indexSpec(specName, parsed.document);
     const cached: CachedSpec = {
@@ -399,9 +379,7 @@ class InMemorySpecRegistry implements SpecRegistry {
       document: parsed.document,
       detectedFormat: parsed.detectedFormat,
       ...(fetched.etag !== undefined ? { etag: fetched.etag } : {}),
-      ...(fetched.lastModified !== undefined
-        ? { lastModified: fetched.lastModified }
-        : {}),
+      ...(fetched.lastModified !== undefined ? { lastModified: fetched.lastModified } : {}),
       ttlSeconds,
     };
     this.cache.set(key, cached);
@@ -415,13 +393,13 @@ class InMemorySpecRegistry implements SpecRegistry {
     ttlSeconds: number,
   ): void {
     const key = this.cacheKey(specName, source);
-    if (this.backgroundRefreshes.has(key)) return;
+    if (this.backgroundRefreshes.has(key)) {
+      return;
+    }
     this.backgroundRefreshes.add(key);
-    void this.runBackgroundRefresh(specName, source, ttlSeconds, key).finally(
-      () => {
-        this.backgroundRefreshes.delete(key);
-      },
-    );
+    void this.runBackgroundRefresh(specName, source, ttlSeconds, key).finally(() => {
+      this.backgroundRefreshes.delete(key);
+    });
   }
 
   private async runBackgroundRefresh(
@@ -431,15 +409,22 @@ class InMemorySpecRegistry implements SpecRegistry {
     key: string,
   ): Promise<void> {
     const existing = this.cache.get(key);
-    if (!existing) return;
+    if (!existing) {
+      return;
+    }
     try {
       const conditional: { etag?: string; lastModified?: string } = {};
-      if (existing.etag) conditional.etag = existing.etag;
-      if (existing.lastModified)
+      if (existing.etag) {
+        conditional.etag = existing.etag;
+      }
+      if (existing.lastModified) {
         conditional.lastModified = existing.lastModified;
+      }
       const fetched = await this.fetcher.fetch(source, conditional);
       const current = this.cache.get(key);
-      if (!current) return;
+      if (!current) {
+        return;
+      }
       if (fetched.notModified) {
         const refreshed: CachedSpec = {
           ...current,
@@ -464,18 +449,13 @@ class InMemorySpecRegistry implements SpecRegistry {
         document: parsed.document,
         detectedFormat: parsed.detectedFormat,
         ...(fetched.etag !== undefined ? { etag: fetched.etag } : {}),
-        ...(fetched.lastModified !== undefined
-          ? { lastModified: fetched.lastModified }
-          : {}),
+        ...(fetched.lastModified !== undefined ? { lastModified: fetched.lastModified } : {}),
         ttlSeconds,
       };
       this.cache.set(key, refreshed);
       await this.diskCache.write(key, this.toDiskEntry(refreshed));
     } catch (err) {
-      getLogger().warn(
-        { err, spec: specName },
-        "background refresh failed; serving stale cache",
-      );
+      getLogger().warn({ err, spec: specName }, 'background refresh failed; serving stale cache');
     }
   }
 
@@ -484,9 +464,7 @@ class InMemorySpecRegistry implements SpecRegistry {
       schemaVersion: 1,
       cachedAt: cached.fetchedAt,
       ...(cached.etag !== undefined ? { etag: cached.etag } : {}),
-      ...(cached.lastModified !== undefined
-        ? { lastModified: cached.lastModified }
-        : {}),
+      ...(cached.lastModified !== undefined ? { lastModified: cached.lastModified } : {}),
       source: cached.source,
       detectedFormat: cached.detectedFormat,
       document: cached.document,
@@ -508,22 +486,24 @@ class InMemorySpecRegistry implements SpecRegistry {
     return { cached: false, ttlSeconds };
   }
 
-  private resolveSource(
-    specName: string,
-    spec: SpecConfig,
-    environment?: string,
-  ): SpecSource {
+  private resolveSource(specName: string, spec: SpecConfig, environment?: string): SpecSource {
     let source: SpecSource = spec.source;
     if (environment) {
       const env = spec.environments[environment];
-      if (!env) throw new UnknownEnvironmentError(specName, environment);
-      if (env.source) source = env.source;
+      if (!env) {
+        throw new UnknownEnvironmentError(specName, environment);
+      }
+      if (env.source) {
+        source = env.source;
+      }
     }
     return this.resolveFilePath(source);
   }
 
   private resolveFilePath(source: SpecSource): SpecSource {
-    if (source.type !== "file" || path.isAbsolute(source.path)) return source;
+    if (source.type !== 'file' || path.isAbsolute(source.path)) {
+      return source;
+    }
     const baseDir = this.configDir ?? process.cwd();
     return { ...source, path: path.resolve(baseDir, source.path) };
   }
@@ -535,18 +515,20 @@ class InMemorySpecRegistry implements SpecRegistry {
    * 정확한 base 위에서 동작하도록.
    */
   private sourceLocationOf(source: SpecSource): string {
-    return source.type === "file" ? source.path : source.url;
+    return source.type === 'file' ? source.path : source.url;
   }
 
   private cacheKey(specName: string, source: SpecSource): string {
-    const target = source.type === "url" ? source.url : source.path;
-    const format = source.format ?? "auto";
+    const target = source.type === 'url' ? source.url : source.path;
+    const format = source.format ?? 'auto';
     return `${specName}::${source.type}::${target}::${format}`;
   }
 
   private requireSpec(specName: string): SpecConfig {
     const spec = this.config.specs[specName];
-    if (!spec) throw new UnknownSpecError(specName);
+    if (!spec) {
+      throw new UnknownSpecError(specName);
+    }
     return spec;
   }
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from 'zod';
 
 /**
  * `openapi-mcp` 단독 진입점 (`bin/openapi-mcp`) 이 받는 config 파일의 스키마.
@@ -10,16 +10,16 @@ import { z } from "zod";
  * zod v4 (agent-toolkit 의 prod dep) 기준으로 작성되어 있으므로 v3 호환 API 는 쓰지 않는다.
  */
 
-const SpecFormatSchema = z.enum(["openapi3", "swagger2", "auto"]);
+const SpecFormatSchema = z.enum(['openapi3', 'swagger2', 'auto']);
 
-const SpecSourceSchema = z.discriminatedUnion("type", [
+const SpecSourceSchema = z.discriminatedUnion('type', [
   z.object({
-    type: z.literal("url"),
+    type: z.literal('url'),
     url: z.string().url(),
     format: SpecFormatSchema.optional(),
   }),
   z.object({
-    type: z.literal("file"),
+    type: z.literal('file'),
     path: z.string().min(1),
     format: SpecFormatSchema.optional(),
   }),
@@ -37,7 +37,7 @@ const SpecConfigSchema = z.object({
   environments: z
     .record(z.string().min(1), EnvironmentConfigSchema)
     .refine((envs) => Object.keys(envs).length > 0, {
-      message: "each spec must declare at least one environment",
+      message: 'each spec must declare at least one environment',
     }),
   cacheTtlSeconds: z.number().int().positive().optional(),
 });
@@ -57,7 +57,7 @@ export const OpenApiMcpConfigSchema = z.object({
   specs: z
     .record(z.string().min(1), SpecConfigSchema)
     .refine((specs) => Object.keys(specs).length > 0, {
-      message: "config.specs must contain at least one entry",
+      message: 'config.specs must contain at least one entry',
     }),
   cache: GlobalCacheConfigSchema.optional(),
   http: GlobalHttpConfigSchema.optional(),

--- a/src/core/toolkit-config.test.ts
+++ b/src/core/toolkit-config.test.ts
@@ -1,166 +1,135 @@
-import { describe, it, expect, beforeEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import {
-  loadConfig,
-  mergeConfigs,
-  validateConfig,
-  type ToolkitConfig,
-} from "./toolkit-config";
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfig, mergeConfigs, validateConfig, type ToolkitConfig } from './toolkit-config';
 
 let userDir: string;
 let userPath: string;
 let projectRoot: string;
 
 beforeEach(() => {
-  const root = mkdtempSync(join(tmpdir(), "agent-toolkit-config-"));
-  userDir = join(root, "user");
+  const root = mkdtempSync(join(tmpdir(), 'agent-toolkit-config-'));
+  userDir = join(root, 'user');
   mkdirSync(userDir, { recursive: true });
-  userPath = join(userDir, "agent-toolkit.json");
-  projectRoot = mkdtempSync(join(tmpdir(), "agent-toolkit-project-"));
+  userPath = join(userDir, 'agent-toolkit.json');
+  projectRoot = mkdtempSync(join(tmpdir(), 'agent-toolkit-project-'));
 });
 
 const writeUser = (config: ToolkitConfig) => {
-  writeFileSync(userPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  writeFileSync(userPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
 };
 
 const writeProject = (config: ToolkitConfig) => {
-  const dir = join(projectRoot, ".opencode");
+  const dir = join(projectRoot, '.opencode');
   mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    join(dir, "agent-toolkit.json"),
-    `${JSON.stringify(config, null, 2)}\n`,
-    "utf8",
-  );
+  writeFileSync(join(dir, 'agent-toolkit.json'), `${JSON.stringify(config, null, 2)}\n`, 'utf8');
 };
 
-describe("validateConfig", () => {
-  it("accepts an empty object", () => {
-    expect(validateConfig({}, "test")).toEqual({});
+describe('validateConfig', () => {
+  it('accepts an empty object', () => {
+    expect(validateConfig({}, 'test')).toEqual({});
   });
 
-  it("accepts a registry with valid identifiers", () => {
+  it('accepts a registry with valid identifiers', () => {
     const config: ToolkitConfig = {
       openapi: {
         registry: {
-          acme: { dev: { users: "https://example.com/users.json" } },
+          acme: { dev: { users: 'https://example.com/users.json' } },
         },
       },
     };
-    expect(validateConfig(config, "test")).toEqual(config);
+    expect(validateConfig(config, 'test')).toEqual(config);
   });
 
-  it("rejects non-object root", () => {
-    expect(() => validateConfig(null, "p")).toThrow(/must be a JSON object/);
-    expect(() => validateConfig([], "p")).toThrow(/must be a JSON object/);
-    expect(() => validateConfig("str", "p")).toThrow(/must be a JSON object/);
+  it('rejects non-object root', () => {
+    expect(() => validateConfig(null, 'p')).toThrow(/must be a JSON object/);
+    expect(() => validateConfig([], 'p')).toThrow(/must be a JSON object/);
+    expect(() => validateConfig('str', 'p')).toThrow(/must be a JSON object/);
   });
 
-  it("rejects host name with colon", () => {
+  it('rejects host name with colon', () => {
     expect(() =>
-      validateConfig(
-        { openapi: { registry: { "ac:me": { dev: { users: "u" } } } } },
-        "p",
-      ),
+      validateConfig({ openapi: { registry: { 'ac:me': { dev: { users: 'u' } } } } }, 'p'),
     ).toThrow(/host name/);
   });
 
-  it("rejects env name with whitespace", () => {
+  it('rejects env name with whitespace', () => {
     expect(() =>
-      validateConfig(
-        { openapi: { registry: { acme: { "de v": { users: "u" } } } } },
-        "p",
-      ),
+      validateConfig({ openapi: { registry: { acme: { 'de v': { users: 'u' } } } } }, 'p'),
     ).toThrow(/env name/);
   });
 
-  it("rejects empty / whitespace-only URL", () => {
+  it('rejects empty / whitespace-only URL', () => {
     expect(() =>
-      validateConfig(
-        { openapi: { registry: { acme: { dev: { users: "" } } } } },
-        "p",
-      ),
+      validateConfig({ openapi: { registry: { acme: { dev: { users: '' } } } } }, 'p'),
     ).toThrow(/non-empty URL/);
     expect(() =>
-      validateConfig(
-        { openapi: { registry: { acme: { dev: { users: "   " } } } } },
-        "p",
-      ),
+      validateConfig({ openapi: { registry: { acme: { dev: { users: '   ' } } } } }, 'p'),
     ).toThrow(/non-empty URL/);
   });
 
-  it("rejects non-string URL", () => {
+  it('rejects non-string URL', () => {
     expect(() =>
-      validateConfig(
-        { openapi: { registry: { acme: { dev: { users: 42 } } } } },
-        "p",
-      ),
+      validateConfig({ openapi: { registry: { acme: { dev: { users: 42 } } } } }, 'p'),
     ).toThrow(/non-empty URL/);
   });
 
-  it("rejects unparseable URL string", () => {
+  it('rejects unparseable URL string', () => {
     expect(() =>
       validateConfig(
         {
-          openapi: { registry: { acme: { dev: { users: "not a url" } } } },
+          openapi: { registry: { acme: { dev: { users: 'not a url' } } } },
         },
-        "p",
+        'p',
       ),
     ).toThrow(/not a valid URL/);
   });
 
-  it("rejects unsupported URL scheme", () => {
+  it('rejects unsupported URL scheme', () => {
     expect(() =>
       validateConfig(
         {
           openapi: {
             registry: {
-              acme: { dev: { users: "ftp://example.com/spec.json" } },
+              acme: { dev: { users: 'ftp://example.com/spec.json' } },
             },
           },
         },
-        "p",
+        'p',
       ),
     ).toThrow(/unsupported scheme/);
   });
 
-  it("accepts http / https / file URLs", () => {
+  it('accepts http / https / file URLs', () => {
     for (const url of [
-      "http://example.com/spec.json",
-      "https://example.com/spec.json",
-      "file:///tmp/spec.json",
+      'http://example.com/spec.json',
+      'https://example.com/spec.json',
+      'file:///tmp/spec.json',
     ]) {
       expect(() =>
-        validateConfig(
-          { openapi: { registry: { acme: { dev: { users: url } } } } },
-          "p",
-        ),
+        validateConfig({ openapi: { registry: { acme: { dev: { users: url } } } } }, 'p'),
       ).not.toThrow();
     }
   });
 
-  it("allows unknown top-level keys for forward compatibility", () => {
+  it('allows unknown top-level keys for forward compatibility', () => {
     // 도메인 재추가 시 같은 파일 (`mysql` / `spec` / `github` 등) 이 future-key 자리에
     // 다시 들어올 수 있어야 한다 — top-level 미지원 키는 통과시킨다.
-    expect(() =>
-      validateConfig({ futureFeature: { foo: "bar" } } as any, "p"),
-    ).not.toThrow();
-    expect(() =>
-      validateConfig({ mysql: { connections: {} } } as any, "p"),
-    ).not.toThrow();
+    expect(() => validateConfig({ futureFeature: { foo: 'bar' } } as any, 'p')).not.toThrow();
+    expect(() => validateConfig({ mysql: { connections: {} } } as any, 'p')).not.toThrow();
   });
 });
 
-describe("mergeConfigs", () => {
-  it("project overrides user at the leaf", () => {
+describe('mergeConfigs', () => {
+  it('project overrides user at the leaf', () => {
     const user: ToolkitConfig = {
       openapi: {
         registry: {
           acme: {
             dev: {
-              users: "https://user/u.json",
-              orders: "https://user/o.json",
+              users: 'https://user/u.json',
+              orders: 'https://user/o.json',
             },
           },
         },
@@ -169,104 +138,88 @@ describe("mergeConfigs", () => {
     const project: ToolkitConfig = {
       openapi: {
         registry: {
-          acme: { dev: { users: "https://project/u.json" } },
+          acme: { dev: { users: 'https://project/u.json' } },
         },
       },
     };
     const merged = mergeConfigs(user, project);
-    expect(merged.openapi?.registry?.acme?.dev?.users).toBe(
-      "https://project/u.json",
-    );
+    expect(merged.openapi?.registry?.acme?.dev?.users).toBe('https://project/u.json');
     // user-only spec survives.
-    expect(merged.openapi?.registry?.acme?.dev?.orders).toBe(
-      "https://user/o.json",
-    );
+    expect(merged.openapi?.registry?.acme?.dev?.orders).toBe('https://user/o.json');
   });
 
-  it("project can introduce new host / env / spec", () => {
+  it('project can introduce new host / env / spec', () => {
     const user: ToolkitConfig = {
       openapi: {
-        registry: { acme: { dev: { users: "https://u.example/u.json" } } },
+        registry: { acme: { dev: { users: 'https://u.example/u.json' } } },
       },
     };
     const project: ToolkitConfig = {
       openapi: {
         registry: {
-          acme: { prod: { users: "https://p.example/u.json" } },
-          beta: { dev: { svc: "https://b.example/svc.json" } },
+          acme: { prod: { users: 'https://p.example/u.json' } },
+          beta: { dev: { svc: 'https://b.example/svc.json' } },
         },
       },
     };
     const merged = mergeConfigs(user, project);
-    expect(merged.openapi?.registry?.acme?.prod?.users).toBe(
-      "https://p.example/u.json",
-    );
-    expect(merged.openapi?.registry?.beta?.dev?.svc).toBe(
-      "https://b.example/svc.json",
-    );
-    expect(merged.openapi?.registry?.acme?.dev?.users).toBe(
-      "https://u.example/u.json",
-    );
+    expect(merged.openapi?.registry?.acme?.prod?.users).toBe('https://p.example/u.json');
+    expect(merged.openapi?.registry?.beta?.dev?.svc).toBe('https://b.example/svc.json');
+    expect(merged.openapi?.registry?.acme?.dev?.users).toBe('https://u.example/u.json');
   });
 
-  it("returns a deep clone — mutating the result does not touch input", () => {
+  it('returns a deep clone — mutating the result does not touch input', () => {
     const user: ToolkitConfig = {
-      openapi: { registry: { acme: { dev: { users: "https://u/u.json" } } } },
+      openapi: { registry: { acme: { dev: { users: 'https://u/u.json' } } } },
     };
     const merged = mergeConfigs(user, {});
-    merged.openapi!.registry!.acme!.dev!.users = "MUTATED";
-    expect(user.openapi?.registry?.acme?.dev?.users).toBe("https://u/u.json");
+    merged.openapi!.registry!.acme!.dev!.users = 'MUTATED';
+    expect(user.openapi?.registry?.acme?.dev?.users).toBe('https://u/u.json');
   });
 });
 
-describe("loadConfig", () => {
-  it("returns {} with no errors when neither file exists", async () => {
+describe('loadConfig', () => {
+  it('returns {} with no errors when neither file exists', async () => {
     const r = await loadConfig({ userPath, projectRoot });
     expect(r.config).toEqual({});
     expect(r.errors).toEqual([]);
   });
 
-  it("loads user-only when project is absent", async () => {
+  it('loads user-only when project is absent', async () => {
     writeUser({
-      openapi: { registry: { acme: { dev: { users: "https://u/u.json" } } } },
+      openapi: { registry: { acme: { dev: { users: 'https://u/u.json' } } } },
     });
     const r = await loadConfig({ userPath, projectRoot });
-    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe(
-      "https://u/u.json",
-    );
+    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe('https://u/u.json');
     expect(r.errors).toEqual([]);
   });
 
-  it("loads project-only when user is absent", async () => {
+  it('loads project-only when user is absent', async () => {
     writeProject({
-      openapi: { registry: { acme: { prod: { users: "https://p/u.json" } } } },
+      openapi: { registry: { acme: { prod: { users: 'https://p/u.json' } } } },
     });
     const r = await loadConfig({ userPath, projectRoot });
-    expect(r.config.openapi?.registry?.acme?.prod?.users).toBe(
-      "https://p/u.json",
-    );
+    expect(r.config.openapi?.registry?.acme?.prod?.users).toBe('https://p/u.json');
     expect(r.errors).toEqual([]);
   });
 
-  it("merges with project taking precedence", async () => {
+  it('merges with project taking precedence', async () => {
     writeUser({
       openapi: {
-        registry: { acme: { dev: { users: "https://user/u.json" } } },
+        registry: { acme: { dev: { users: 'https://user/u.json' } } },
       },
     });
     writeProject({
       openapi: {
-        registry: { acme: { dev: { users: "https://project/u.json" } } },
+        registry: { acme: { dev: { users: 'https://project/u.json' } } },
       },
     });
     const r = await loadConfig({ userPath, projectRoot });
-    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe(
-      "https://project/u.json",
-    );
+    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe('https://project/u.json');
   });
 
-  it("reports malformed JSON in errors[] without throwing", async () => {
-    writeFileSync(userPath, "{ not json", "utf8");
+  it('reports malformed JSON in errors[] without throwing', async () => {
+    writeFileSync(userPath, '{ not json', 'utf8');
     const r = await loadConfig({ userPath, projectRoot });
     expect(r.errors.length).toBe(1);
     expect(r.errors[0]?.source).toBe(userPath);
@@ -274,55 +227,47 @@ describe("loadConfig", () => {
     expect(r.config).toEqual({});
   });
 
-  it("reports schema-violating config in errors[] without throwing", async () => {
+  it('reports schema-violating config in errors[] without throwing', async () => {
     writeUser({
-      openapi: { registry: { "bad:host": { dev: { users: "u" } } } } as any,
+      openapi: { registry: { 'bad:host': { dev: { users: 'u' } } } } as any,
     });
     const r = await loadConfig({ userPath, projectRoot });
     expect(r.errors.length).toBe(1);
     expect(r.errors[0]?.message).toMatch(/host name/);
   });
 
-  it("preserves valid project config when user file is malformed", async () => {
-    writeFileSync(userPath, "{ broken", "utf8");
+  it('preserves valid project config when user file is malformed', async () => {
+    writeFileSync(userPath, '{ broken', 'utf8');
     writeProject({
       openapi: {
-        registry: { acme: { prod: { users: "https://api.acme/u.json" } } },
+        registry: { acme: { prod: { users: 'https://api.acme/u.json' } } },
       },
     });
     const r = await loadConfig({ userPath, projectRoot });
     expect(r.errors.length).toBe(1);
     expect(r.errors[0]?.source).toBe(userPath);
-    expect(r.config.openapi?.registry?.acme?.prod?.users).toBe(
-      "https://api.acme/u.json",
-    );
+    expect(r.config.openapi?.registry?.acme?.prod?.users).toBe('https://api.acme/u.json');
   });
 
-  it("preserves valid user config when project file is malformed", async () => {
+  it('preserves valid user config when project file is malformed', async () => {
     writeUser({
       openapi: {
-        registry: { acme: { dev: { users: "https://dev.acme/u.json" } } },
+        registry: { acme: { dev: { users: 'https://dev.acme/u.json' } } },
       },
     });
-    const projectFile = join(projectRoot, ".opencode", "agent-toolkit.json");
-    mkdirSync(join(projectRoot, ".opencode"), { recursive: true });
-    writeFileSync(projectFile, "{ also broken", "utf8");
+    const projectFile = join(projectRoot, '.opencode', 'agent-toolkit.json');
+    mkdirSync(join(projectRoot, '.opencode'), { recursive: true });
+    writeFileSync(projectFile, '{ also broken', 'utf8');
     const r = await loadConfig({ userPath, projectRoot });
     expect(r.errors.length).toBe(1);
     expect(r.errors[0]?.source).toBe(projectFile);
-    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe(
-      "https://dev.acme/u.json",
-    );
+    expect(r.config.openapi?.registry?.acme?.dev?.users).toBe('https://dev.acme/u.json');
   });
 
-  it("collects errors from both files when both are malformed", async () => {
-    writeFileSync(userPath, "{ user broken", "utf8");
-    mkdirSync(join(projectRoot, ".opencode"), { recursive: true });
-    writeFileSync(
-      join(projectRoot, ".opencode", "agent-toolkit.json"),
-      "{ project broken",
-      "utf8",
-    );
+  it('collects errors from both files when both are malformed', async () => {
+    writeFileSync(userPath, '{ user broken', 'utf8');
+    mkdirSync(join(projectRoot, '.opencode'), { recursive: true });
+    writeFileSync(join(projectRoot, '.opencode', 'agent-toolkit.json'), '{ project broken', 'utf8');
     const r = await loadConfig({ userPath, projectRoot });
     expect(r.errors.length).toBe(2);
     expect(r.config).toEqual({});

--- a/src/core/toolkit-config.ts
+++ b/src/core/toolkit-config.ts
@@ -1,7 +1,7 @@
-import { existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 /**
  * openapi-core 의 단일 config 로더 + 검증.
@@ -33,7 +33,7 @@ export interface OpenapiRegistryLeafObject {
   /** 환경의 실제 API base URL — `openapi_endpoint` 의 fullUrl 합성에 사용. */
   baseUrl?: string;
   /** 형식 hint. 미지정이면 본문의 `openapi` / `swagger` 필드로 자동 감지. */
-  format?: "openapi3" | "swagger2" | "auto";
+  format?: 'openapi3' | 'swagger2' | 'auto';
 }
 
 export type OpenapiRegistryLeaf = string | OpenapiRegistryLeafObject;
@@ -48,22 +48,24 @@ export interface OpenapiRegistry {
 
 /** leaf 가 string 이든 object 이든 spec URL 을 꺼낸다. */
 export function getRegistryUrl(leaf: OpenapiRegistryLeaf): string {
-  return typeof leaf === "string" ? leaf : leaf.url;
+  return typeof leaf === 'string' ? leaf : leaf.url;
 }
 
 /** leaf 의 baseUrl. string leaf 또는 baseUrl 미선언 object 면 undefined. */
-export function getRegistryBaseUrl(
-  leaf: OpenapiRegistryLeaf,
-): string | undefined {
-  if (typeof leaf === "string") return undefined;
+export function getRegistryBaseUrl(leaf: OpenapiRegistryLeaf): string | undefined {
+  if (typeof leaf === 'string') {
+    return undefined;
+  }
   return leaf.baseUrl;
 }
 
 /** leaf 의 format hint. string leaf 또는 format 미선언 object 면 undefined. */
 export function getRegistryFormat(
   leaf: OpenapiRegistryLeaf,
-): "openapi3" | "swagger2" | "auto" | undefined {
-  if (typeof leaf === "string") return undefined;
+): 'openapi3' | 'swagger2' | 'auto' | undefined {
+  if (typeof leaf === 'string') {
+    return undefined;
+  }
   return leaf.format;
 }
 
@@ -98,47 +100,47 @@ export interface LoadConfigResult {
 /** user-level config 기본 경로. `AGENT_TOOLKIT_CONFIG` 로 오버라이드. */
 export const USER_CONFIG_PATH = join(
   homedir(),
-  ".config",
-  "opencode",
-  "agent-toolkit",
-  "agent-toolkit.json",
+  '.config',
+  'opencode',
+  'agent-toolkit',
+  'agent-toolkit.json',
 );
 
 /** project-level config 의 상대 경로. */
-export const PROJECT_CONFIG_RELATIVE = ".opencode/agent-toolkit.json";
+export const PROJECT_CONFIG_RELATIVE = '.opencode/agent-toolkit.json';
 
 /**
  * host / env / spec 식별자 본문 (anchor 없음).
  * 다른 모듈 (`openapi-registry.ts`) 이 핸들 / 스코프 정규식을 합성할 때 재사용한다 —
  * 이 한 군데만 바꾸면 schema / registry 둘 다 같이 따라간다.
  */
-export const ID_BODY = "[a-zA-Z0-9_-]+";
+export const ID_BODY = '[a-zA-Z0-9_-]+';
 
 /** host / env / spec 식별자 정규식 (앵커 포함). 콜론은 handle separator 로 예약. */
 export const ID_PATTERN = new RegExp(`^${ID_BODY}$`);
 
 /** 레지스트리 leaf URL 에 허용되는 스킴. spec 다운로드 단이 받는 종류와 동일. */
-const URL_SCHEMES = new Set(["http:", "https:", "file:"]);
+const URL_SCHEMES = new Set(['http:', 'https:', 'file:']);
 
 /** registry leaf object 에서 허용하는 키 (오타 가드, 스키마 lockstep). */
-const ALLOWED_REGISTRY_LEAF_KEYS = new Set(["url", "baseUrl", "format"]);
+const ALLOWED_REGISTRY_LEAF_KEYS = new Set(['url', 'baseUrl', 'format']);
 
 /** registry leaf object 의 format 필드에 허용되는 값. */
-const ALLOWED_REGISTRY_LEAF_FORMATS = new Set(["openapi3", "swagger2", "auto"]);
+const ALLOWED_REGISTRY_LEAF_FORMATS = new Set(['openapi3', 'swagger2', 'auto']);
 
 /**
  * 파싱된 JSON 값이 ToolkitConfig 인지 검증한다. 어긋나면 throw — 메시지에 source(path) 포함.
  * 부분 적합도 OK (모든 필드 optional). registry 가 있으면 깊이 끝까지 식별자 / URL 검증.
  */
 export function validateConfig(input: unknown, source: string): ToolkitConfig {
-  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
     throw new Error(`${source}: config must be a JSON object`);
   }
   const config = input as Record<string, unknown>;
   if (config.openapi !== undefined) {
     if (
       config.openapi === null ||
-      typeof config.openapi !== "object" ||
+      typeof config.openapi !== 'object' ||
       Array.isArray(config.openapi)
     ) {
       throw new Error(`${source}: openapi must be an object`);
@@ -151,11 +153,8 @@ export function validateConfig(input: unknown, source: string): ToolkitConfig {
   return config as ToolkitConfig;
 }
 
-function validateRegistry(
-  reg: unknown,
-  source: string,
-): asserts reg is OpenapiRegistry {
-  if (reg === null || typeof reg !== "object" || Array.isArray(reg)) {
+function validateRegistry(reg: unknown, source: string): asserts reg is OpenapiRegistry {
+  if (reg === null || typeof reg !== 'object' || Array.isArray(reg)) {
     throw new Error(`${source}: openapi.registry must be an object`);
   }
   for (const [host, envs] of Object.entries(reg as Record<string, unknown>)) {
@@ -164,36 +163,23 @@ function validateRegistry(
         `${source}: host name "${host}" must match ${ID_PATTERN} (alphanumeric, "_" or "-" only — colons are reserved for handle separators)`,
       );
     }
-    if (envs === null || typeof envs !== "object" || Array.isArray(envs)) {
-      throw new Error(
-        `${source}: openapi.registry["${host}"] must be an object of environments`,
-      );
+    if (envs === null || typeof envs !== 'object' || Array.isArray(envs)) {
+      throw new Error(`${source}: openapi.registry["${host}"] must be an object of environments`);
     }
-    for (const [env, specs] of Object.entries(
-      envs as Record<string, unknown>,
-    )) {
+    for (const [env, specs] of Object.entries(envs as Record<string, unknown>)) {
       if (!ID_PATTERN.test(env)) {
-        throw new Error(
-          `${source}: env name "${host}:${env}" must match ${ID_PATTERN}`,
-        );
+        throw new Error(`${source}: env name "${host}:${env}" must match ${ID_PATTERN}`);
       }
-      if (specs === null || typeof specs !== "object" || Array.isArray(specs)) {
+      if (specs === null || typeof specs !== 'object' || Array.isArray(specs)) {
         throw new Error(
           `${source}: openapi.registry["${host}"]["${env}"] must be an object of specs`,
         );
       }
-      for (const [spec, leaf] of Object.entries(
-        specs as Record<string, unknown>,
-      )) {
+      for (const [spec, leaf] of Object.entries(specs as Record<string, unknown>)) {
         if (!ID_PATTERN.test(spec)) {
-          throw new Error(
-            `${source}: spec name "${host}:${env}:${spec}" must match ${ID_PATTERN}`,
-          );
+          throw new Error(`${source}: spec name "${host}:${env}:${spec}" must match ${ID_PATTERN}`);
         }
-        validateRegistryLeaf(
-          leaf,
-          `${source}: openapi.registry["${host}"]["${env}"]["${spec}"]`,
-        );
+        validateRegistryLeaf(leaf, `${source}: openapi.registry["${host}"]["${env}"]["${spec}"]`);
       }
     }
   }
@@ -204,55 +190,48 @@ function validateRegistry(
  * 모두 받는다. URL 은 둘 다 같은 스킴 / non-empty 검증을 통과해야 한다.
  */
 function validateRegistryLeaf(leaf: unknown, where: string): void {
-  if (typeof leaf === "string") {
+  if (typeof leaf === 'string') {
     if (leaf.trim().length === 0) {
       throw new Error(`${where} must be a non-empty URL string`);
     }
     validateRegistryUrlString(leaf, where);
     return;
   }
-  if (leaf === null || typeof leaf !== "object" || Array.isArray(leaf)) {
-    throw new Error(
-      `${where} must be a non-empty URL string or object { url, baseUrl?, format? }`,
-    );
+  if (leaf === null || typeof leaf !== 'object' || Array.isArray(leaf)) {
+    throw new Error(`${where} must be a non-empty URL string or object { url, baseUrl?, format? }`);
   }
   const obj = leaf as Record<string, unknown>;
   for (const key of Object.keys(obj)) {
     if (!ALLOWED_REGISTRY_LEAF_KEYS.has(key)) {
       throw new Error(
-        `${where} has unsupported key "${key}" — allowed: ${[...ALLOWED_REGISTRY_LEAF_KEYS].join(", ")}`,
+        `${where} has unsupported key "${key}" — allowed: ${[...ALLOWED_REGISTRY_LEAF_KEYS].join(', ')}`,
       );
     }
   }
-  if (typeof obj.url !== "string" || obj.url.trim().length === 0) {
+  if (typeof obj.url !== 'string' || obj.url.trim().length === 0) {
     throw new Error(`${where}.url must be a non-empty URL string`);
   }
   validateRegistryUrlString(obj.url, `${where}.url`);
   if (obj.baseUrl !== undefined) {
-    if (typeof obj.baseUrl !== "string" || obj.baseUrl.trim().length === 0) {
+    if (typeof obj.baseUrl !== 'string' || obj.baseUrl.trim().length === 0) {
       throw new Error(`${where}.baseUrl must be a non-empty string`);
     }
     let parsed: URL;
     try {
       parsed = new URL(obj.baseUrl);
     } catch {
-      throw new Error(
-        `${where}.baseUrl is not a valid URL — got "${obj.baseUrl}"`,
-      );
+      throw new Error(`${where}.baseUrl is not a valid URL — got "${obj.baseUrl}"`);
     }
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
       throw new Error(
         `${where}.baseUrl uses unsupported scheme "${parsed.protocol}" — only http / https are accepted`,
       );
     }
   }
   if (obj.format !== undefined) {
-    if (
-      typeof obj.format !== "string" ||
-      !ALLOWED_REGISTRY_LEAF_FORMATS.has(obj.format)
-    ) {
+    if (typeof obj.format !== 'string' || !ALLOWED_REGISTRY_LEAF_FORMATS.has(obj.format)) {
       throw new Error(
-        `${where}.format must be one of ${[...ALLOWED_REGISTRY_LEAF_FORMATS].join(" / ")}`,
+        `${where}.format must be one of ${[...ALLOWED_REGISTRY_LEAF_FORMATS].join(' / ')}`,
       );
     }
   }
@@ -273,15 +252,15 @@ function validateRegistryUrlString(url: string, where: string): void {
 }
 
 async function loadOne(path: string): Promise<ToolkitConfig | null> {
-  if (!existsSync(path)) return null;
-  const raw = await readFile(path, "utf8");
+  if (!existsSync(path)) {
+    return null;
+  }
+  const raw = await readFile(path, 'utf8');
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    throw new Error(
-      `Failed to parse ${path} as JSON: ${(err as Error).message}`,
-    );
+    throw new Error(`Failed to parse ${path} as JSON: ${(err as Error).message}`);
   }
   return validateConfig(parsed, path);
 }
@@ -290,10 +269,7 @@ async function loadOne(path: string): Promise<ToolkitConfig | null> {
  * user → project 순서로 깊이 병합. 같은 leaf (host:env:spec) 는 project 가 이긴다.
  * 새 host / env / spec 은 project 쪽에서 추가 가능.
  */
-export function mergeConfigs(
-  user: ToolkitConfig,
-  project: ToolkitConfig,
-): ToolkitConfig {
+export function mergeConfigs(user: ToolkitConfig, project: ToolkitConfig): ToolkitConfig {
   // Bun ≥ 1.0 / Node ≥ 17 모두 structuredClone 표준 지원. JSON round-trip 보다 성능과
   // 의도가 명확 — 입력은 plain JSON 모양이라 Date / Map / Set 호환은 신경 쓰지 않아도 된다.
   const out = structuredClone(user) as ToolkitConfig;
@@ -324,11 +300,8 @@ export function mergeConfigs(
  * 두 파일 모두 없으면 `{ config: {}, errors: [] }`. `AGENT_TOOLKIT_CONFIG` 환경변수가
  * 있으면 user 경로를 그 값으로 덮어쓴다.
  */
-export async function loadConfig(
-  options: LoadConfigOptions = {},
-): Promise<LoadConfigResult> {
-  const userPath =
-    options.userPath ?? process.env.AGENT_TOOLKIT_CONFIG ?? USER_CONFIG_PATH;
+export async function loadConfig(options: LoadConfigOptions = {}): Promise<LoadConfigResult> {
+  const userPath = options.userPath ?? process.env.AGENT_TOOLKIT_CONFIG ?? USER_CONFIG_PATH;
   const projectRoot = options.projectRoot ?? process.cwd();
   const projectPath = resolve(projectRoot, PROJECT_CONFIG_RELATIVE);
   const errors: LoadConfigError[] = [];

--- a/src/core/url.test.ts
+++ b/src/core/url.test.ts
@@ -1,38 +1,34 @@
-import { describe, it, expect } from "bun:test";
-import { joinBaseAndPath, syntheticOperationId } from "./url";
+import { describe, it, expect } from 'bun:test';
+import { joinBaseAndPath, syntheticOperationId } from './url';
 
-describe("joinBaseAndPath", () => {
-  it("inserts a slash when missing", () => {
-    expect(joinBaseAndPath("https://api.example.com", "pet")).toBe(
-      "https://api.example.com/pet",
-    );
+describe('joinBaseAndPath', () => {
+  it('inserts a slash when missing', () => {
+    expect(joinBaseAndPath('https://api.example.com', 'pet')).toBe('https://api.example.com/pet');
   });
-  it("strips trailing slashes from baseUrl and keeps the path verbatim", () => {
+  it('strips trailing slashes from baseUrl and keeps the path verbatim', () => {
     // baseUrl 끝의 `/` 를 모두 제거한 뒤 path 를 그대로 이어 붙인다 — path 안의
     // `//` 는 정규화 대상이 아님 (OpenAPI path 가 의도해서 비워 둔 segment 일 수 있어
     // joinBaseAndPath 가 자의적으로 합치지 않는다).
-    expect(joinBaseAndPath("https://api.example.com/", "/pet")).toBe(
-      "https://api.example.com/pet",
-    );
-    expect(joinBaseAndPath("https://api.example.com//", "//pet")).toBe(
-      "https://api.example.com//pet",
+    expect(joinBaseAndPath('https://api.example.com/', '/pet')).toBe('https://api.example.com/pet');
+    expect(joinBaseAndPath('https://api.example.com//', '//pet')).toBe(
+      'https://api.example.com//pet',
     );
   });
-  it("preserves path-style base URLs", () => {
-    expect(joinBaseAndPath("https://api.example.com/v1", "/pet/{petId}")).toBe(
-      "https://api.example.com/v1/pet/{petId}",
+  it('preserves path-style base URLs', () => {
+    expect(joinBaseAndPath('https://api.example.com/v1', '/pet/{petId}')).toBe(
+      'https://api.example.com/v1/pet/{petId}',
     );
   });
-  it("returns path as-is when baseUrl is empty", () => {
-    expect(joinBaseAndPath("", "/pet")).toBe("/pet");
+  it('returns path as-is when baseUrl is empty', () => {
+    expect(joinBaseAndPath('', '/pet')).toBe('/pet');
   });
 });
 
-describe("syntheticOperationId", () => {
-  it("drops braces and lowercases method", () => {
-    expect(syntheticOperationId("GET", "/pet/{petId}")).toBe("get_pet_petId");
+describe('syntheticOperationId', () => {
+  it('drops braces and lowercases method', () => {
+    expect(syntheticOperationId('GET', '/pet/{petId}')).toBe('get_pet_petId');
   });
-  it("handles root path", () => {
-    expect(syntheticOperationId("post", "/")).toBe("post_root");
+  it('handles root path', () => {
+    expect(syntheticOperationId('post', '/')).toBe('post_root');
   });
 });

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -4,20 +4,22 @@
  */
 
 export function joinBaseAndPath(baseUrl: string, apiPath: string): string {
-  if (!baseUrl) return apiPath;
-  const base = baseUrl.replace(/\/+$/, "");
-  const suffix = apiPath.startsWith("/") ? apiPath : `/${apiPath}`;
+  if (!baseUrl) {
+    return apiPath;
+  }
+  const base = baseUrl.replace(/\/+$/, '');
+  const suffix = apiPath.startsWith('/') ? apiPath : `/${apiPath}`;
   return `${base}${suffix}`;
 }
 
 export function sanitizeForOperationId(s: string): string {
   return s
-    .replace(/[{}]/g, "")
-    .replace(/[^A-Za-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+    .replace(/[{}]/g, '')
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
 }
 
 export function syntheticOperationId(method: string, apiPath: string): string {
   const cleaned = sanitizeForOperationId(apiPath);
-  return `${method.toLowerCase()}_${cleaned || "root"}`;
+  return `${method.toLowerCase()}_${cleaned || 'root'}`;
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,70 +11,66 @@
  * suite.
  */
 
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { buildServer } from "./index";
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { buildServer } from './index';
 
 const EXPECTED_TOOLS = [
-  "openapi_get",
-  "openapi_refresh",
-  "openapi_status",
-  "openapi_search",
-  "openapi_envs",
-  "openapi_endpoint",
-  "openapi_tags",
+  'openapi_get',
+  'openapi_refresh',
+  'openapi_status',
+  'openapi_search',
+  'openapi_envs',
+  'openapi_endpoint',
+  'openapi_tags',
 ] as const;
 
 /** v0.3 부터 surface 에서 빠진 tool — 누수 회귀 가드. archive/pre-openapi-only-slim 참조. */
 const REMOVED_TOOLS = [
-  "notion_get",
-  "notion_refresh",
-  "notion_status",
-  "notion_extract",
-  "journal_append",
-  "journal_read",
-  "journal_search",
-  "journal_status",
-  "mysql_envs",
-  "mysql_status",
-  "mysql_tables",
-  "mysql_schema",
-  "mysql_query",
-  "spec_pact_fragment",
-  "pr_watch_start",
-  "pr_watch_stop",
-  "pr_watch_status",
-  "pr_event_record",
-  "pr_event_pending",
-  "pr_event_resolve",
+  'notion_get',
+  'notion_refresh',
+  'notion_status',
+  'notion_extract',
+  'journal_append',
+  'journal_read',
+  'journal_search',
+  'journal_status',
+  'mysql_envs',
+  'mysql_status',
+  'mysql_tables',
+  'mysql_schema',
+  'mysql_query',
+  'spec_pact_fragment',
+  'pr_watch_start',
+  'pr_watch_stop',
+  'pr_watch_status',
+  'pr_event_record',
+  'pr_event_pending',
+  'pr_event_resolve',
 ] as const;
 
-const ENV_KEYS_TO_RESTORE = ["AGENT_TOOLKIT_OPENAPI_CACHE_DIR"] as const;
+const ENV_KEYS_TO_RESTORE = ['AGENT_TOOLKIT_OPENAPI_CACHE_DIR'] as const;
 
 let client: Client;
 let tmpHome: string;
 const savedEnv: Record<string, string | undefined> = {};
 
 beforeAll(async () => {
-  tmpHome = mkdtempSync(join(tmpdir(), "agent-toolkit-server-test-"));
+  tmpHome = mkdtempSync(join(tmpdir(), 'agent-toolkit-server-test-'));
   for (const key of ENV_KEYS_TO_RESTORE) {
     savedEnv[key] = process.env[key];
   }
-  process.env.AGENT_TOOLKIT_OPENAPI_CACHE_DIR = join(tmpHome, "openapi-cache");
+  process.env.AGENT_TOOLKIT_OPENAPI_CACHE_DIR = join(tmpHome, 'openapi-cache');
 
   const server = await buildServer();
-  const [clientTransport, serverTransport] =
-    InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-  client = new Client({ name: "agent-toolkit-test", version: "0" });
-  await Promise.all([
-    server.connect(serverTransport),
-    client.connect(clientTransport),
-  ]);
+  client = new Client({ name: 'agent-toolkit-test', version: '0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
 });
 
 afterAll(async () => {
@@ -92,14 +88,14 @@ afterAll(async () => {
   }
 });
 
-describe("agent-toolkit Claude Code MCP server", () => {
-  test("exposes exactly the 7 openapi tools", async () => {
+describe('agent-toolkit Claude Code MCP server', () => {
+  test('exposes exactly the 7 openapi tools', async () => {
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name).sort();
     expect(names).toEqual([...EXPECTED_TOOLS].sort());
   });
 
-  test("does not leak removed-domain tools", async () => {
+  test('does not leak removed-domain tools', async () => {
     const result = await client.listTools();
     const names = new Set(result.tools.map((t) => t.name));
     for (const removed of REMOVED_TOOLS) {
@@ -110,21 +106,23 @@ describe("agent-toolkit Claude Code MCP server", () => {
   // NOTE: 이 required 필드는 플러그인(handle 기반) contract 이다. standalone CLI
   // (`src/standalone.ts`) 는 openapi_endpoint 가 spec+environment 를 요구하는 등
   // 형태가 다르다 — 그쪽 계약은 이 테스트 대상이 아니다.
-  test("advertises the expected required fields per openapi tool", async () => {
+  test('advertises the expected required fields per openapi tool', async () => {
     const { tools } = await client.listTools();
     const byName = new Map(tools.map((t) => [t.name, t]));
 
     const requiredFields = (name: string): string[] => {
       const tool = byName.get(name);
-      if (!tool) throw new Error(`tool not found: ${name}`);
+      if (!tool) {
+        throw new Error(`tool not found: ${name}`);
+      }
       const schema = tool.inputSchema as { required?: string[] };
       return [...(schema.required ?? [])].sort();
     };
 
-    expect(requiredFields("openapi_get")).toEqual(["input"]);
-    expect(requiredFields("openapi_search")).toEqual(["query"]);
-    expect(requiredFields("openapi_endpoint")).toEqual(["input"]);
-    expect(requiredFields("openapi_tags")).toEqual(["input"]);
-    expect(requiredFields("openapi_envs")).toEqual([]);
+    expect(requiredFields('openapi_get')).toEqual(['input']);
+    expect(requiredFields('openapi_search')).toEqual(['query']);
+    expect(requiredFields('openapi_endpoint')).toEqual(['input']);
+    expect(requiredFields('openapi_tags')).toEqual(['input']);
+    expect(requiredFields('openapi_envs')).toEqual([]);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,10 @@
  * phase 단위로 재추가된다.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
-import pkg from "../package.json" with { type: "json" };
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import pkg from '../package.json' with { type: 'json' };
 import {
   createAgentToolkitRegistry,
   HTTP_METHODS,
@@ -26,7 +26,7 @@ import {
   handleSwaggerSearch,
   handleSwaggerStatus,
   handleSwaggerTags,
-} from "./core";
+} from './core';
 
 /**
  * MCP `tools/call` results must be a `CallToolResult`. We always serialize the
@@ -36,7 +36,7 @@ function jsonResult(value: unknown) {
   return {
     content: [
       {
-        type: "text" as const,
+        type: 'text' as const,
         text: JSON.stringify(value, null, 2),
       },
     ],
@@ -60,48 +60,44 @@ export async function buildServer() {
   });
 
   const server = new McpServer({
-    name: "agent-toolkit",
+    name: 'agent-toolkit',
     version: pkg.version,
   });
 
   server.registerTool(
-    "openapi_get",
+    'openapi_get',
     {
       description:
-        "OpenAPI / Swagger spec 을 캐시 우선 정책으로 가져온다. swagger 2.0 은 자동으로 OpenAPI 3.0 으로 변환되고 $ref 는 모두 deref 된다. fresh hit 은 remote 호출 없음. stale hit (TTL 경과) 은 즉시 stale 데이터로 응답하고 백그라운드 conditional GET (If-None-Match / If-Modified-Since) 으로 재검증. miss 면 fetch + parse + index. (input: spec URL 또는 agent-toolkit.json 의 host:env:spec handle)",
+        'OpenAPI / Swagger spec 을 캐시 우선 정책으로 가져온다. swagger 2.0 은 자동으로 OpenAPI 3.0 으로 변환되고 $ref 는 모두 deref 된다. fresh hit 은 remote 호출 없음. stale hit (TTL 경과) 은 즉시 stale 데이터로 응답하고 백그라운드 conditional GET (If-None-Match / If-Modified-Since) 으로 재검증. miss 면 fetch + parse + index. (input: spec URL 또는 agent-toolkit.json 의 host:env:spec handle)',
       inputSchema: { input: z.string() },
     },
-    async ({ input }) =>
-      jsonResult(await handleSwaggerGet(openapiRegistry, input, registry)),
+    async ({ input }) => jsonResult(await handleSwaggerGet(openapiRegistry, input, registry)),
   );
 
   server.registerTool(
-    "openapi_refresh",
+    'openapi_refresh',
     {
-      description:
-        "캐시 (메모리 + 디스크) 를 무시하고 OpenAPI spec 을 강제 재다운로드한다.",
+      description: '캐시 (메모리 + 디스크) 를 무시하고 OpenAPI spec 을 강제 재다운로드한다.',
       inputSchema: { input: z.string() },
     },
-    async ({ input }) =>
-      jsonResult(await handleSwaggerRefresh(openapiRegistry, input, registry)),
+    async ({ input }) => jsonResult(await handleSwaggerRefresh(openapiRegistry, input, registry)),
   );
 
   server.registerTool(
-    "openapi_status",
+    'openapi_status',
     {
       description:
-        "캐시된 OpenAPI spec 의 메타 (cached / fetchedAt / ttlSeconds / environments) 만 조회. remote 호출 없음.",
+        '캐시된 OpenAPI spec 의 메타 (cached / fetchedAt / ttlSeconds / environments) 만 조회. remote 호출 없음.',
       inputSchema: { input: z.string() },
     },
-    async ({ input }) =>
-      jsonResult(await handleSwaggerStatus(openapiRegistry, input, registry)),
+    async ({ input }) => jsonResult(await handleSwaggerStatus(openapiRegistry, input, registry)),
   );
 
   server.registerTool(
-    "openapi_search",
+    'openapi_search',
     {
       description:
-        "캐시 (메모리 또는 디스크) 에 있는 OpenAPI spec 들을 가로질러 endpoint 를 점수화 검색한다 (operationId>path>summary>description). remote 호출 없음 — 미캐시 spec 은 결과에 포함되지 않으니 먼저 `openapi_get` 으로 받아둬야 한다.",
+        '캐시 (메모리 또는 디스크) 에 있는 OpenAPI spec 들을 가로질러 endpoint 를 점수화 검색한다 (operationId>path>summary>description). remote 호출 없음 — 미캐시 spec 은 결과에 포함되지 않으니 먼저 `openapi_get` 으로 받아둬야 한다.',
       inputSchema: {
         query: z.string(),
         limit: z.number().int().positive().optional(),
@@ -109,31 +105,24 @@ export async function buildServer() {
       },
     },
     async ({ query, limit, scope }) =>
-      jsonResult(
-        await handleSwaggerSearch(
-          openapiRegistry,
-          query,
-          { limit, scope },
-          registry,
-        ),
-      ),
+      jsonResult(await handleSwaggerSearch(openapiRegistry, query, { limit, scope }, registry)),
   );
 
   server.registerTool(
-    "openapi_envs",
+    'openapi_envs',
     {
       description:
-        "agent-toolkit.json 의 openapi.registry 를 host:env:spec 평면 리스트로 반환한다. baseUrl / format 이 있으면 함께 반환. remote 호출 없음.",
+        'agent-toolkit.json 의 openapi.registry 를 host:env:spec 평면 리스트로 반환한다. baseUrl / format 이 있으면 함께 반환. remote 호출 없음.',
       inputSchema: {},
     },
     async () => jsonResult(handleSwaggerEnvs(toolkitConfig)),
   );
 
   server.registerTool(
-    "openapi_endpoint",
+    'openapi_endpoint',
     {
       description:
-        "단일 endpoint 의 풍부한 정보 (parameters / requestBody / responses / examples / fullUrl) 를 반환한다. baseUrl 합성된 fullUrl 은 leaf 의 baseUrl 이 비어 있으면 path 자체.",
+        '단일 endpoint 의 풍부한 정보 (parameters / requestBody / responses / examples / fullUrl) 를 반환한다. baseUrl 합성된 fullUrl 은 leaf 의 baseUrl 이 비어 있으면 path 자체.',
       inputSchema: {
         input: z.string(),
         operationId: z.string().optional(),
@@ -153,14 +142,12 @@ export async function buildServer() {
   );
 
   server.registerTool(
-    "openapi_tags",
+    'openapi_tags',
     {
-      description:
-        "spec 의 OpenAPI tag 목록 + 각 tag 의 endpoint 개수를 반환한다.",
+      description: 'spec 의 OpenAPI tag 목록 + 각 tag 의 endpoint 개수를 반환한다.',
       inputSchema: { input: z.string() },
     },
-    async ({ input }) =>
-      jsonResult(await handleSwaggerTags(openapiRegistry, input, registry)),
+    async ({ input }) => jsonResult(await handleSwaggerTags(openapiRegistry, input, registry)),
   );
 
   return server;
@@ -178,9 +165,7 @@ async function main() {
 
 if (import.meta.main) {
   main().catch((err) => {
-    console.error(
-      `agent-toolkit MCP server failed: ${(err as Error).stack ?? err}`,
-    );
+    console.error(`agent-toolkit MCP server failed: ${(err as Error).stack ?? err}`);
     process.exit(1);
   });
 }

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -9,33 +9,25 @@
  * 두 진입점이 같은 surface 를 노출한다.
  */
 
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { z } from "zod";
-import pkg from "../package.json" with { type: "json" };
-import {
-  createDiskCache,
-  createNoopDiskCache,
-  type DiskCache,
-} from "./core/cache";
-import { defaultDiskCacheDir } from "./core/config-loader";
-import { createFetcher } from "./core/fetcher";
-import {
-  buildEndpointDetail,
-  HTTP_METHODS,
-  resolveEndpoint,
-} from "./core/indexer";
-import { filterEndpoints } from "./core/filter";
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import pkg from '../package.json' with { type: 'json' };
+import { createDiskCache, createNoopDiskCache, type DiskCache } from './core/cache';
+import { defaultDiskCacheDir } from './core/config-loader';
+import { createFetcher } from './core/fetcher';
+import { buildEndpointDetail, HTTP_METHODS, resolveEndpoint } from './core/indexer';
+import { filterEndpoints } from './core/filter';
 import {
   createSpecRegistry,
   UnknownEnvironmentError,
   UnknownSpecError,
   type SpecRegistry,
-} from "./core/registry";
-import type { OpenApiMcpConfig } from "./core/schema";
-import { getLogger } from "./core/logger";
+} from './core/registry';
+import type { OpenApiMcpConfig } from './core/schema';
+import { getLogger } from './core/logger';
 
-export const SERVER_NAME = "openapi-mcp";
+export const SERVER_NAME = 'openapi-mcp';
 /** package.json 의 version 을 단일 source 로 사용 — `bin/openapi-mcp -V` 와 동기. */
 export const SERVER_VERSION = pkg.version;
 
@@ -53,7 +45,7 @@ function jsonResult(value: unknown) {
   return {
     content: [
       {
-        type: "text" as const,
+        type: 'text' as const,
         text: JSON.stringify(value, null, 2),
       },
     ],
@@ -65,7 +57,7 @@ function errorResult(message: string) {
     isError: true,
     content: [
       {
-        type: "text" as const,
+        type: 'text' as const,
         text: JSON.stringify({ error: message }, null, 2),
       },
     ],
@@ -77,12 +69,15 @@ export function buildServer(
   options: BuildServerOptions = {},
 ): ServerHandle {
   const fetcherOptions: Parameters<typeof createFetcher>[0] = {};
-  if (config.http?.timeoutMs !== undefined)
+  if (config.http?.timeoutMs !== undefined) {
     fetcherOptions.timeoutMs = config.http.timeoutMs;
-  if (config.http?.insecureTls !== undefined)
+  }
+  if (config.http?.insecureTls !== undefined) {
     fetcherOptions.insecureTls = config.http.insecureTls;
-  if (config.http?.extraCaCerts !== undefined)
+  }
+  if (config.http?.extraCaCerts !== undefined) {
     fetcherOptions.extraCaCerts = config.http.extraCaCerts;
+  }
   const fetcher = createFetcher(fetcherOptions);
 
   const diskCacheEnabled = config.cache?.diskCache ?? true;
@@ -101,16 +96,16 @@ export function buildServer(
     { name: SERVER_NAME, version: SERVER_VERSION },
     {
       instructions:
-        "Browse internal OpenAPI / Swagger specs. openapi_envs → openapi_get → openapi_search → openapi_endpoint / openapi_tags. openapi_refresh forces a re-fetch.",
+        'Browse internal OpenAPI / Swagger specs. openapi_envs → openapi_get → openapi_search → openapi_endpoint / openapi_tags. openapi_refresh forces a re-fetch.',
     },
   );
 
   // openapi_envs (단독 entry 에는 toolkit-config registry 가 없으므로 specs.* 를 그대로 평탄화)
   server.registerTool(
-    "openapi_envs",
+    'openapi_envs',
     {
       description:
-        "Configured spec 목록과 각 spec 의 environments(baseUrl 포함). remote 호출 없음.",
+        'Configured spec 목록과 각 spec 의 environments(baseUrl 포함). remote 호출 없음.',
       inputSchema: {},
     },
     async () => {
@@ -126,10 +121,10 @@ export function buildServer(
   );
 
   server.registerTool(
-    "openapi_get",
+    'openapi_get',
     {
       description:
-        "spec 을 캐시 우선으로 가져온다. swagger 2.0 자동 변환 + $ref deref. (input: spec name, optional environment)",
+        'spec 을 캐시 우선으로 가져온다. swagger 2.0 자동 변환 + $ref deref. (input: spec name, optional environment)',
       inputSchema: {
         input: z.string(),
         environment: z.string().optional(),
@@ -144,10 +139,7 @@ export function buildServer(
           document: indexed.document,
         });
       } catch (err) {
-        if (
-          err instanceof UnknownSpecError ||
-          err instanceof UnknownEnvironmentError
-        ) {
+        if (err instanceof UnknownSpecError || err instanceof UnknownEnvironmentError) {
           return errorResult(err.message);
         }
         throw err;
@@ -156,34 +148,34 @@ export function buildServer(
   );
 
   server.registerTool(
-    "openapi_refresh",
+    'openapi_refresh',
     {
-      description:
-        "캐시를 비우고 spec 을 강제 재다운로드. (input: spec name 옵션)",
+      description: '캐시를 비우고 spec 을 강제 재다운로드. (input: spec name 옵션)',
       inputSchema: { input: z.string().optional() },
     },
-    async ({ input }) =>
-      jsonResult({ refreshed: await registry.refresh(input) }),
+    async ({ input }) => jsonResult({ refreshed: await registry.refresh(input) }),
   );
 
   server.registerTool(
-    "openapi_status",
+    'openapi_status',
     {
-      description: "spec 의 cache status. remote 호출 없음.",
+      description: 'spec 의 cache status. remote 호출 없음.',
       inputSchema: { input: z.string() },
     },
     async ({ input }) => {
       const summary = registry.listSpecs().find((s) => s.name === input);
-      if (!summary) return errorResult(`unknown spec '${input}'`);
+      if (!summary) {
+        return errorResult(`unknown spec '${input}'`);
+      }
       return jsonResult(summary);
     },
   );
 
   server.registerTool(
-    "openapi_search",
+    'openapi_search',
     {
       description:
-        "endpoint 점수화 검색 (operationId>path>summary>description). spec / tag / method 로 필터.",
+        'endpoint 점수화 검색 (operationId>path>summary>description). spec / tag / method 로 필터.',
       inputSchema: {
         query: z.string().optional(),
         spec: z.string().optional(),
@@ -202,17 +194,21 @@ export function buildServer(
         }
         // 후보 spec 들을 병렬 로드. 한 spec fetch 실패는 그 spec 만 빼고 나머지는
         // 계속 (allSettled).
-        const settled = await Promise.allSettled(
-          targets.map((name) => registry.loadSpec(name)),
-        );
-        const all = settled.flatMap((r) =>
-          r.status === "fulfilled" ? r.value.endpoints : [],
-        );
+        const settled = await Promise.allSettled(targets.map((name) => registry.loadSpec(name)));
+        const all = settled.flatMap((r) => (r.status === 'fulfilled' ? r.value.endpoints : []));
         const filter: Parameters<typeof filterEndpoints>[1] = {};
-        if (spec) filter.spec = spec;
-        if (tag) filter.tag = tag;
-        if (method) filter.method = method;
-        if (query?.trim()) filter.keyword = query.trim();
+        if (spec) {
+          filter.spec = spec;
+        }
+        if (tag) {
+          filter.tag = tag;
+        }
+        if (method) {
+          filter.method = method;
+        }
+        if (query?.trim()) {
+          filter.keyword = query.trim();
+        }
         const filtered = filterEndpoints(all, filter);
         const cap = limit ?? 50;
         return jsonResult({
@@ -229,17 +225,19 @@ export function buildServer(
           })),
         });
       } catch (err) {
-        if (err instanceof UnknownSpecError) return errorResult(err.message);
+        if (err instanceof UnknownSpecError) {
+          return errorResult(err.message);
+        }
         throw err;
       }
     },
   );
 
   server.registerTool(
-    "openapi_endpoint",
+    'openapi_endpoint',
     {
       description:
-        "단일 endpoint 의 detail (parameters / requestBody / responses / examples / fullUrl).",
+        '단일 endpoint 의 detail (parameters / requestBody / responses / examples / fullUrl).',
       inputSchema: {
         spec: z.string(),
         environment: z.string(),
@@ -251,28 +249,19 @@ export function buildServer(
     async ({ spec, environment, operationId, method, path }) => {
       try {
         if (!operationId && !(method && path)) {
-          return errorResult(
-            "must supply either operationId or both method and path",
-          );
+          return errorResult('must supply either operationId or both method and path');
         }
         const env = registry.getEnvironment(spec, environment);
         const indexed = await registry.loadSpec(spec, environment);
         const ep = resolveEndpoint(indexed, { operationId, method, path });
         if (!ep) {
-          const where = operationId
-            ? `operationId='${operationId}'`
-            : `${method} ${path}`;
-          return errorResult(
-            `endpoint not found in spec '${spec}' for ${where}`,
-          );
+          const where = operationId ? `operationId='${operationId}'` : `${method} ${path}`;
+          return errorResult(`endpoint not found in spec '${spec}' for ${where}`);
         }
         const detail = buildEndpointDetail(indexed, ep, env.baseUrl);
         return jsonResult({ spec, environment, endpoint: detail });
       } catch (err) {
-        if (
-          err instanceof UnknownSpecError ||
-          err instanceof UnknownEnvironmentError
-        ) {
+        if (err instanceof UnknownSpecError || err instanceof UnknownEnvironmentError) {
           return errorResult(err.message);
         }
         throw err;
@@ -281,19 +270,22 @@ export function buildServer(
   );
 
   server.registerTool(
-    "openapi_tags",
+    'openapi_tags',
     {
-      description: "spec 의 OpenAPI tag 목록 + endpoint 개수.",
+      description: 'spec 의 OpenAPI tag 목록 + endpoint 개수.',
       inputSchema: { spec: z.string() },
     },
     async ({ spec }) => {
       try {
-        if (!registry.hasSpec(spec))
+        if (!registry.hasSpec(spec)) {
           return errorResult(`unknown spec '${spec}'`);
+        }
         const indexed = await registry.loadSpec(spec);
         return jsonResult({ spec, tags: indexed.tags });
       } catch (err) {
-        if (err instanceof UnknownSpecError) return errorResult(err.message);
+        if (err instanceof UnknownSpecError) {
+          return errorResult(err.message);
+        }
         throw err;
       }
     },
@@ -309,9 +301,6 @@ export async function startStdioServer(
   const handle = buildServer(config, options);
   const transport = new StdioServerTransport();
   await handle.server.connect(transport);
-  getLogger().info(
-    { specs: Object.keys(config.specs).length },
-    "openapi-mcp connected over stdio",
-  );
+  getLogger().info({ specs: Object.keys(config.specs).length }, 'openapi-mcp connected over stdio');
   return handle;
 }


### PR DESCRIPTION
## 요약
Biome 설정을 로컬 인라인 규칙에서 공용 [`@minjun0219/biome-config`](https://www.npmjs.com/package/@minjun0219/biome-config) preset extends 로 전환합니다.

## 변경
- `@minjun0219/biome-config@2.1.0` devDep 추가, Biome `2.4.14` → `2.5.3` (preset peer `>=2.5.0` 요구)
- `biome.json` → `"extends": ["@minjun0219/biome-config"]`. repo 고유 override 만 유지:
  - `files.includes` 제외 (`!.sisyphus`, `!.claude`, `!.archive`)
  - `assist.enabled: false`
  - lint off: `noUselessSwitchCase` / `noNonNullAssertion` / `noExplicitAny`
- preset 스타일(single quote, trailing comma `all`, lineWidth 100, `useBlockStatements`)에 맞춰 소스 재포맷

## 검증
- `bun run check` ✅
- `bun run typecheck` ✅
- `bun test` 87 pass ✅

> 모든 리뷰 코멘트는 한국어로 작성해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)