### PR TITLE
docs: AGENTS.md 에 rocky 개인 플러그인 scope framing 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ Shared guide for AI coding agents (Claude Code, opencode, codex, etc.) working i
 
 Previous toolkit surfaces (journal / mysql / notion / spec-pact / pr-watch + rocky / grace / mindy agents + 5 skills) live on [`archive/pre-openapi-only-slim`](https://github.com/minjun0219/rocky/tree/archive/pre-openapi-only-slim); the former opencode plugin is archived in-tree at [`.archive/agent-toolkit-opencode/`](./.archive/agent-toolkit-opencode) (excluded from all gates). Domains re-enter in follow-up PRs via one of two shapes (plugin-bound handlers, or a separate CLI entry alongside `openapi-mcp`). The shape is decided per domain at re-introduction time.
 
+> **Scope framing (read this before treating a feature request as out-of-scope).** rocky is the owner's **personal Claude Code plugin**, not an OpenAPI-scoped product. The current openapi-only surface is today's **slim baseline, not a ceiling** — the owner grows rocky by adding whatever domains / features they need. So when the owner asks for a domain or feature (notion, journal, a brand-new capability, …), the answer is to **build it** — follow *Reintroduction strategy* for an archived domain, or just add a new one — not to shelve it as "out of scope". The "hold the line" discipline in *MVP scope* only guards against **unrequested** scope creep; it never overrides an explicit owner request.
+
 ## Layout
 
 ```


### PR DESCRIPTION
## 배경

한번은 main 의 "openapi-only" 프레이밍(ROADMAP / index.ts 주석)을 하드 경계로 오해해서, 사용자가 원하던 notion 기능을 "도메인이 아카이브됐으니 재이식 불가"라며 shelve 하려 했다. 사용자가 "rocky 는 openapi 에 한정된 게 아니라 필요한 기능을 추가할 개인 플러그인"이라고 바로잡음.

## 변경

- **`AGENTS.md` "Project in one line" 절에 scope framing 블록 추가**: openapi-only 는 현재 slim baseline 일 뿐 ceiling 이 아니며, rocky 는 owner 의 개인 Claude Code 플러그인이다. owner 가 요청한 도메인 / 기능은 out-of-scope 로 shelve 하지 말고 구현(archive 도메인은 *Reintroduction strategy*, 신규는 그냥 추가)하도록 명시. "hold the line" 규율은 요청 없는 scope creep 만 막는다는 점을 분명히 함.

## 참고

- 원래 이 PR 에 있던 ROADMAP notion refresh diff POC 참고 링크는 제거했다 — notion 도메인이 PR #73 에서 실제로 재추가되면서 superseded 되었기 때문. 이 PR 은 이제 scope-framing 문서 한 줄기만 담는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)