### PR TITLE
feat(plugin): seo_validate 도구를 새 src/ 구조로 이식 (ogpeek)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,12 +2,12 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "rocky",
   "version": "0.4.0",
-  "description": "rocky Claude Code plugin (Bun runtime). 7 openapi_* tools — cache-first OpenAPI / Swagger spec inspection, endpoint search, tag list. Archived domains (journal / mysql / notion / spec-pact / pr-watch) re-enter as separate PRs.",
+  "description": "rocky Claude Code plugin (Bun runtime). 7 openapi_* tools (cache-first OpenAPI / Swagger spec inspection, endpoint search, tag list) + seo_validate (OG / Twitter Card / JSON-LD / favicon meta validation via ogpeek). Archived domains (journal / mysql / notion / spec-pact / pr-watch) re-enter as separate PRs.",
   "author": {
     "name": "Minjun Kim"
   },
   "license": "MIT",
-  "keywords": ["openapi", "swagger", "rocky", "bun", "mcp"],
+  "keywords": ["openapi", "swagger", "seo", "ogp", "rocky", "bun", "mcp"],
   "mcpServers": {
     "rocky": {
       "type": "stdio",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Shared guide for AI coding agents (Claude Code, opencode, codex, etc.) working i
 
 ## Project in one line
 
-**rocky** (named after Project Hail Mary's Rocky) — a **single Bun package** whose `src/core/` OpenAPI core backs two distribution targets — a **Claude Code plugin** (marketplace; MCP server declared in `.claude-plugin/plugin.json`'s `mcpServers`, entry `src/index.ts`) and a host-agnostic **`openapi-mcp` standalone stdio CLI** (`bin/openapi-mcp` → `src/standalone.ts`, npm). Both expose the **same 7-tool surface** (`openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags`). No workspaces, no `packages/` — one `package.json`, one `tsconfig.json`.
+**rocky** (named after Project Hail Mary's Rocky) — a **single Bun package** whose `src/core/` OpenAPI core backs two distribution targets — a **Claude Code plugin** (marketplace; MCP server declared in `.claude-plugin/plugin.json`'s `mcpServers`, entry `src/index.ts`) and a host-agnostic **`openapi-mcp` standalone stdio CLI** (`bin/openapi-mcp` → `src/standalone.ts`, npm). Both expose the **same 7 openapi tools** (`openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags`); the Claude Code plugin adds one plugin-only tool, `seo_validate` (OG / Twitter Card / JSON-LD / favicon meta validation via `ogpeek`, `src/core/seo-validate.ts`). No workspaces, no `packages/` — one `package.json`, one `tsconfig.json`.
 
 Previous toolkit surfaces (journal / mysql / notion / spec-pact / pr-watch + rocky / grace / mindy agents + 5 skills) live on [`archive/pre-openapi-only-slim`](https://github.com/minjun0219/rocky/tree/archive/pre-openapi-only-slim); the former opencode plugin is archived in-tree at [`.archive/agent-toolkit-opencode/`](./.archive/agent-toolkit-opencode) (excluded from all gates). Domains re-enter in follow-up PRs via one of two shapes (plugin-bound handlers, or a separate CLI entry alongside `openapi-mcp`). The shape is decided per domain at re-introduction time.
 
@@ -25,9 +25,9 @@ rocky/                                      single package — @minjun0219/rocky
 ├── bin/
 │   └── openapi-mcp                         `#!/usr/bin/env bun` shebang, arg 파싱 → src/standalone
 └── src/
-    ├── index.ts                            ★ Claude Code plugin 진입점 — MCP 등록만, handler 호출은 ./core
-    ├── index.test.ts                       in-memory MCP smoke (7 tool, 누수 가드)
-    ├── standalone.ts                       standalone stdio MCP 로직 — 7 tool 등록 + `SpecRegistry`
+    ├── index.ts                            ★ Claude Code plugin 진입점 — MCP 등록만 (7 openapi + seo_validate), handler 호출은 ./core
+    ├── index.test.ts                       in-memory MCP smoke (8 tool, 누수 가드)
+    ├── standalone.ts                       standalone stdio MCP 로직 — 7 tool 등록 + `SpecRegistry` (seo_validate 미포함)
     └── core/                               ← 구 @minjun0219/openapi-core
         ├── index.ts                        barrel (플러그인이 `./core` 로 소비)
         ├── adapter.ts                      `rocky.json` registry → SpecRegistry + 핸들 평탄화
@@ -42,7 +42,8 @@ rocky/                                      single package — @minjun0219/rocky
         ├── parser.ts                       yaml + swagger2→3 + `$ref` deref (swagger-parser)
         ├── registry.ts                     메모리 + 디스크 registry + TTL + 백그라운드 revalidate
         ├── schema.ts                       `openapi-mcp.json` zod schema
-        ├── rocky-config.ts                 `rocky.json` 로더 (project > user, openapi-only)
+        ├── rocky-config.ts                 `rocky.json` 로더 (project > user, openapi + seo)
+        ├── seo-validate.ts                 `seo_validate` 코어 + handler (ogpeek, SSRF 가드) — plugin 전용
         ├── url.ts                          URL join / synthetic operationId
         ├── __fixtures__/                   petstore 2.0 / 3.0 (JSON + YAML)
         └── *.test.ts                       unit tests + handlers.test.ts
@@ -52,7 +53,7 @@ rocky/                                      single package — @minjun0219/rocky
 
 ## MVP scope (hold the line)
 
-**In**: OpenAPI / Swagger spec 캐시 + endpoint search + tag list + cross-spec scoped search + `host:env:spec` registry (`rocky.json`, project > user precedence), 단일 7-tool surface 를 2 배포 타깃 (Claude Code plugin + standalone CLI) 에 공유, 단일 Bun 패키지. 모든 handler 는 `src/core/handlers.ts` 한 곳에 정의 — 두 진입점 간 drift 방지.
+**In**: OpenAPI / Swagger spec 캐시 + endpoint search + tag list + cross-spec scoped search + `host:env:spec` registry (`rocky.json`, project > user precedence), 공유 7 openapi tool 을 2 배포 타깃 (Claude Code plugin + standalone CLI) 에 공유, 단일 Bun 패키지. 모든 openapi handler 는 `src/core/handlers.ts` 한 곳에 정의 — 두 진입점 간 drift 방지. 추가로 **`seo_validate`** (단일 URL 의 OG / Twitter Card / JSON-LD / favicon 메타를 `ogpeek` 으로 검증, 기본 SSRF 가드 — IP literal 기준 private/loopback 차단, `rocky.json` 의 `seo.allowPrivateHosts` / `seo.timeoutMs` 기본값, 도구 인자 우선) 는 Claude Code plugin 에만 등록 (handler `src/core/seo-validate.ts`, standalone CLI 미포함).
 
 **Out**: journal / mysql / notion / spec-pact / pr-watch / agents / skills (전부 archive 브랜치 박제), opencode plugin (`.archive/agent-toolkit-opencode/` 박제), 도메인 재추가 (별도 PR), npm publish 자동화 (별도 PR). OpenAPI YAML stream parsing, full SDK code generation, multi-spec merge, mock servers, UI 도 모두 out.
 
@@ -87,7 +88,7 @@ bun test            # 모든 src/**/*.test.ts
 - **ESM safety**: never use `__dirname`. Use `import.meta.url` + `fileURLToPath`, or Bun's `import.meta.dir`.
 - **Repo-local JSDoc**: write JSDoc on exported functions / classes when touching this repository, but do not treat it as a custom hard-lint gate. Korean comments are fine for tricky logic.
 - **Errors**: include context in messages (input value, timeout, status code, handle mismatch, …).
-- **Dependencies**: avoid adding any if possible. Prefer the standard library and Bun built-ins. **Explicit prod-dep exceptions:** `@modelcontextprotocol/sdk` + `zod` (MCP wire protocol + blessed schema dialect), `@apidevtools/swagger-parser` + `swagger2openapi` + `js-yaml` + `openapi-types` + `pino` (OpenAPI parsing / conversion / structured stderr logging). HTTP transport는 Bun의 native `fetch` (with `tls` option) 직접 사용. Dev-only tooling (linters / formatters) 는 OK. New runtime deps 는 별도 scope 논의. (`@opencode-ai/plugin` 은 opencode plugin 아카이브와 함께 제거됨.)
+- **Dependencies**: avoid adding any if possible. Prefer the standard library and Bun built-ins. **Explicit prod-dep exceptions:** `@modelcontextprotocol/sdk` + `zod` (MCP wire protocol + blessed schema dialect), `@apidevtools/swagger-parser` + `swagger2openapi` + `js-yaml` + `openapi-types` + `pino` (OpenAPI parsing / conversion / structured stderr logging), `ogpeek` (`seo_validate` 의 HTML fetch + OG / Twitter Card / JSON-LD / favicon 파싱 — 손으로 유지할 표면이 아님). HTTP transport는 Bun의 native `fetch` (with `tls` option) 직접 사용. Dev-only tooling (linters / formatters) 는 OK. New runtime deps 는 별도 scope 논의. (`@opencode-ai/plugin` 은 opencode plugin 아카이브와 함께 제거됨.)
 - **Tests**: keep `*.test.ts` next to the source and run with `bun test`. Isolate fs-dependent tests with `mkdtempSync`. 핸들러 동작 자체는 `src/core/handlers.test.ts` 에서 검증, 플러그인 진입점의 `src/index.test.ts` 는 surface (tool 개수 / 누수 회귀) 만 검증.
 
 ## Runtime project comment guidance

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -6,13 +6,13 @@
 
 ## 한 눈에
 
-- **단일 패키지 (`@minjun0219/rocky`) — 두 배포 타깃, 동일한 7-tool surface**:
+- **단일 패키지 (`@minjun0219/rocky`) — 두 배포 타깃, 공유 7 openapi tool + plugin 전용 `seo_validate`**:
   | 배포 타깃 | 역할 | 설치 |
   | --- | --- | --- |
   | **Claude Code plugin** (`src/index.ts`) | `.claude-plugin/plugin.json` 의 `mcpServers` (`${CLAUDE_PLUGIN_ROOT}/src/index.ts`) 로 stdio MCP 서버를 등록. marketplace 배포. | Claude Code plugin marketplace |
   | **`openapi-mcp` 단독 CLI** (`bin/openapi-mcp` → `src/standalone.ts`) | host-agnostic subset MCP. 어떤 stdio MCP host (Cursor / Continue / Claude Desktop / …) 든 등록해 쓰는 단독 CLI. | `bun link` (npm publish 는 별도 PR) |
 - **공유 core**: [`src/core/`](./src/core) — 두 타깃 모두 이 디렉토리의 `handlers.ts` / `registry.ts` / `adapter.ts` 등을 import. plugin 진입점은 barrel (`./core`) 로, standalone 은 `./core/<file>` subpath 로 가져온다.
-- **Surface (7 tool, 두 타깃 동일)**: `openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags`.
+- **Surface**: 공유 7 openapi tool (두 타깃 동일) — `openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags` — 에 더해 Claude Code plugin 전용 `seo_validate` (OG / Twitter Card / JSON-LD / favicon 메타 검증, `ogpeek` 기반). 단독 `openapi-mcp` CLI 는 OpenAPI 도메인만 다뤄 `seo_validate` 를 노출하지 않는다.
 - **설정 파일**:
   - `rocky.json` — plugin 이 읽는다 (project 의 `./rocky.json` 이 user 의 `~/.config/rocky/rocky.json` 을 leaf 단위로 덮어쓴다). v0.3 부터 `openapi.registry` 한 키만 존재.
   - `openapi-mcp.json` — 단독 CLI 가 읽는다. config 형태 (`specs.<name>.environments.<env>.baseUrl`) 가 다르고 평탄화 없이 그대로 SpecRegistry 에 들어간다.
@@ -31,12 +31,12 @@ Input          — 필수 + 선택 파라미터
 Output         — 반환값의 최상위 shape
 Side effects   — 디스크 / 네트워크 영향 (없으면 "none")
 Related config — 이 도구가 읽는 env 변수 + rocky.json 키
-Hosts          — 어디서 호출되는지 (Claude Code plugin / standalone CLI — 항상 둘 다)
+Hosts          — 어디서 호출되는지 (Claude Code plugin / standalone CLI — openapi_* 는 둘 다, seo_validate 는 plugin 만)
 ```
 
 ## 도구
 
-두 배포 타깃 모두 동일한 7개를 노출한다. handler 구현은 `src/core/handlers.ts` 한 곳에 정의되어 있고, Claude Code plugin (`src/index.ts`) 은 그걸 호출만 한다. 단독 CLI (`openapi-mcp`, `src/standalone.ts`) 는 자체 tool 정의를 가지되 같은 `SpecRegistry` 를 사용한다.
+두 배포 타깃 모두 동일한 7 개 openapi 도구를 노출한다. handler 구현은 `src/core/handlers.ts` 한 곳에 정의되어 있고, Claude Code plugin (`src/index.ts`) 은 그걸 호출만 한다. 단독 CLI (`openapi-mcp`, `src/standalone.ts`) 는 자체 tool 정의를 가지되 같은 `SpecRegistry` 를 사용한다. 여기에 더해 `seo_validate` 는 Claude Code plugin 에만 등록된다 (handler 는 `src/core/seo-validate.ts`).
 
 ### `openapi_get`
 
@@ -101,6 +101,15 @@ Hosts          — 어디서 호출되는지 (Claude Code plugin / standalone CL
 - **Related config**: 동일.
 - **Hosts**: 둘 다.
 
+### `seo_validate`
+
+- **What**: 단일 URL 의 OG / Twitter Card / JSON-LD / favicon 메타를 `ogpeek` 으로 fetch + parse 해 검증한다. redirect 를 끝까지 추적하고, ogpeek warnings 를 severity 별 (`errors` / `warnings` / `info`) 로 분리한다. 기본 SSRF 가드가 private / loopback / link-local / IPv6 ULA 호스트를 차단한다 (IP literal 기준 — DNS rebinding 은 범위 밖).
+- **Input**: `url` — 검증할 `http` / `https` URL (필수). `timeoutMs?` — fetch timeout (1..30000, 기본 8000). `allowPrivateHosts?` — SSRF 가드 비활성 (기본 `config.seo.allowPrivateHosts ?? false`).
+- **Output**: `{ summary, raw }`. `summary` 는 finalUrl / redirects / og:title / og:description / og:image / og:type / og:url / canonical / errors / warnings / info / hasJsonLd / hasFavicon / iconCount. `raw` 는 ogpeek 의 원본 `OgDebugResult`.
+- **Side effects**: 대상 URL 로 outbound HTTP GET (SSRF 가드 통과 시). 디스크 캐시 없음.
+- **Related config**: `rocky.json` 의 `seo` (`allowPrivateHosts` / `timeoutMs`) — 도구 인자가 우선. env 변수 없음.
+- **Hosts**: Claude Code plugin 만 (단독 CLI 미노출).
+
 ## 환경 변수
 
 `ROCKY_*` 변수는 **Claude Code plugin 진입점 (`src/index.ts`) 전용** — standalone `openapi-mcp` CLI 는 인지하지 않는다 (CLI 는 `openapi-mcp.json` config 파일 + XDG 표준 변수만 본다).
@@ -135,11 +144,16 @@ standalone CLI 는 위 XDG 변수에 추가로 `openapi-mcp` CLI flag (`--config
         }
       }
     }
+  },
+  "seo": {
+    "allowPrivateHosts": false,
+    "timeoutMs": 8000
   }
 }
 ```
 
 - 핸들 규칙: `host:env:spec`. 각 식별자는 `^[a-zA-Z0-9_-]+$` — 콜론은 separator 예약.
+- `seo` (옵션): `seo_validate` 도구 기본값. `allowPrivateHosts` (boolean, 기본 false) / `timeoutMs` (1..30000). 두 값 모두 도구 호출 인자가 우선. plugin 전용이며 단독 CLI 는 이 키를 읽지 않는다.
 - leaf 는 string (URL only) 또는 object (`{ url, baseUrl?, format? }`). `baseUrl` 은 `openapi_endpoint` 의 `fullUrl` 합성에 사용. `format` 은 `openapi3` / `swagger2` / `auto` (기본 auto).
 - project (`./rocky.json`) 가 user (`~/.config/rocky/rocky.json`) 를 leaf 단위로 덮어쓴다.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ OpenAPI / Swagger 명세를 캐시-우선으로 둘러보는 MCP toolkit — 이
 | **Claude Code plugin** | `.claude-plugin/plugin.json` 의 `mcpServers` 로 stdio MCP 서버를 등록. marketplace 배포. | Claude Code plugin marketplace |
 | **`openapi-mcp` 단독 CLI** | 어떤 stdio MCP host (Cursor / Continue / Claude Desktop / …) 든 등록해 쓰는 host-agnostic CLI. `bin/openapi-mcp`. | `bun link` (npm publish 는 별도 PR) |
 
-둘 다 **동일한 7 tool surface** (`openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags`) 를 노출한다. 공유 core 는 [`src/core/`](./src/core) — spec 다운로드 / 디스크 캐시 / `$ref` deref / swagger 2.0 → OpenAPI 3 변환 / endpoint 점수화 검색 / handler 함수.
+둘 다 **동일한 7 openapi tool surface** (`openapi_get` / `openapi_refresh` / `openapi_status` / `openapi_search` / `openapi_envs` / `openapi_endpoint` / `openapi_tags`) 를 노출한다. 공유 core 는 [`src/core/`](./src/core) — spec 다운로드 / 디스크 캐시 / `$ref` deref / swagger 2.0 → OpenAPI 3 변환 / endpoint 점수화 검색 / handler 함수.
+
+추가로 **Claude Code plugin 에만** `seo_validate` 도구가 붙는다 — 단일 URL 의 OG / Twitter Card / JSON-LD / favicon 메타를 [`ogpeek`](https://www.npmjs.com/package/ogpeek) 으로 fetch + parse 해 검증한다 (기본 SSRF 가드로 private / loopback 호스트 차단). 단독 `openapi-mcp` CLI 는 OpenAPI 도메인만 다루므로 이 도구는 노출하지 않는다.
 
 > - v0.2 까지의 journal / mysql / notion / spec-pact / pr-watch 도메인은 [`archive/pre-openapi-only-slim`](https://github.com/minjun0219/rocky/tree/archive/pre-openapi-only-slim) 브랜치에 박제되어 있다.
 > - opencode plugin 은 [`.archive/agent-toolkit-opencode/`](./.archive/agent-toolkit-opencode) 에 박제되어 있다 (게이트에서 제외).

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@apidevtools/swagger-parser": "^10.1.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "js-yaml": "^4.1.0",
+        "ogpeek": "^0.5.0",
         "openapi-types": "^12.1.3",
         "pino": "^9.5.0",
         "swagger2openapi": "^7.0.8",
@@ -122,6 +123,14 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
@@ -129,6 +138,8 @@
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -179,6 +190,8 @@
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+
+    "htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
@@ -239,6 +252,8 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "ogpeek": ["ogpeek@0.5.0", "", { "dependencies": { "htmlparser2": "9.1.0" } }, "sha512-ZSJNghNjFPJHfz/k7Qoi81jeN7td/PqrVp8wpXf4S9AUK7qqBdoNzUyUon4/DC10eMpHZB2ph+D+CxR7zb+XtQ=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@minjun0219/rocky",
   "version": "0.4.0",
-  "description": "rocky (named after Project Hail Mary) — a single Bun package shipping a Claude Code plugin (marketplace) plus a host-agnostic openapi-mcp stdio CLI (npm), sharing one OpenAPI / Swagger core. 7 openapi_* tools: cache-first spec inspection, endpoint search, tag list. journal / mysql / notion / spec-pact / pr-watch domains live on archive/pre-openapi-only-slim; the opencode plugin is archived in-tree under .archive/agent-toolkit-opencode/.",
+  "description": "rocky (named after Project Hail Mary) — a single Bun package shipping a Claude Code plugin (marketplace) plus a host-agnostic openapi-mcp stdio CLI (npm), sharing one OpenAPI / Swagger core. 7 openapi_* tools (cache-first spec inspection, endpoint search, tag list) + 1 seo_validate tool (OG / Twitter Card / JSON-LD / favicon meta validation via ogpeek). journal / mysql / notion / spec-pact / pr-watch domains live on archive/pre-openapi-only-slim; the opencode plugin is archived in-tree under .archive/agent-toolkit-opencode/.",
   "license": "MIT",
   "author": "Minjun Kim",
   "homepage": "https://github.com/minjun0219/rocky",
@@ -49,6 +49,7 @@
     "@apidevtools/swagger-parser": "^10.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "js-yaml": "^4.1.0",
+    "ogpeek": "^0.5.0",
     "openapi-types": "^12.1.3",
     "pino": "^9.5.0",
     "swagger2openapi": "^7.0.8",

--- a/rocky.schema.json
+++ b/rocky.schema.json
@@ -74,6 +74,23 @@
           "additionalProperties": false
         }
       }
+    },
+    "seo": {
+      "type": "object",
+      "description": "Defaults for the seo_validate tool. Every field is overridden by the tool call arguments.",
+      "properties": {
+        "allowPrivateHosts": {
+          "type": "boolean",
+          "description": "When true, allow fetching private / loopback / link-local hosts (SSRF guard off). Default false. The tool arg `allowPrivateHosts` wins."
+        },
+        "timeoutMs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 30000,
+          "description": "Fetch timeout in ms (1..30000). The tool arg `timeoutMs` wins. ogpeek default is 8000."
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -24,5 +24,6 @@ export * from './openapi-registry';
 export * from './parser';
 export * from './registry';
 export * from './schema';
+export * from './seo-validate';
 export * from './rocky-config';
 export * from './url';

--- a/src/core/rocky-config.test.ts
+++ b/src/core/rocky-config.test.ts
@@ -174,6 +174,55 @@ describe('mergeConfigs', () => {
     merged.openapi!.registry!.acme!.dev!.users = 'MUTATED';
     expect(user.openapi?.registry?.acme?.dev?.users).toBe('https://u/u.json');
   });
+
+  it('project seo fields override user seo, field by field', () => {
+    const user: RockyConfig = { seo: { allowPrivateHosts: true, timeoutMs: 5000 } };
+    const project: RockyConfig = { seo: { timeoutMs: 9000 } };
+    const merged = mergeConfigs(user, project);
+    // timeoutMs 는 project 값, allowPrivateHosts 는 user 값 유지.
+    expect(merged.seo?.timeoutMs).toBe(9000);
+    expect(merged.seo?.allowPrivateHosts).toBe(true);
+  });
+});
+
+describe('validateConfig — seo', () => {
+  it('accepts a well-formed seo block', () => {
+    const config = { seo: { allowPrivateHosts: true, timeoutMs: 8000 } };
+    expect(validateConfig(config, 'test')).toEqual(config);
+  });
+
+  it('accepts an empty / omitted seo block', () => {
+    expect(() => validateConfig({ seo: {} }, 'test')).not.toThrow();
+  });
+
+  it('rejects a non-object seo', () => {
+    expect(() => validateConfig({ seo: 'nope' } as any, 'p')).toThrow(/seo must be an object/);
+    expect(() => validateConfig({ seo: [] } as any, 'p')).toThrow(/seo must be an object/);
+  });
+
+  it('rejects unknown seo keys', () => {
+    expect(() => validateConfig({ seo: { retries: 3 } } as any, 'p')).toThrow(
+      /unknown key "retries"/,
+    );
+  });
+
+  it('rejects a non-boolean allowPrivateHosts', () => {
+    expect(() => validateConfig({ seo: { allowPrivateHosts: 'yes' } } as any, 'p')).toThrow(
+      /seo.allowPrivateHosts must be a boolean/,
+    );
+  });
+
+  it('rejects out-of-range / non-integer timeoutMs', () => {
+    expect(() => validateConfig({ seo: { timeoutMs: 0 } } as any, 'p')).toThrow(
+      /between 1 and 30000/,
+    );
+    expect(() => validateConfig({ seo: { timeoutMs: 30001 } } as any, 'p')).toThrow(
+      /between 1 and 30000/,
+    );
+    expect(() => validateConfig({ seo: { timeoutMs: 12.5 } } as any, 'p')).toThrow(
+      /between 1 and 30000/,
+    );
+  });
 });
 
 describe('loadConfig', () => {

--- a/src/core/rocky-config.ts
+++ b/src/core/rocky-config.ts
@@ -69,11 +69,25 @@ export function getRegistryFormat(
   return leaf.format;
 }
 
+/**
+ * `seo_validate` 도구 기본값. 모든 필드는 도구 호출 인자로 override 된다.
+ */
+export interface SeoConfig {
+  /**
+   * true 면 private / loopback / link-local 호스트 fetch 를 허용. 기본 false.
+   * `seo_validate` 도구 호출 인자 (`allowPrivateHosts`) 가 우선.
+   */
+  allowPrivateHosts?: boolean;
+  /** fetch timeout (ms). 1..30000. 도구 호출 인자 (`timeoutMs`) 가 우선. */
+  timeoutMs?: number;
+}
+
 export interface RockyConfig {
   $schema?: string;
   openapi?: {
     registry?: OpenapiRegistry;
   };
+  seo?: SeoConfig;
 }
 
 export interface LoadConfigOptions {
@@ -144,7 +158,41 @@ export function validateConfig(input: unknown, source: string): RockyConfig {
       validateRegistry(oapi.registry, source);
     }
   }
+  if (config.seo !== undefined) {
+    validateSeo(config.seo, source);
+  }
   return config as RockyConfig;
+}
+
+/** `seo` 객체에서 허용하는 키 (오타 가드, 스키마 lockstep). */
+const ALLOWED_SEO_KEYS = new Set(['allowPrivateHosts', 'timeoutMs']);
+
+/**
+ * `seo` 객체 모양 검증. `seo_validate` 도구 기본값을 받는다 — 미지원 key 는 reject.
+ */
+function validateSeo(seo: unknown, source: string): void {
+  if (seo === null || typeof seo !== 'object' || Array.isArray(seo)) {
+    throw new Error(`${source}: seo must be an object`);
+  }
+  const obj = seo as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_SEO_KEYS.has(key)) {
+      throw new Error(`${source}: seo: unknown key "${key}"`);
+    }
+  }
+  if (obj.allowPrivateHosts !== undefined && typeof obj.allowPrivateHosts !== 'boolean') {
+    throw new Error(`${source}: seo.allowPrivateHosts must be a boolean`);
+  }
+  if (obj.timeoutMs !== undefined) {
+    if (
+      typeof obj.timeoutMs !== 'number' ||
+      !Number.isInteger(obj.timeoutMs) ||
+      obj.timeoutMs < 1 ||
+      obj.timeoutMs > 30_000
+    ) {
+      throw new Error(`${source}: seo.timeoutMs must be an integer between 1 and 30000`);
+    }
+  }
 }
 
 function validateRegistry(reg: unknown, source: string): asserts reg is OpenapiRegistry {
@@ -280,6 +328,10 @@ export function mergeConfigs(user: RockyConfig, project: RockyConfig): RockyConf
         }
       }
     }
+  }
+  // seo 는 leaf 별 병합이 아니라 필드 단위로 project 가 user 를 덮어쓴다.
+  if (project.seo) {
+    out.seo = { ...out.seo, ...project.seo };
   }
   return out;
 }

--- a/src/core/seo-validate.test.ts
+++ b/src/core/seo-validate.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { FetchError } from 'ogpeek/fetch';
+import {
+  handleSeoValidate,
+  isPrivateHost,
+  runSeoValidate,
+  SEO_BLOCKED_CODE,
+  SEO_MAX_TIMEOUT_MS,
+} from './seo-validate';
+
+describe('isPrivateHost', () => {
+  it('recognizes localhost names', () => {
+    expect(isPrivateHost('localhost')).toBe(true);
+    expect(isPrivateHost('LocalHost')).toBe(true);
+    expect(isPrivateHost('api.localhost')).toBe(true);
+    expect(isPrivateHost('not-localhost.example')).toBe(false);
+  });
+
+  it('recognizes RFC1918 + loopback + link-local IPv4', () => {
+    expect(isPrivateHost('127.0.0.1')).toBe(true);
+    expect(isPrivateHost('127.255.255.254')).toBe(true);
+    expect(isPrivateHost('10.0.0.1')).toBe(true);
+    expect(isPrivateHost('172.16.0.1')).toBe(true);
+    expect(isPrivateHost('172.31.255.255')).toBe(true);
+    expect(isPrivateHost('172.32.0.1')).toBe(false);
+    expect(isPrivateHost('172.15.0.1')).toBe(false);
+    expect(isPrivateHost('192.168.1.1')).toBe(true);
+    expect(isPrivateHost('169.254.1.1')).toBe(true);
+    expect(isPrivateHost('0.0.0.0')).toBe(true);
+  });
+
+  it('does not flag public IPv4', () => {
+    expect(isPrivateHost('8.8.8.8')).toBe(false);
+    expect(isPrivateHost('1.1.1.1')).toBe(false);
+    expect(isPrivateHost('172.32.0.1')).toBe(false);
+    expect(isPrivateHost('169.255.0.1')).toBe(false);
+  });
+
+  it('recognizes IPv6 loopback / ULA / link-local', () => {
+    expect(isPrivateHost('::1')).toBe(true);
+    expect(isPrivateHost('::')).toBe(true);
+    expect(isPrivateHost('fe80::1')).toBe(true);
+    expect(isPrivateHost('fc00::1')).toBe(true);
+    expect(isPrivateHost('fd12:3456::1')).toBe(true);
+  });
+
+  it('does not flag public IPv6', () => {
+    expect(isPrivateHost('2001:4860:4860::8888')).toBe(false);
+    expect(isPrivateHost('2606:4700:4700::1111')).toBe(false);
+  });
+
+  it('does not flag external hostnames', () => {
+    expect(isPrivateHost('example.com')).toBe(false);
+    expect(isPrivateHost('ogp.me')).toBe(false);
+  });
+});
+
+describe('runSeoValidate', () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let nextResponse: { html: string; status?: number; contentType?: string };
+  let baseUrl: string;
+
+  beforeEach(() => {
+    nextResponse = { html: '' };
+    server = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch() {
+        return new Response(nextResponse.html, {
+          status: nextResponse.status ?? 200,
+          headers: {
+            'content-type': nextResponse.contentType ?? 'text/html; charset=utf-8',
+          },
+        });
+      },
+    });
+    baseUrl = `http://${server.hostname}:${server.port}/`;
+  });
+
+  afterEach(() => {
+    server.stop(true);
+  });
+
+  it('rejects non-http(s) URLs', async () => {
+    await expect(
+      runSeoValidate({ url: 'ftp://example.com', allowPrivateHosts: true }),
+    ).rejects.toThrow(/only http\/https/);
+  });
+
+  it('rejects empty / malformed URLs', async () => {
+    await expect(runSeoValidate({ url: '' })).rejects.toThrow(/non-empty/);
+    await expect(runSeoValidate({ url: 'not-a-url', allowPrivateHosts: true })).rejects.toThrow(
+      /invalid URL/,
+    );
+  });
+
+  it('rejects negative / non-finite timeoutMs', async () => {
+    await expect(
+      runSeoValidate({ url: baseUrl, timeoutMs: 0, allowPrivateHosts: true }),
+    ).rejects.toThrow(/positive finite/);
+    await expect(
+      runSeoValidate({ url: baseUrl, timeoutMs: Number.NaN, allowPrivateHosts: true }),
+    ).rejects.toThrow(/positive finite/);
+  });
+
+  it('clamps absurdly large timeoutMs to SEO_MAX_TIMEOUT_MS', async () => {
+    nextResponse.html = '<html><head><title>x</title></head></html>';
+    // 호출이 성공하면 clamp 가 동작했다는 뜻 (음수 / NaN 만 reject — 큰 수는 silent clamp).
+    const result = await runSeoValidate({
+      url: baseUrl,
+      timeoutMs: SEO_MAX_TIMEOUT_MS * 10,
+      allowPrivateHosts: true,
+    });
+    expect(result.summary.finalUrl).toBe(baseUrl);
+  });
+
+  it('blocks private host fetch when allowPrivateHosts is unset', async () => {
+    nextResponse.html = '<html></html>';
+    let caught: unknown;
+    try {
+      await runSeoValidate({ url: baseUrl });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FetchError);
+    expect((caught as FetchError).code).toBe(SEO_BLOCKED_CODE);
+    expect((caught as FetchError).message).toMatch(/Refusing to fetch private/);
+  });
+
+  it('blocks private host fetch when allowPrivateHosts is explicitly false', async () => {
+    nextResponse.html = '<html></html>';
+    let caught: unknown;
+    try {
+      await runSeoValidate({ url: baseUrl, allowPrivateHosts: false });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(FetchError);
+    expect((caught as FetchError).code).toBe(SEO_BLOCKED_CODE);
+  });
+
+  it('allows private host when allowPrivateHosts: true', async () => {
+    nextResponse.html = `<!doctype html>
+<html prefix="og: https://ogp.me/ns#">
+<head>
+  <title>Hello</title>
+  <meta property="og:title" content="Hello OG" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="${baseUrl}cover.png" />
+  <meta property="og:url" content="${baseUrl}" />
+  <meta property="og:description" content="OG desc" />
+  <link rel="canonical" href="${baseUrl}" />
+  <link rel="icon" href="${baseUrl}favicon.ico" />
+</head>
+<body></body>
+</html>`;
+    const result = await runSeoValidate({ url: baseUrl, allowPrivateHosts: true });
+    expect(result.summary.ogTitle).toBe('Hello OG');
+    expect(result.summary.ogType).toBe('website');
+    expect(result.summary.ogImage).toBe(`${baseUrl}cover.png`);
+    expect(result.summary.ogDescription).toBe('OG desc');
+    expect(result.summary.ogUrl).toBe(baseUrl);
+    expect(result.summary.canonical).toBe(baseUrl);
+    expect(result.summary.errors).toEqual([]);
+    expect(result.summary.hasFavicon).toBe(true);
+    expect(result.summary.iconCount).toBeGreaterThanOrEqual(1);
+    expect(result.raw.ogp.title).toBe('Hello OG');
+  });
+
+  it('surfaces OG_TITLE_MISSING when og:title is absent', async () => {
+    nextResponse.html = `<!doctype html>
+<html prefix="og: https://ogp.me/ns#">
+<head>
+  <title>Plain</title>
+  <meta property="og:type" content="website" />
+</head>
+<body></body>
+</html>`;
+    const result = await runSeoValidate({ url: baseUrl, allowPrivateHosts: true });
+    const codes = result.summary.errors.map((w) => w.code);
+    expect(codes).toContain('OG_TITLE_MISSING');
+  });
+
+  it('returns redirects array (empty for direct hits)', async () => {
+    nextResponse.html = '<html><head><title>x</title></head></html>';
+    const result = await runSeoValidate({ url: baseUrl, allowPrivateHosts: true });
+    expect(result.summary.redirects).toEqual([]);
+  });
+});
+
+describe('handleSeoValidate', () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    server = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch() {
+        return new Response('<html><head><title>x</title></head></html>', {
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        });
+      },
+    });
+    baseUrl = `http://${server.hostname}:${server.port}/`;
+  });
+
+  afterEach(() => {
+    server.stop(true);
+  });
+
+  it('falls back to config seo.allowPrivateHosts when the arg is omitted', async () => {
+    // config 가 private host 를 허용 → 인자 없이도 통과.
+    const result = await handleSeoValidate({ allowPrivateHosts: true }, { url: baseUrl });
+    expect(result.summary.finalUrl).toBe(baseUrl);
+  });
+
+  it('blocks private host when neither arg nor config allows it', async () => {
+    await expect(handleSeoValidate(undefined, { url: baseUrl })).rejects.toBeInstanceOf(FetchError);
+  });
+
+  it('tool arg overrides config default', async () => {
+    // config 는 막지만 (allowPrivateHosts:false) 도구 인자가 true 로 이긴다.
+    const result = await handleSeoValidate(
+      { allowPrivateHosts: false },
+      { url: baseUrl, allowPrivateHosts: true },
+    );
+    expect(result.summary.finalUrl).toBe(baseUrl);
+  });
+});

--- a/src/core/seo-validate.test.ts
+++ b/src/core/seo-validate.test.ts
@@ -44,9 +44,34 @@ describe('isPrivateHost', () => {
     expect(isPrivateHost('fd12:3456::1')).toBe(true);
   });
 
+  it('recognizes the full fe80::/10 link-local range (not just fe80::/16)', () => {
+    // fe80–febf 는 모두 link-local. 이전 구현은 fe80: prefix 만 잡아 fe90+ 를 뚫었다.
+    expect(isPrivateHost('fe80::1')).toBe(true);
+    expect(isPrivateHost('fe90::1')).toBe(true);
+    expect(isPrivateHost('fea0::1')).toBe(true);
+    expect(isPrivateHost('feb0::1')).toBe(true);
+    expect(isPrivateHost('febf::1')).toBe(true);
+    // fec0:: 는 link-local 이 아니다 (deprecated site-local) — 차단 대상 아님.
+    expect(isPrivateHost('fec0::1')).toBe(false);
+  });
+
+  it('blocks IPv4-mapped IPv6 that embeds a private / loopback IPv4', () => {
+    // WHATWG URL 은 [::ffff:127.0.0.1] 을 ::ffff:7f00:1 로 정규화한다. dotted / hex 양쪽 검증.
+    expect(isPrivateHost('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateHost('::ffff:7f00:1')).toBe(true); // 127.0.0.1
+    expect(isPrivateHost('::ffff:a00:1')).toBe(true); // 10.0.0.1
+    expect(isPrivateHost('::ffff:c0a8:101')).toBe(true); // 192.168.1.1
+    // URL 파서를 거친 실제 hostname 형태도 확인.
+    expect(isPrivateHost(new URL('http://[::ffff:127.0.0.1]/').hostname)).toBe(true);
+    expect(isPrivateHost(new URL('http://[::ffff:10.0.0.1]/').hostname)).toBe(true);
+  });
+
   it('does not flag public IPv6', () => {
     expect(isPrivateHost('2001:4860:4860::8888')).toBe(false);
     expect(isPrivateHost('2606:4700:4700::1111')).toBe(false);
+    // 공인 IPv4 를 담은 mapped 는 통과시켜야 한다.
+    expect(isPrivateHost('::ffff:8.8.8.8')).toBe(false);
+    expect(isPrivateHost('::ffff:808:808')).toBe(false); // 8.8.8.8
   });
 
   it('does not flag external hostnames', () => {

--- a/src/core/seo-validate.ts
+++ b/src/core/seo-validate.ts
@@ -81,15 +81,8 @@ export function isPrivateHost(hostname: string): boolean {
   }
   const ipVersion = isIP(host);
   if (ipVersion === 4) {
-    const parts = host.split('.');
-    if (parts.length !== 4) {
-      return false;
-    }
-    const octets = parts.map((p) => Number.parseInt(p, 10));
-    if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
-      return false;
-    }
-    const [a, b] = octets as [number, number, number, number];
+    // isIP === 4 는 유효한 dotted-quad 를 보장하므로 octet 재검증은 불필요.
+    const [a, b] = host.split('.').map(Number) as [number, number, number, number];
     if (a === 0) {
       return true;
     }
@@ -114,20 +107,64 @@ export function isPrivateHost(hostname: string): boolean {
     if (host === '::' || host === '::1') {
       return true;
     }
-    if (host.startsWith('fe80:') || host.startsWith('fe80::')) {
+    // IPv4-mapped IPv6 (`::ffff:127.0.0.1`, WHATWG 정규화 시 `::ffff:7f00:1` hex 형태) 는
+    // 임베디드 IPv4 를 꺼내 IPv4 규칙으로 재검사 — 그렇지 않으면 loopback / RFC1918 이
+    // mapped 리터럴로 가드를 우회한다.
+    const mappedIpv4 = extractMappedIpv4(host);
+    if (mappedIpv4 !== null && isPrivateHost(mappedIpv4)) {
       return true;
     }
-    // fc00::/7 → 첫 byte 의 상위 7 bit 가 1111110.
     const firstHextet = host.split(':')[0] ?? '';
     if (firstHextet.length > 0) {
       const value = Number.parseInt(firstHextet, 16);
-      if (Number.isFinite(value) && (value & 0xfe00) === 0xfc00) {
-        return true;
+      if (Number.isFinite(value)) {
+        // link-local fe80::/10 → 첫 hextet 의 상위 10 bit 가 1111111010.
+        if ((value & 0xffc0) === 0xfe80) {
+          return true;
+        }
+        // ULA fc00::/7 → 첫 hextet 의 상위 7 bit 가 1111110.
+        if ((value & 0xfe00) === 0xfc00) {
+          return true;
+        }
       }
     }
     return false;
   }
   return false;
+}
+
+/**
+ * IPv4-mapped IPv6 리터럴에서 임베디드 IPv4 (`a.b.c.d`) 를 추출한다. mapped 가 아니면 null.
+ * WHATWG URL 파서는 `::ffff:127.0.0.1` 을 hex 형태 `::ffff:7f00:1` 로 정규화하므로 두 표현
+ * (dotted `::ffff:a.b.c.d`, hex `::ffff:HHHH:HHHH`) 을 모두 받는다.
+ */
+function extractMappedIpv4(host: string): string | null {
+  const rest = /^::ffff:(.+)$/.exec(host)?.[1];
+  if (rest === undefined) {
+    return null;
+  }
+  // dotted 형태면 그대로 IPv4.
+  if (isIP(rest) === 4) {
+    return rest;
+  }
+  // hex 형태 `HHHH:HHHH` — 두 hextet 을 32bit 로 합쳐 4 octet 으로 분해.
+  const parts = rest.split(':');
+  if (parts.length !== 2) {
+    return null;
+  }
+  const hi = Number.parseInt(parts[0] as string, 16);
+  const lo = Number.parseInt(parts[1] as string, 16);
+  if (
+    !Number.isInteger(hi) ||
+    !Number.isInteger(lo) ||
+    hi < 0 ||
+    hi > 0xffff ||
+    lo < 0 ||
+    lo > 0xffff
+  ) {
+    return null;
+  }
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
 }
 
 /**

--- a/src/core/seo-validate.ts
+++ b/src/core/seo-validate.ts
@@ -1,0 +1,240 @@
+import { isIP } from 'node:net';
+import { parse } from 'ogpeek';
+import type { OgDebugResult, Warning } from 'ogpeek';
+import { FetchError, fetchHtml, type RedirectHop } from 'ogpeek/fetch';
+import type { SeoConfig } from './rocky-config';
+
+/**
+ * `seo_validate` 도구의 코어 — 단일 URL 을 fetch + ogpeek parse 해서 OG / Twitter Card /
+ * JSON-LD / favicon 메타를 검증한다. OpenAPI 도메인과 독립적이며 `ogpeek` 하나에만 의존한다.
+ */
+
+export interface SeoValidateOptions {
+  /** 검증 대상 URL. http / https 만 허용. */
+  url: string;
+  /** fetch timeout (ms). 호출 인자 우선; 없으면 ogpeek 기본 8000. 1..30000 으로 clamp. */
+  timeoutMs?: number;
+  /** true 면 SSRF 가드 비활성. 호출 인자 우선; 없으면 호출자 (`handleSeoValidate`) 가 config 기본을 채워 넣는다. */
+  allowPrivateHosts?: boolean;
+  /** 테스트 / DI 용 transport override. 기본 `globalThis.fetch`. */
+  fetch?: (url: string, init: RequestInit) => Promise<Response>;
+}
+
+export interface SeoValidateSummary {
+  /** redirect 까지 마친 최종 URL. */
+  finalUrl: string;
+  /** redirect 추적 결과 (없으면 빈 배열). */
+  redirects: RedirectHop[];
+  ogTitle: string | null;
+  ogDescription: string | null;
+  /** og:image 가 여러 개면 첫 번째만. */
+  ogImage: string | null;
+  ogType: string | null;
+  ogUrl: string | null;
+  canonical: string | null;
+  /** ogpeek warnings 중 severity="error" 만. */
+  errors: Warning[];
+  /** ogpeek warnings 중 severity="warn" 만. */
+  warnings: Warning[];
+  /** ogpeek warnings 중 severity="info" 만. */
+  info: Warning[];
+  hasJsonLd: boolean;
+  hasFavicon: boolean;
+  iconCount: number;
+}
+
+export interface SeoValidateResult {
+  /** 에이전트가 그대로 markdown 표 / 권고로 가공하기 좋은 요약. */
+  summary: SeoValidateSummary;
+  /** ogpeek `parse` 의 원본 결과 — twitter / typed / raw / icons / jsonld 까지 모두 포함. */
+  raw: OgDebugResult;
+}
+
+/**
+ * SSRF 가드 hit 시 surface 되는 ogpeek `FetchError` 의 code.
+ * ogpeek `fetchHtml` 의 guard 슬롯은 throw 된 `FetchError` 를 그대로 다시 던지지만
+ * 그 외 Error 는 `code: "GUARD_FAILED"` 로 wrapping 한다. 따라서 호출자에게 깔끔한
+ * code 한 종류만 노출되도록 가드는 처음부터 `FetchError("BLOCKED", ...)` 를 던진다.
+ */
+export const SEO_BLOCKED_CODE = 'BLOCKED';
+
+/** 도구 호출 인자 / config 양쪽에서 받는 timeout 의 상한. ogpeek 기본은 8000ms. */
+export const SEO_MAX_TIMEOUT_MS = 30_000;
+
+/**
+ * RFC1918 / loopback / link-local / IPv6 ULA 범위 검사.
+ * IP literal 만 차단한다 — DNS resolve 후 사설 IP 로 가는 외부 호스트는 막지 않는다 (그건
+ * fetch 단의 socket-level guard 가 필요하고, MVP 범위 밖). hostname 이 호스트명일 때는
+ * `localhost` / `*.localhost` 만 차단.
+ */
+export function isPrivateHost(hostname: string): boolean {
+  if (!hostname) {
+    return false;
+  }
+  // IPv6 literal 의 양 끝 대괄호 제거.
+  const host = hostname.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+  if (host === 'localhost') {
+    return true;
+  }
+  if (host.endsWith('.localhost')) {
+    return true;
+  }
+  const ipVersion = isIP(host);
+  if (ipVersion === 4) {
+    const parts = host.split('.');
+    if (parts.length !== 4) {
+      return false;
+    }
+    const octets = parts.map((p) => Number.parseInt(p, 10));
+    if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+      return false;
+    }
+    const [a, b] = octets as [number, number, number, number];
+    if (a === 0) {
+      return true;
+    }
+    if (a === 10) {
+      return true;
+    }
+    if (a === 127) {
+      return true;
+    }
+    if (a === 169 && b === 254) {
+      return true;
+    }
+    if (a === 172 && b >= 16 && b <= 31) {
+      return true;
+    }
+    if (a === 192 && b === 168) {
+      return true;
+    }
+    return false;
+  }
+  if (ipVersion === 6) {
+    if (host === '::' || host === '::1') {
+      return true;
+    }
+    if (host.startsWith('fe80:') || host.startsWith('fe80::')) {
+      return true;
+    }
+    // fc00::/7 → 첫 byte 의 상위 7 bit 가 1111110.
+    const firstHextet = host.split(':')[0] ?? '';
+    if (firstHextet.length > 0) {
+      const value = Number.parseInt(firstHextet, 16);
+      if (Number.isFinite(value) && (value & 0xfe00) === 0xfc00) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return false;
+}
+
+/**
+ * ogpeek `fetchHtml` 의 `guard` 슬롯에 그대로 꽂을 수 있는 차단 함수.
+ * 초기 호출과 모든 redirect hop 직전에 한 번씩 평가된다.
+ *
+ * `FetchError` 를 던지는 이유: ogpeek 의 `runGuard` 는 throw 된 값이 `FetchError`
+ * 인스턴스면 그대로 re-throw 하지만, 그 외 Error 는 `code: "GUARD_FAILED"` 로 다시
+ * 감싼다. 호출자에게 한결같은 `code: "BLOCKED"` 가 노출되도록 처음부터 FetchError
+ * 로 던진다.
+ */
+export function makePrivateHostGuard(): (url: URL) => void {
+  return (url: URL) => {
+    if (isPrivateHost(url.hostname)) {
+      throw new FetchError(
+        SEO_BLOCKED_CODE,
+        400,
+        `Refusing to fetch private/loopback host ${url.hostname} — set seo.allowPrivateHosts=true in rocky.json (or pass allowPrivateHosts=true to seo_validate) to override for trusted internal scans.`,
+      );
+    }
+  };
+}
+
+/**
+ * URL 한 개를 fetch 하고 ogpeek 으로 파싱해 요약 + raw 결과를 돌려준다.
+ * SSRF 가드는 `allowPrivateHosts` 가 true 가 아닐 때 자동 적용.
+ */
+export async function runSeoValidate(opts: SeoValidateOptions): Promise<SeoValidateResult> {
+  if (typeof opts.url !== 'string' || opts.url.length === 0) {
+    throw new Error('seo_validate: url must be a non-empty string');
+  }
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(opts.url);
+  } catch {
+    throw new Error(`seo_validate: invalid URL ${JSON.stringify(opts.url)}`);
+  }
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new Error(`seo_validate: only http/https URLs are supported — got ${parsedUrl.protocol}`);
+  }
+  const timeoutMs = clampTimeout(opts.timeoutMs);
+  const guard = opts.allowPrivateHosts ? undefined : makePrivateHostGuard();
+
+  const { html, finalUrl, redirects } = await fetchHtml(opts.url, {
+    timeoutMs,
+    guard,
+    fetch: opts.fetch,
+  });
+  const result = parse(html, { url: finalUrl });
+  return {
+    summary: buildSummary(result, finalUrl, redirects),
+    raw: result,
+  };
+}
+
+function clampTimeout(ms: number | undefined): number | undefined {
+  if (ms === undefined) {
+    return undefined;
+  }
+  if (!Number.isFinite(ms) || ms < 1) {
+    throw new Error('seo_validate: timeoutMs must be a positive finite number');
+  }
+  return Math.min(Math.floor(ms), SEO_MAX_TIMEOUT_MS);
+}
+
+function buildSummary(
+  r: OgDebugResult,
+  finalUrl: string,
+  redirects: RedirectHop[],
+): SeoValidateSummary {
+  return {
+    finalUrl,
+    redirects,
+    ogTitle: r.ogp.title ?? null,
+    ogDescription: r.ogp.description ?? null,
+    ogImage: r.ogp.images[0]?.url ?? null,
+    ogType: r.ogp.type ?? null,
+    ogUrl: r.ogp.url ?? null,
+    canonical: r.meta.canonical,
+    errors: r.warnings.filter((w) => w.severity === 'error'),
+    warnings: r.warnings.filter((w) => w.severity === 'warn'),
+    info: r.warnings.filter((w) => w.severity === 'info'),
+    hasJsonLd: r.jsonld.length > 0,
+    hasFavicon: r.icons.length > 0,
+    iconCount: r.icons.length,
+  };
+}
+
+/**
+ * `seo_validate` 도구 핸들러. 도구 호출 인자가 있으면 그것이 우선이고, 없으면
+ * `rocky.json` 의 `seo` 섹션 기본값으로 채운다. 그 외 동작은 `runSeoValidate`
+ * 에 전부 위임 — fetch / parse / SSRF 가드 / timeout clamp 까지.
+ */
+export async function handleSeoValidate(
+  seoConfig: SeoConfig | undefined,
+  args: {
+    url: string;
+    timeoutMs?: number;
+    allowPrivateHosts?: boolean;
+  },
+  injectFetch?: SeoValidateOptions['fetch'],
+): Promise<SeoValidateResult> {
+  const seoCfg = seoConfig ?? {};
+  return runSeoValidate({
+    url: args.url,
+    timeoutMs: args.timeoutMs ?? seoCfg.timeoutMs,
+    allowPrivateHosts: args.allowPrivateHosts ?? seoCfg.allowPrivateHosts ?? false,
+    fetch: injectFetch,
+  });
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -27,6 +27,7 @@ const EXPECTED_TOOLS = [
   'openapi_envs',
   'openapi_endpoint',
   'openapi_tags',
+  'seo_validate',
 ] as const;
 
 /** v0.3 부터 surface 에서 빠진 tool — 누수 회귀 가드. archive/pre-openapi-only-slim 참조. */
@@ -89,7 +90,7 @@ afterAll(async () => {
 });
 
 describe('rocky Claude Code MCP server', () => {
-  test('exposes exactly the 7 openapi tools', async () => {
+  test('exposes exactly the 7 openapi tools + seo_validate', async () => {
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name).sort();
     expect(names).toEqual([...EXPECTED_TOOLS].sort());

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
   handleSwaggerGet,
   handleSwaggerRefresh,
   handleSwaggerSearch,
+  handleSeoValidate,
   handleSwaggerStatus,
   handleSwaggerTags,
 } from './core';
@@ -148,6 +149,21 @@ export async function buildServer() {
       inputSchema: { input: z.string() },
     },
     async ({ input }) => jsonResult(await handleSwaggerTags(openapiRegistry, input, registry)),
+  );
+
+  server.registerTool(
+    'seo_validate',
+    {
+      description:
+        '단일 URL 의 OG / Twitter Card / JSON-LD / favicon 메타를 ogpeek 으로 fetch + parse 해서 검증한다. summary (finalUrl / redirects / og:title / og:description / og:image / og:type / og:url / canonical / errors / warnings / info / hasJsonLd / hasFavicon / iconCount) + raw OgDebugResult 둘 다 반환. errors 는 ogpeek warnings 중 severity=error (`OG_TITLE_MISSING` / `OG_TYPE_MISSING` / `OG_IMAGE_MISSING` / `OG_URL_MISSING`) 만 추린 것. 기본 SSRF 가드는 private / loopback / link-local / IPv6 ULA 호스트 차단 — rocky.json 의 `seo.allowPrivateHosts:true` 또는 도구 호출 인자 `allowPrivateHosts:true` 로 끈다. (url: 검증할 http/https URL, timeoutMs?: fetch timeout (1..30000, 기본 8000), allowPrivateHosts?: SSRF 가드 비활성, 기본 config.seo.allowPrivateHosts ?? false)',
+      inputSchema: {
+        url: z.string(),
+        timeoutMs: z.number().int().positive().optional(),
+        allowPrivateHosts: z.boolean().optional(),
+      },
+    },
+    async ({ url, timeoutMs, allowPrivateHosts }) =>
+      jsonResult(await handleSeoValidate(toolkitConfig.seo, { url, timeoutMs, allowPrivateHosts })),
   );
 
   return server;


### PR DESCRIPTION
## 배경

PR #61 (`feat(plugin): SEO 검증 도구 + 스킬 추가`) 은 v0.2 의 **opencode 플러그인 구조**(`.opencode/plugins/agent-toolkit.ts`, `lib/`, `agents/rocky.md`, skills) 위에 올라가 있었다. 그 사이 main 이 openapi-only Claude Code 플러그인(`src/core/*`)으로 전면 재편(#66/#67/#69)되면서 해당 파일들이 전부 `.archive/` 로 이동 → PR #61 은 modify/delete 충돌로 **머지 불가**.

이 PR 은 seo_validate 의 재사용 가능한 코어를 새 아키텍처로 다시 구현한다. **PR #61 은 이 PR 로 대체되며 close 대상.**

## 변경

- `src/core/seo-validate.ts` — 코어(`runSeoValidate`) + 도구 handler(`handleSeoValidate`). `ogpeek` 하나에만 의존. 기본 SSRF 가드(IP literal 기준 private / loopback / link-local / IPv6 ULA 차단).
- `src/index.ts` — `seo_validate` MCP 도구 등록. **Claude Code plugin 전용** — 단독 `openapi-mcp` CLI 는 OpenAPI 도메인만 다뤄 미노출.
- `src/core/rocky-config.ts` + `rocky.schema.json` — `seo` config(`allowPrivateHosts` / `timeoutMs`) 추가, 검증 + field 단위 merge (lockstep).
- `package.json` / `.claude-plugin/plugin.json` — `ogpeek` prod dep, surface 설명(7 openapi + seo_validate).
- docs — `README.md` / `FEATURES.md` / `AGENTS.md` 서페이스·config·의존성 정책 갱신.

## 원본 PR 대비 차이

- **skill 제외**: 새 구조엔 skills 계층이 없어 `skills/seo-validation/SKILL.md` 는 이식하지 않고, 가이드는 도구 description 으로 흡수.
- config 기본값을 `ToolkitConfig.seo` → `RockyConfig.seo` 로 옮기고, handler 는 config 전체 대신 `SeoConfig` 만 받도록 슬림화.

## 검증

- `bun run check` ✅ (biome)
- `bun run typecheck` ✅
- `bun test ./src` ✅ 112 pass / 0 fail
  - seo-validate 18 (isPrivateHost / runSeoValidate / handleSeoValidate)
  - rocky-config seo 검증·merge 7
  - index surface 8-tool 회귀 가드 갱신

> 모든 리뷰 코멘트는 한국어로 작성해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)