### PR TITLE
feat(commands): /finish · /pr-watch 슬래시 커맨드 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Shared guide for AI coding agents (Claude Code, opencode, codex, etc.) working i
 
 ## Project in one line
 
-**rocky** (named after Project Hail Mary's Rocky) — a **single Bun package** whose `src/core/` OpenAPI core backs two distribution targets — a **Claude Code plugin** (marketplace; MCP server declared in `.claude-plugin/plugin.json`'s `mcpServers`, entry `src/index.ts`) and a host-agnostic **`openapi-mcp` standalone stdio CLI** (`bin/openapi-mcp` → `src/standalone.ts`, npm). Both expose the **same 7-tool surface** (`openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags`). No workspaces, no `packages/` — one `package.json`, one `tsconfig.json`.
+**rocky** (named after Project Hail Mary's Rocky) — a **single Bun package** whose `src/core/` OpenAPI core backs two distribution targets — a **Claude Code plugin** (marketplace; MCP server declared in `.claude-plugin/plugin.json`'s `mcpServers`, entry `src/index.ts`) and a host-agnostic **`openapi-mcp` standalone stdio CLI** (`bin/openapi-mcp` → `src/standalone.ts`, npm). Both expose the **same 7-tool surface** (`openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags`). Separately, the Claude Code plugin ships **slash commands** in `commands/` (`/finish`, `/pr-watch` — `gh` CLI based, not MCP tools). No workspaces, no `packages/` — one `package.json`, one `tsconfig.json`.
 
 Previous toolkit surfaces (journal / mysql / notion / spec-pact / pr-watch + rocky / grace / mindy agents + 5 skills) live on [`archive/pre-openapi-only-slim`](https://github.com/minjun0219/rocky/tree/archive/pre-openapi-only-slim); the former opencode plugin is archived in-tree at [`.archive/agent-toolkit-opencode/`](./.archive/agent-toolkit-opencode) (excluded from all gates). Domains re-enter in follow-up PRs via one of two shapes (plugin-bound handlers, or a separate CLI entry alongside `openapi-mcp`). The shape is decided per domain at re-introduction time.
 
@@ -22,6 +22,9 @@ rocky/                                      single package — @minjun0219/rocky
 ├── .claude-plugin/plugin.json              ★ marketplace metadata + mcpServers (via ${CLAUDE_PLUGIN_ROOT}/src/index.ts)
 ├── README.md / FEATURES.md / AGENTS.md / ROADMAP.md / REVIEW.md / LICENSE
 ├── docs/openapi-mcp.md                     standalone CLI 보조 문서
+├── commands/                               ★ Claude Code plugin 슬래시 커맨드 (자동 발견, gh CLI 기반, MCP tool surface 와 별개)
+│   ├── finish.md                           `/finish` — 게이트 → 커밋 → 푸시 → PR 생성
+│   └── pr-watch.md                         `/pr-watch` — 열린 PR 을 머지 가능 상태까지 감시·알림 (자동 머지 X)
 ├── bin/
 │   └── openapi-mcp                         `#!/usr/bin/env bun` shebang, arg 파싱 → src/standalone
 └── src/

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -101,6 +101,26 @@ Hosts          — 어디서 호출되는지 (Claude Code plugin / standalone CL
 - **Related config**: 동일.
 - **Hosts**: 둘 다.
 
+## Claude Code 커맨드
+
+MCP tool 과 별개로, Claude Code plugin 은 `commands/` 의 슬래시 커맨드를 노출한다 (`gh` CLI 기반, MCP tool surface 와 무관). `/finish` → `/pr-watch` 가 한 쌍 — 마무리로 PR 을 만들고, 그 PR 을 머지까지 감시한다.
+
+### `/finish [힌트]`
+
+- **What**: 현재 변경을 마무리한다 — 게이트(`bun run check` / `typecheck` / `test`) 통과 확인 → 변경 요약 → 브랜치 → 커밋 → 푸시 → PR 생성.
+- **Input**: (옵션) 커밋/PR 요약에 참고할 힌트.
+- **하지 않는 것**: 게이트 실패 시 커밋 금지(우회 X), `main` 직접 커밋 금지(먼저 브랜치), 무관한 파일 싸잡아 스테이지 금지.
+- **규칙**: Conventional Commits 한국어 제목, 커밋 `Co-Authored-By` / PR 본문 서명 trailer 부착, 리뷰 요청 시 한국어 코멘트 요청.
+- **의존성**: 인증된 `gh` CLI.
+
+### `/pr-watch [PR]`
+
+- **What**: 열린 GitHub PR 하나의 상태(CI 체크 · 리뷰 · 머지 가능성)를 점검하고, 열린 리뷰 코멘트를 코드와 대조해 타당/반박/보류로 정리한 뒤, **머지 가능한 상태가 되면 알려준다.**
+- **Input**: PR 번호 / URL / `owner/repo#123`. 생략하면 현재 브랜치에 연결된 PR 을 자동으로 찾는다.
+- **동작**: CI 진행 중이면 `gh pr checks --watch` 로 한 턴 안에서 완료까지 대기 후 재판정. 사람 리뷰 대기로 막히면 재실행 / `/loop 5m /pr-watch <PR>` 폴링을 안내.
+- **하지 않는 것**: **자동 머지 금지** (`gh pr merge` 실행 X — 머지 가능 알림까지만), 코드 수정 · 리뷰 답글 자동 게시 금지 (권고까지만).
+- **의존성**: 인증된 `gh` CLI. GitHub MCP 는 쓰지 않는다.
+
 ## 환경 변수
 
 `ROCKY_*` 변수는 **Claude Code plugin 진입점 (`src/index.ts`) 전용** — standalone `openapi-mcp` CLI 는 인지하지 않는다 (CLI 는 `openapi-mcp.json` config 파일 + XDG 표준 변수만 본다).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ OpenAPI / Swagger 명세를 캐시-우선으로 둘러보는 MCP toolkit — 이
 
 둘 다 **동일한 7 tool surface** (`openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags`) 를 노출한다. 공유 core 는 [`src/core/`](./src/core) — spec 다운로드 / 디스크 캐시 / `$ref` deref / swagger 2.0 → OpenAPI 3 변환 / endpoint 점수화 검색 / handler 함수.
 
+MCP tool 외에, Claude Code plugin 은 `commands/` 의 **슬래시 커맨드** 도 노출한다 (`gh` CLI 기반) — `/finish` (게이트→커밋→푸시→PR 생성) 와 `/pr-watch` (그 PR 을 머지 가능 상태까지 감시·알림) 가 한 쌍. 자세한 건 [`FEATURES.md`](./FEATURES.md#claude-code-커맨드).
+
 > - v0.2 까지의 journal / mysql / notion / spec-pact / pr-watch 도메인은 [`archive/pre-openapi-only-slim`](https://github.com/minjun0219/rocky/tree/archive/pre-openapi-only-slim) 브랜치에 박제되어 있다.
 > - opencode plugin 은 [`.archive/agent-toolkit-opencode/`](./.archive/agent-toolkit-opencode) 에 박제되어 있다 (게이트에서 제외).
 >

--- a/commands/finish.md
+++ b/commands/finish.md
@@ -58,7 +58,7 @@ bun test            # 단위 + smoke
 - 승인 흐름상 그대로 커밋한다. 커밋 메시지 말미에 아래 trailer 를 반드시 붙인다:
 
   ```
-  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Co-Authored-By: Claude <noreply@anthropic.com>
   ```
 
 - 관련 없는 파일까지 싸잡아 `git add -A` 하지 말고, 이번 작업에 해당하는 변경만 스테이지한다.

--- a/commands/finish.md
+++ b/commands/finish.md
@@ -1,0 +1,97 @@
+---
+description: 현재 변경을 마무리한다 — 게이트(check/typecheck/test) 통과 확인 → 변경 요약 → 브랜치 → 커밋 → 푸시 → PR 생성까지. 게이트가 실패하면 커밋하지 않고 멈춘다.
+argument-hint: "[PR/커밋 요약 힌트] (생략 가능)"
+allowed-tools: Bash(bun:*), Bash(git:*), Bash(gh:*), Read, Grep, Glob
+---
+
+# finish — 변경 마무리 (게이트 → 커밋 → PR)
+
+지금까지의 작업을 저장소 규칙에 맞게 마무리한다. `$ARGUMENTS` 는 커밋/PR 요약에 참고할
+힌트(있으면). 출력·커밋·PR 은 **한국어** (코드 identifier / 경로 / 명령어는 영어 그대로).
+
+## 원칙
+
+1. **게이트 먼저.** 하나라도 실패하면 커밋/푸시/PR 로 넘어가지 않고, 실패 내용을 그대로
+   보여주고 멈춘다. 실패를 감추거나 `--no-verify` 로 우회하지 않는다.
+2. **`main` 에 직접 커밋하지 않는다.** 현재 브랜치가 기본 브랜치면 먼저 새 브랜치를 판다.
+3. **사용자가 명시적으로 이 커맨드를 호출한 것 = 커밋·푸시·PR 승인.** 다만 커밋 메시지와
+   PR 초안은 만들기 전에 한 번 보여준다.
+4. Conventional Commits 스타일 제목 (`type(scope): 한국어 요약` 또는 `type: 한국어 요약`).
+
+## 절차
+
+### 1. 현재 상태 파악
+
+```bash
+git status
+git branch --show-current
+git diff --stat HEAD          # 스테이지+워킹 변경 규모
+git log --oneline -5
+```
+
+- 변경이 전혀 없으면(워킹 트리 clean & main 대비 커밋 없음) 그 사실만 알리고 멈춘다.
+
+### 2. 게이트 실행
+
+이 저장소의 change checklist 순서대로:
+
+```bash
+bun run check       # Biome verify
+bun run typecheck   # tsc --noEmit
+bun test            # 단위 + smoke
+```
+
+- 하나라도 실패 → 실패 로그를 인용하고, 무엇을 고쳐야 하는지 한 줄 진단 후 **멈춘다.**
+  (직접 코드를 고칠지 여부는 사용자에게 확인.)
+- 이번 변경이 사용자 표면(tool / env var / 커맨드 / handle)을 건드렸다면, 두 단일 문서
+  (`FEATURES.md` 한국어 · `AGENTS.md` 영문)와 진입 문서(`README.md` 등) 가 갱신됐는지
+  `git diff --stat` 로 점검하고, 빠졌으면 한 줄로 지적한다.
+
+### 3. 브랜치 확인
+
+- 현재 브랜치가 `main`(기본 브랜치)이면: 변경 내용에 맞는 이름으로 새 브랜치를 만든다
+  (`git switch -c <type>/<짧은-요약>`). 이미 feature 브랜치면 그대로 사용.
+
+### 4. 커밋 초안 → 커밋
+
+- `git diff` 를 읽고 변경의 핵심을 한국어로 요약해 **커밋 제목 + 본문 초안**을 만들어 보여준다.
+- 승인 흐름상 그대로 커밋한다. 커밋 메시지 말미에 아래 trailer 를 반드시 붙인다:
+
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  ```
+
+- 관련 없는 파일까지 싸잡아 `git add -A` 하지 말고, 이번 작업에 해당하는 변경만 스테이지한다.
+
+### 5. 푸시
+
+```bash
+git push -u origin <현재 브랜치>
+```
+
+### 6. PR 생성
+
+```bash
+gh pr create --base main --head <브랜치> --title "<Conventional 한국어 제목>" --body "<본문>"
+```
+
+- 제목: Conventional Commits 스타일 한국어.
+- 본문(한국어): **요약** / **변경 사항**(bullet) / **검증**(돌린 게이트 결과) 순. 장문 리포트 금지.
+- 본문 말미에 반드시:
+
+  ```
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  ```
+
+- 리뷰를 요청하는 맥락이면 "모든 리뷰 코멘트는 한국어로 작성해 주세요." 를 본문/코멘트에 포함.
+
+### 7. 마무리 & 다음 단계
+
+- 생성된 PR URL 을 출력한다.
+- 이어서 머지까지 지켜보려면 `/pr-watch <PR>` 를 안내한다.
+
+## 실패 / 예외 처리
+
+- `gh` 미인증 → `gh auth status` 확인 안내 후, 커밋·푸시까지만 하고 PR 단계에서 멈춘다.
+- 원격에 upstream 이 없거나 push 거부 → 에러를 그대로 인용하고 멈춘다 (강제 푸시 금지).
+- 게이트 실패 → 3단계 이후로 넘어가지 않는다 (커밋 없음).

--- a/commands/pr-watch.md
+++ b/commands/pr-watch.md
@@ -69,14 +69,22 @@ gh pr view <PR> --json number,title,url,state,isDraft,mergeable,mergeStateStatus
 
 리뷰/코멘트가 있으면 코드와 대조해 사용자의 대응을 돕는다.
 
-- 리뷰 본문 / 인라인 코멘트를 가져온다:
+- 리뷰 본문과 **미해결 리뷰 스레드**를 가져온다. REST(`/pulls/<n>/comments`)는 스레드의
+  `isResolved` 를 주지 않으므로, 미해결만 정확히 거르려면 GraphQL `reviewThreads` 를 쓴다:
   ```bash
-  gh pr view <PR> --json reviews
-  gh api repos/{owner}/{repo}/pulls/<number>/comments   # 인라인 리뷰 코멘트
+  gh pr view <PR> --json reviews          # 리뷰 본문 (approve / changes / comment)
+  gh api graphql -F owner=<owner> -F repo=<repo> -F num=<number> -f query='
+  query($owner:String!,$repo:String!,$num:Int!){
+    repository(owner:$owner, name:$repo){ pullRequest(number:$num){
+      reviewThreads(first:50){ nodes {
+        isResolved isOutdated
+        comments(first:1){ nodes { author{login} path line body } } } } } } }'
+  # → isResolved==false 인 스레드만 아래에서 다룬다 (resolved 는 이미 처리됨)
   ```
-  `{owner}` / `{repo}` 는 현재 저장소 컨텍스트에서 gh 가 자동 치환한다 — 직접 채우지 마라.
-  `<number>` 만 PR 번호로 치환한다 (1단계에서 `gh pr view <PR> --json number` 로 확보).
-- 각 미해결 코멘트에 대해 `Read` / `Grep` / `Glob` 으로 해당 파일·라인을 확인하고,
+  주의: `{owner}`/`{repo}` 자동 치환은 gh 의 **REST 엔드포인트** 기능이라 GraphQL query 문자열엔
+  적용되지 않는다. GraphQL 은 위처럼 `$owner`/`$repo`/`$num` **변수**로 넘겨라 —
+  값은 `gh repo view --json owner,name` 과 1단계의 `gh pr view <PR> --json number` 로 확보한다.
+- 각 **미해결(isResolved==false)** 코멘트에 대해 `Read` / `Grep` / `Glob` 으로 해당 파일·라인을 확인하고,
   다음 셋 중 하나로 **분류 + 한 줄 근거**를 제시한다:
   - **타당** — 지적이 코드와 일치. 어떻게 고치면 되는지 `file:line` 인용과 함께 권고.
   - **반박** — 지적이 사실과 다르거나 scope 밖. 근거(코드 라인 / 기존 합의)를 들어 반박안 제시.

--- a/commands/pr-watch.md
+++ b/commands/pr-watch.md
@@ -1,0 +1,137 @@
+---
+description: PR 상태(CI 체크·리뷰·머지 가능성)를 점검하고, 열린 리뷰 코멘트를 코드와 대조해 정리한 뒤, 머지 가능한 상태가 되면 알려준다. 머지는 하지 않는다.
+argument-hint: "[PR 번호 | URL | owner/repo#123] (생략 시 현재 브랜치의 PR)"
+allowed-tools: Bash(gh:*), Bash(git:*), Read, Grep, Glob
+---
+
+# pr-watch — PR 머지 대기 감시
+
+너는 지금 **하나의 열린 GitHub PR** 을 대상으로 상태를 점검하고, 리뷰를 정리하고,
+**머지 가능한 상태가 되면 사용자에게 알려주는** 역할을 한다.
+
+- 대상 PR: `$ARGUMENTS` (비어 있으면 현재 브랜치에 연결된 PR 을 자동으로 찾는다)
+- 모든 GitHub 접근은 `gh` CLI 로만 한다. `curl` / 직접 API fetch 금지.
+- 출력은 **한국어**. 코드 identifier / 경로 / 명령어 / API path 는 영어 그대로.
+
+## 핵심 원칙 (반드시 지킬 것)
+
+1. **머지하지 않는다.** `gh pr merge` 를 절대 실행하지 마라. 이 커맨드의 종착점은
+   "머지 가능해졌다"는 **알림**까지다. 실제 머지는 사용자가 직접 한다.
+2. **코드를 수정하지 않는다.** 리뷰 코멘트에 대해서는 "이 위치를 이렇게 고치면 된다"는
+   **권고**까지만. 실제 commit / push 는 사용자 몫.
+3. **사람 리뷰를 강제 대기하지 않는다.** CI 는 `gh pr checks --watch` 로 이 턴 안에서
+   끝까지 기다릴 수 있지만, reviewer 의 승인은 기다릴 수 없으니 재실행을 안내한다.
+4. 한 번 호출 = 한 번의 완결된 점검. 무한 루프를 스스로 돌지 않는다.
+
+## 절차
+
+### 1. 대상 PR 확정
+
+- `$ARGUMENTS` 가 있으면 그것을 PR 핸들로 쓴다 (번호 / URL / `owner/repo#123` 모두 허용).
+- 비어 있으면 현재 브랜치의 PR 을 찾는다:
+  `gh pr view --json number,url,headRefName 2>/dev/null`
+  - 실패하면(= 현재 브랜치에 PR 없음) 사용자에게 PR 번호/URL 을 한 번 묻고 멈춘다.
+
+### 2. 스냅샷 수집
+
+한 번의 호출로 필요한 필드를 모두 가져온다:
+
+```bash
+gh pr view <PR> --json number,title,url,state,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRefName,baseRefName,reviewRequests
+```
+
+- `state != OPEN` (이미 MERGED / CLOSED) 이면: 그 사실만 한 줄로 알리고 멈춘다.
+  watch 할 대상이 없다.
+- `isDraft == true` 이면: draft 라는 점을 알리고, ready 로 바꾸기 전엔 머지 불가임을
+  안내한다 (draft 해제는 사용자가).
+
+### 3. 현재 상태 리포트
+
+아래 신호를 사람이 읽기 쉽게 한국어로 요약한다:
+
+- **CI 체크** — `statusCheckRollup` 을 집계해 `성공 N / 실패 M / 진행중 K` 로. 실패 항목은
+  이름과 함께 나열.
+- **리뷰** — `reviewDecision` (`APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED` / null) 과
+  대기 중인 `reviewRequests`.
+- **머지 상태** — `mergeStateStatus` 를 해석한다:
+  | 값 | 의미 | 머지 가능? |
+  |---|---|---|
+  | `CLEAN` | 모든 조건 충족 | ✅ 가능 |
+  | `HAS_HOOKS` | 통과 (hook 있음) | ✅ 가능 |
+  | `UNSTABLE` | 비필수 체크 실패 있음 | ⚠️ 가능하나 확인 권장 |
+  | `BLOCKED` | 필수 리뷰/체크 미충족 | ❌ |
+  | `BEHIND` | base 보다 뒤처짐 (업데이트 필요) | ❌ |
+  | `DIRTY` | 머지 충돌 | ❌ |
+  | `DRAFT` | draft 상태 | ❌ |
+  | `UNKNOWN` | GitHub 계산 중 | 재확인 필요 |
+
+### 4. 열린 리뷰 코멘트 정리 (있을 때만)
+
+리뷰/코멘트가 있으면 코드와 대조해 사용자의 대응을 돕는다.
+
+- 리뷰 본문 / 인라인 코멘트를 가져온다:
+  ```bash
+  gh pr view <PR> --json reviews
+  gh api repos/{owner}/{repo}/pulls/<number>/comments   # 인라인 리뷰 코멘트
+  ```
+- 각 미해결 코멘트에 대해 `Read` / `Grep` / `Glob` 으로 해당 파일·라인을 확인하고,
+  다음 셋 중 하나로 **분류 + 한 줄 근거**를 제시한다:
+  - **타당** — 지적이 코드와 일치. 어떻게 고치면 되는지 `file:line` 인용과 함께 권고.
+  - **반박** — 지적이 사실과 다르거나 scope 밖. 근거(코드 라인 / 기존 합의)를 들어 반박안 제시.
+  - **보류** — 합리적이나 이 PR scope 밖. 후속 이슈/PR 제안.
+- **답글을 자동으로 달지 않는다.** 위 정리를 사용자에게 보여주고, 사용자가 답글/수정 여부를 결정.
+  (테스트 / 타입 / lint 결과로 갈리는 코멘트는 스스로 굴리지 말고, 필요하면 사용자에게
+  `bun test` / `bun run typecheck` 결과를 물어본다.)
+
+### 5. 머지 가능 여부 판정 & 대기
+
+- **이미 머지 가능** (`mergeStateStatus` ∈ {`CLEAN`, `HAS_HOOKS`}):
+  → 6단계 "머지 가능 알림" 으로 간다.
+
+- **CI 가 진행 중** (`statusCheckRollup` 에 `PENDING`/`IN_PROGRESS`, 또는 `mergeStateStatus == UNKNOWN`):
+  → CI 완료까지 이 턴 안에서 기다린다:
+  ```bash
+  gh pr checks <PR> --watch --fail-fast
+  ```
+  (이 명령은 모든 체크가 끝나면 반환한다. 실패 시 non-zero.)
+  완료 후 **2단계 스냅샷을 다시 찍어** 재판정한다. 이제 머지 가능하면 6단계로,
+  여전히 막혀 있으면 아래 "사람 리뷰 대기" 로.
+
+- **사람 리뷰 대기로 막힘** (`BLOCKED` / `reviewDecision ∈ {REVIEW_REQUIRED, CHANGES_REQUESTED}` 이고
+  CI 는 통과):
+  → reviewer 승인은 강제할 수 없다. 무엇이 막고 있는지(누구의 리뷰 대기 / changes requested)
+  명확히 알리고, **재실행 안내**로 멈춘다:
+  > 사람 리뷰 대기 중이라 지금은 머지 불가. 승인이 올라온 뒤 `/pr-watch <PR>` 를 다시 돌리거나,
+  > 주기적으로 지켜보려면 `/loop 5m /pr-watch <PR>` 로 백그라운드 폴링을 걸 수 있다.
+
+- **머지 충돌 / BEHIND / DIRTY**:
+  → 원인과 사용자가 할 일(rebase/merge base, 충돌 해소)을 한 줄로 안내하고 멈춘다.
+
+### 6. 머지 가능 알림
+
+머지 가능 상태(`CLEAN` / `HAS_HOOKS`, 또는 사용자가 수용한 `UNSTABLE`)가 되면 **눈에 띄게** 알린다:
+
+- 터미널 벨을 울려 주의를 끈다: `printf '\a'`
+- 아래 형식으로 결론을 출력한다:
+
+```markdown
+## ✅ 머지 가능 — <title> (#<number>)
+
+<PR URL>
+
+- CI: 전체 통과 (N/N)
+- 리뷰: <APPROVED 등>
+- 머지 상태: <CLEAN 등>
+
+지금 머지할 수 있다. 머지는 직접:
+`gh pr merge <PR> --squash` (또는 --merge / --rebase, repo 정책에 맞게)
+```
+
+- **여기서 멈춘다.** 머지는 실행하지 않는다.
+
+## 실패 / 예외 처리
+
+- `gh` 미인증 → `gh auth status` 로 확인하라고 한 줄 안내하고 멈춘다.
+- PR 핸들 파싱 실패 → 입력을 그대로 인용하고 한 번 묻고 멈춘다.
+- `gh pr checks --watch` 중 체크 실패(non-zero) → 실패한 체크 이름을 나열하고,
+  로그 확인(`gh pr checks <PR>` 또는 `gh run view`)을 안내한 뒤 멈춘다. (자동 재시도 금지)

--- a/commands/pr-watch.md
+++ b/commands/pr-watch.md
@@ -1,7 +1,7 @@
 ---
 description: PR 상태(CI 체크·리뷰·머지 가능성)를 점검하고, 열린 리뷰 코멘트를 코드와 대조해 정리한 뒤, 머지 가능한 상태가 되면 알려준다. 머지는 하지 않는다.
 argument-hint: "[PR 번호 | URL | owner/repo#123] (생략 시 현재 브랜치의 PR)"
-allowed-tools: Bash(gh:*), Bash(git:*), Read, Grep, Glob
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(printf:*), Read, Grep, Glob
 ---
 
 # pr-watch — PR 머지 대기 감시
@@ -74,6 +74,8 @@ gh pr view <PR> --json number,title,url,state,isDraft,mergeable,mergeStateStatus
   gh pr view <PR> --json reviews
   gh api repos/{owner}/{repo}/pulls/<number>/comments   # 인라인 리뷰 코멘트
   ```
+  `{owner}` / `{repo}` 는 현재 저장소 컨텍스트에서 gh 가 자동 치환한다 — 직접 채우지 마라.
+  `<number>` 만 PR 번호로 치환한다 (1단계에서 `gh pr view <PR> --json number` 로 확보).
 - 각 미해결 코멘트에 대해 `Read` / `Grep` / `Glob` 으로 해당 파일·라인을 확인하고,
   다음 셋 중 하나로 **분류 + 한 줄 근거**를 제시한다:
   - **타당** — 지적이 코드와 일치. 어떻게 고치면 되는지 `file:line` 인용과 함께 권고.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "files": [
     "src",
     "bin",
+    "commands",
     ".claude-plugin",
     "README.md"
   ],


### PR DESCRIPTION
## 요약

Claude Code plugin 에 `gh` CLI 기반 슬래시 커맨드 두 개를 추가한다. MCP tool surface(7개 `openapi_*`)와는 별개이며, `commands/` 자동 발견으로 로드된다. `/finish` → `/pr-watch` 가 한 쌍 — 마무리로 PR 을 만들고, 그 PR 을 머지 가능 상태까지 감시한다.

## 변경 사항

- **`/finish [힌트]`** — 게이트(`bun run check` / `typecheck` / `test`) 통과 확인 → 변경 요약 → 브랜치 → 커밋 → 푸시 → PR 생성. 게이트 실패 시 커밋하지 않고 멈춤, `main` 직접 커밋 금지, Conventional Commits 한국어 제목 + 서명 trailer.
- **`/pr-watch [PR]`** — 열린 PR 의 CI 체크·리뷰·머지 가능성 점검, 열린 리뷰 코멘트를 코드와 대조해 타당/반박/보류로 정리, **머지 가능해지면 알림**. CI 진행 중이면 `gh pr checks --watch` 로 한 턴 대기, 사람 리뷰 대기는 재실행/`/loop` 안내. **자동 머지 X**(`gh pr merge` 실행 안 함).
- MCP 는 고려 대상에서 제외 — 두 커맨드 모두 인증된 `gh` CLI 단일 의존.
- 문서 동기화: `FEATURES.md`(한국어) / `AGENTS.md`(영문) 커맨드 표면 + Layout, `README.md` 커맨드 소개, `package.json` `files` 에 `commands` 추가.

## 검증

- `bun run check` ✅
- `bun run typecheck` ✅
- `bun test` ✅ (87 pass)

모든 리뷰 코멘트는 한국어로 작성해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)