### PR TITLE
feat(journal): journal_status 에 dirSource / wikiDirSource 경로 출처 노출

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -181,7 +181,7 @@ Hosts          — 어디서 호출되는지 (Claude Code plugin / standalone CL
 
 #### `journal_status`
 
-- **What**: 저널 메타(`path` / `exists` / `totalEntries` — 손상 라인 제외 / `sizeBytes` / `lastEntryAt`) + 정리 대상 `wikiDir` + 프로젝트 키 `projectKey` (`<basename>-<hash8>`) + 마지막 curate watermark(`lastCurateAt`)를 조회. `/curate` 가 정리 시작 시 이걸로 정리 루트(`<wikiDir>/<projectKey>/`)와 증분 기준점을 확인한다.
+- **What**: 저널 메타(`path` / `exists` / `totalEntries` — 손상 라인 제외 / `sizeBytes` / `lastEntryAt`) + 정리 대상 `wikiDir` + 프로젝트 키 `projectKey` (`<basename>-<hash8>`) + 마지막 curate watermark(`lastCurateAt`) + 경로 출처 힌트 `dirSource`(`env` / `config` / `default`) · `wikiDirSource`(`env` / `config` / `unset`)를 조회. `dirSource` / `wikiDirSource` 는 소스를 안 읽어도 저장 위치 / curate 위치가 어디서 왔는지 · env / `rocky.json` 으로 바꿀 수 있는지 발견하게 하는 힌트 (`wikiDirSource:"unset"` 이면 curate 대상 미설정). `/curate` 가 정리 시작 시 이걸로 정리 루트(`<wikiDir>/<projectKey>/`)와 증분 기준점을 확인한다.
 - **Input**: 없음.
 - **Output**: `JournalStatus`.
 - **Side effects**: 없음.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -181,7 +181,7 @@ Hosts          — 어디서 호출되는지 (Claude Code plugin / standalone CL
 
 #### `journal_status`
 
-- **What**: 저널 메타(`path` / `exists` / `totalEntries` — 손상 라인 제외 / `sizeBytes` / `lastEntryAt`) + 정리 대상 `wikiDir` + 프로젝트 키 `projectKey` (`<basename>-<hash8>`) + 마지막 curate watermark(`lastCurateAt`) + 경로 출처 힌트 `dirSource`(`env` / `config` / `default`) · `wikiDirSource`(`env` / `config` / `unset`)를 조회. `dirSource` / `wikiDirSource` 는 소스를 안 읽어도 저장 위치 / curate 위치가 어디서 왔는지 · env / `rocky.json` 으로 바꿀 수 있는지 발견하게 하는 힌트 (`wikiDirSource:"unset"` 이면 curate 대상 미설정). `/curate` 가 정리 시작 시 이걸로 정리 루트(`<wikiDir>/<projectKey>/`)와 증분 기준점을 확인한다.
+- **What**: 저널 메타(`path` / `exists` / `totalEntries` — 손상 라인 제외 / `sizeBytes` / `lastEntryAt`) + 정리 대상 `wikiDir` + 프로젝트 키 `projectKey` (`<basename>-<hash8>`) + 마지막 curate watermark(`lastCurateAt`) + 경로 출처 힌트 `dirSource`(`env` / `config` / `default`) · `wikiDirSource`(`env` / `config` / `unset`)를 조회. `dirSource` / `wikiDirSource` 는 소스를 안 읽어도 저장 위치 / curate 위치가 어디서 왔는지 · env / `rocky.json` 으로 바꿀 수 있는지 발견하게 하는 힌트 (`wikiDirSource:"unset"` 이면 curate 대상 미설정). 출처와 경로는 항상 일관된다 — `wikiDirSource:"unset" ⟺ wikiDir` 없음, `dirSource:"default" ⟺` 기본 경로. `/curate` 가 정리 시작 시 이걸로 정리 루트(`<wikiDir>/<projectKey>/`)와 증분 기준점을 확인한다.
 - **Input**: 없음.
 - **Output**: `JournalStatus`.
 - **Side effects**: 없음.

--- a/src/core/journal.test.ts
+++ b/src/core/journal.test.ts
@@ -232,6 +232,41 @@ describe('AgentJournal.status', () => {
     expect(s.wikiDirSource).toBe('unset');
     expect(s.wikiDir).toBeUndefined();
   });
+
+  it('clamps wikiDirSource=unset to config when wikiDir is present (invariant)', async () => {
+    const j = new AgentJournal({ baseDir: dir, wikiDir: '/tmp/vault', wikiDirSource: 'unset' });
+    const s = await j.status();
+    expect(s.wikiDir).toBe(resolve('/tmp/vault'));
+    // wikiDir 이 있으면 'unset' 은 불가능 — 'config' 로 교정된다.
+    expect(s.wikiDirSource).toBe('config');
+  });
+
+  it('clamps wikiDirSource=env to unset when wikiDir is absent (invariant)', async () => {
+    const j = new AgentJournal({ baseDir: dir, wikiDirSource: 'env' });
+    const s = await j.status();
+    expect(s.wikiDir).toBeUndefined();
+    // wikiDir 이 없으면 넘어온 값 무시하고 항상 'unset'.
+    expect(s.wikiDirSource).toBe('unset');
+  });
+
+  it('clamps dirSource=default to config when baseDir is present (invariant)', async () => {
+    const j = new AgentJournal({ baseDir: dir, dirSource: 'default' });
+    const s = await j.status();
+    // baseDir 이 있으면 'default' 는 불가능 — 'config' 로 교정된다.
+    expect(s.dirSource).toBe('config');
+  });
+
+  it('preserves a valid explicit env source (no over-clamping)', async () => {
+    const j = new AgentJournal({
+      baseDir: dir,
+      wikiDir: '/tmp/vault',
+      dirSource: 'env',
+      wikiDirSource: 'env',
+    });
+    const s = await j.status();
+    expect(s.dirSource).toBe('env');
+    expect(s.wikiDirSource).toBe('env');
+  });
 });
 
 describe('expandTilde', () => {

--- a/src/core/journal.test.ts
+++ b/src/core/journal.test.ts
@@ -170,6 +170,9 @@ describe('AgentJournal.status', () => {
     expect(s.totalEntries).toBe(0);
     expect(s.sizeBytes).toBe(0);
     expect(s.lastEntryAt).toBeUndefined();
+    // 출처 힌트는 write 전에도 항상 노출된다.
+    expect(s.dirSource).toBe('config');
+    expect(s.wikiDirSource).toBe('unset');
   });
 
   it('reports totalEntries / lastEntryAt after writes', async () => {
@@ -205,6 +208,30 @@ describe('AgentJournal.status', () => {
     expect(s.exists).toBe(false);
     expect(s.projectKey).toBe('x-12345678');
   });
+
+  it('surfaces explicit dirSource / wikiDirSource unchanged before and after writes', async () => {
+    const j = new AgentJournal({
+      baseDir: dir,
+      wikiDir: '/tmp/vault',
+      dirSource: 'env',
+      wikiDirSource: 'config',
+    });
+    const before = await j.status();
+    expect(before.dirSource).toBe('env');
+    expect(before.wikiDirSource).toBe('config');
+    await j.append({ content: 'a' });
+    const after = await j.status();
+    expect(after.dirSource).toBe('env');
+    expect(after.wikiDirSource).toBe('config');
+  });
+
+  it('infers dirSource=default / wikiDirSource=unset when neither is provided', async () => {
+    const j = new AgentJournal({ projectKey: 'x-12345678' });
+    const s = await j.status();
+    expect(s.dirSource).toBe('default');
+    expect(s.wikiDirSource).toBe('unset');
+    expect(s.wikiDir).toBeUndefined();
+  });
 });
 
 describe('expandTilde', () => {
@@ -227,7 +254,7 @@ describe('expandTilde', () => {
 });
 
 describe('createJournalFromEnv', () => {
-  it('lets ROCKY_JOURNAL_DIR / ROCKY_JOURNAL_WIKI_DIR win over config', () => {
+  it('lets ROCKY_JOURNAL_DIR / ROCKY_JOURNAL_WIKI_DIR win over config', async () => {
     const prevDir = process.env.ROCKY_JOURNAL_DIR;
     const prevWiki = process.env.ROCKY_JOURNAL_WIKI_DIR;
     try {
@@ -236,20 +263,46 @@ describe('createJournalFromEnv', () => {
       const j = createJournalFromEnv({ dir: '/tmp/config-dir', wikiDir: '/tmp/config-vault' });
       expect(j.getDir()).toBe(resolve(dir));
       expect(j.getWikiDir()).toBe(resolve('/tmp/env-vault'));
+      const s = await j.status();
+      expect(s.dirSource).toBe('env');
+      expect(s.wikiDirSource).toBe('env');
     } finally {
       restoreEnv('ROCKY_JOURNAL_DIR', prevDir);
       restoreEnv('ROCKY_JOURNAL_WIKI_DIR', prevWiki);
     }
   });
 
-  it('falls back to config when env is unset', () => {
+  it('falls back to config when env is unset', async () => {
     const prevDir = process.env.ROCKY_JOURNAL_DIR;
+    const prevWiki = process.env.ROCKY_JOURNAL_WIKI_DIR;
     try {
       delete process.env.ROCKY_JOURNAL_DIR;
+      delete process.env.ROCKY_JOURNAL_WIKI_DIR;
       const j = createJournalFromEnv({ dir });
       expect(j.getDir()).toBe(resolve(dir));
+      const s = await j.status();
+      expect(s.dirSource).toBe('config');
+      // wikiDir 은 config 에도 없으니 unset.
+      expect(s.wikiDirSource).toBe('unset');
     } finally {
       restoreEnv('ROCKY_JOURNAL_DIR', prevDir);
+      restoreEnv('ROCKY_JOURNAL_WIKI_DIR', prevWiki);
+    }
+  });
+
+  it('reports dirSource=default when neither env nor config is set', async () => {
+    const prevDir = process.env.ROCKY_JOURNAL_DIR;
+    const prevWiki = process.env.ROCKY_JOURNAL_WIKI_DIR;
+    try {
+      delete process.env.ROCKY_JOURNAL_DIR;
+      delete process.env.ROCKY_JOURNAL_WIKI_DIR;
+      const j = createJournalFromEnv();
+      const s = await j.status();
+      expect(s.dirSource).toBe('default');
+      expect(s.wikiDirSource).toBe('unset');
+    } finally {
+      restoreEnv('ROCKY_JOURNAL_DIR', prevDir);
+      restoreEnv('ROCKY_JOURNAL_WIKI_DIR', prevWiki);
     }
   });
 });

--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -176,13 +176,16 @@ export interface AgentJournalOptions {
   projectKey?: string;
   /**
    * 저널 dir 의 해석 출처 (status 노출용). `createJournalFromEnv` 가 env/config/기본값
-   * 판정을 넘겨준다. 미지정이면 `baseDir` 유무로 추정한다 — 주어졌으면 `'config'`,
-   * 없으면 `'default'` (직접 생성하는 테스트가 명시 없이도 합리적 값을 얻도록).
+   * 판정을 넘겨준다. 생성자가 불변식(`dirSource === 'default' ⟺ baseDir 미제공`)을
+   * 강제하므로 모순되는 값은 클램프된다 — `baseDir` 없으면 항상 `'default'`,
+   * 있는데 미지정/`'default'` 면 `'config'` 로 교정.
    */
   dirSource?: JournalDirSource;
   /**
-   * wikiDir 의 해석 출처 (status 노출용). 미지정이면 `wikiDir` 유무로 추정한다 —
-   * 주어졌으면 `'config'`, 없으면 `'unset'`.
+   * wikiDir 의 해석 출처 (status 노출용). 생성자가 불변식
+   * (`wikiDirSource === 'unset' ⟺ wikiDir === undefined`)을 강제하므로 모순되는 값은
+   * 클램프된다 — `wikiDir` 없으면 항상 `'unset'`, 있는데 미지정/`'unset'` 이면
+   * `'config'` 로 교정.
    */
   wikiDirSource?: JournalWikiDirSource;
 }
@@ -211,10 +214,25 @@ export class AgentJournal {
         ? resolve(expandTilde(options.wikiDir.trim()))
         : undefined;
     this.projectKey = options.projectKey ?? defaultProjectKey();
-    // 출처가 명시되지 않으면 baseDir / wikiDir 유무로 추정한다 (직접 생성 경로용).
-    // createJournalFromEnv 는 env/config/기본값 판정을 명시적으로 넘겨준다.
-    this.dirSource = options.dirSource ?? (options.baseDir ? 'config' : 'default');
-    this.wikiDirSource = options.wikiDirSource ?? (this.wikiDir ? 'config' : 'unset');
+    // 출처 힌트의 불변식을 생성자에서 강제해 invalid state 를 배제한다 — status 의
+    // discoverability 힌트가 항상 실제 경로 상태와 일치하도록. 유일한 팩토리
+    // createJournalFromEnv 는 이미 일관된 값을 넘기므로 그 경로에선 클램프가 no-op.
+    //
+    // dir: 항상 값이 있으니 `dirSource === 'default' ⟺ baseDir 미제공`.
+    //   baseDir 있으면 'env'|'config' 만 허용 (없거나 'default' 면 'config' 로 클램프).
+    this.dirSource = options.baseDir
+      ? options.dirSource && options.dirSource !== 'default'
+        ? options.dirSource
+        : 'config'
+      : 'default';
+    // wikiDir: `wikiDirSource === 'unset' ⟺ wikiDir === undefined`.
+    //   wikiDir 있으면 'env'|'config' 만 허용 (없거나 'unset' 이면 'config' 로 클램프),
+    //   없으면 항상 'unset'.
+    this.wikiDirSource = this.wikiDir
+      ? options.wikiDirSource && options.wikiDirSource !== 'unset'
+        ? options.wikiDirSource
+        : 'config'
+      : 'unset';
   }
 
   getDir(): string {

--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -119,6 +119,21 @@ export interface JournalSearchOptions {
   kind?: string;
 }
 
+/**
+ * 저널 dir 의 해석 출처. `createJournalFromEnv` 의 우선순위와 1:1 로 대응한다:
+ * env(`ROCKY_JOURNAL_DIR`) 있으면 `'env'`, 없고 config(`journal.dir`) 있으면 `'config'`,
+ * 둘 다 없으면 계산된 프로젝트별 기본 경로라 `'default'`. 이 값을 status 로 노출해,
+ * 소스를 안 읽어도 저장 위치가 어디서 왔는지 / 바꿀 수 있는지 발견 가능하게 한다.
+ */
+export type JournalDirSource = 'env' | 'config' | 'default';
+
+/**
+ * 저널 wikiDir 의 해석 출처. env(`ROCKY_JOURNAL_WIKI_DIR`) 있으면 `'env'`, 없고
+ * config(`journal.wikiDir`) 있으면 `'config'`, 둘 다 없으면 `'unset'` — 미설정이라
+ * `wikiDir` 필드 자체는 빠져도 이 힌트로 curate 대상이 미설정임을 발견 가능하게 한다.
+ */
+export type JournalWikiDirSource = 'env' | 'config' | 'unset';
+
 export interface JournalStatus {
   path: string;
   exists: boolean;
@@ -131,6 +146,18 @@ export interface JournalStatus {
    * 가 journal 을 읽어 이 위치로 markdown 을 컴파일한다. 미설정이면 undefined.
    */
   wikiDir?: string;
+  /**
+   * 저널 저장 dir(`path` 의 부모)이 어디서 왔는지. `'env'` = `ROCKY_JOURNAL_DIR`,
+   * `'config'` = `rocky.json` 의 `journal.dir`, `'default'` = 프로젝트별 기본 경로.
+   * 소스를 안 읽어도 저장 위치가 변경 가능함을 status 만으로 발견하게 하는 힌트.
+   */
+  dirSource: JournalDirSource;
+  /**
+   * 정리 대상 wikiDir 의 출처. `'env'` = `ROCKY_JOURNAL_WIKI_DIR`, `'config'` =
+   * `rocky.json` 의 `journal.wikiDir`, `'unset'` = 미설정(그래서 `wikiDir` 필드도 없음).
+   * `'unset'` 이면 curate 대상을 아직 지정하지 않았고 위 두 방법으로 설정할 수 있다는 뜻.
+   */
+  wikiDirSource: JournalWikiDirSource;
   /** 마지막 `kind:"curate"` watermark 의 timestamp (있으면). 증분 정리의 기준점. */
   lastCurateAt?: string;
   /**
@@ -147,6 +174,17 @@ export interface AgentJournalOptions {
   wikiDir?: string;
   /** 프로젝트 키 override (기본 `defaultProjectKey()`). 테스트에서 고정할 때 쓴다. */
   projectKey?: string;
+  /**
+   * 저널 dir 의 해석 출처 (status 노출용). `createJournalFromEnv` 가 env/config/기본값
+   * 판정을 넘겨준다. 미지정이면 `baseDir` 유무로 추정한다 — 주어졌으면 `'config'`,
+   * 없으면 `'default'` (직접 생성하는 테스트가 명시 없이도 합리적 값을 얻도록).
+   */
+  dirSource?: JournalDirSource;
+  /**
+   * wikiDir 의 해석 출처 (status 노출용). 미지정이면 `wikiDir` 유무로 추정한다 —
+   * 주어졌으면 `'config'`, 없으면 `'unset'`.
+   */
+  wikiDirSource?: JournalWikiDirSource;
 }
 
 const DEFAULT_LIMIT = 20;
@@ -162,6 +200,8 @@ export class AgentJournal {
   private readonly file: string;
   private readonly wikiDir?: string;
   private readonly projectKey: string;
+  private readonly dirSource: JournalDirSource;
+  private readonly wikiDirSource: JournalWikiDirSource;
 
   constructor(options: AgentJournalOptions = {}) {
     this.dir = resolve(options.baseDir ? expandTilde(options.baseDir) : resolveDefaultJournalDir());
@@ -171,6 +211,10 @@ export class AgentJournal {
         ? resolve(expandTilde(options.wikiDir.trim()))
         : undefined;
     this.projectKey = options.projectKey ?? defaultProjectKey();
+    // 출처가 명시되지 않으면 baseDir / wikiDir 유무로 추정한다 (직접 생성 경로용).
+    // createJournalFromEnv 는 env/config/기본값 판정을 명시적으로 넘겨준다.
+    this.dirSource = options.dirSource ?? (options.baseDir ? 'config' : 'default');
+    this.wikiDirSource = options.wikiDirSource ?? (this.wikiDir ? 'config' : 'unset');
   }
 
   getDir(): string {
@@ -335,6 +379,8 @@ export class AgentJournal {
         totalEntries: 0,
         sizeBytes: 0,
         projectKey: this.projectKey,
+        dirSource: this.dirSource,
+        wikiDirSource: this.wikiDirSource,
         ...(this.wikiDir ? { wikiDir: this.wikiDir } : {}),
       };
     }
@@ -354,6 +400,8 @@ export class AgentJournal {
       totalEntries: all.length,
       sizeBytes,
       projectKey: this.projectKey,
+      dirSource: this.dirSource,
+      wikiDirSource: this.wikiDirSource,
       lastEntryAt: last?.timestamp,
       ...(this.wikiDir ? { wikiDir: this.wikiDir } : {}),
       ...(lastCurate ? { lastCurateAt: lastCurate.timestamp } : {}),
@@ -508,7 +556,18 @@ export interface JournalEnvOptions {
 export function createJournalFromEnv(config: JournalEnvOptions = {}): AgentJournal {
   const baseDir = firstNonEmpty(process.env.ROCKY_JOURNAL_DIR, config.dir);
   const wikiDir = firstNonEmpty(process.env.ROCKY_JOURNAL_WIKI_DIR, config.wikiDir);
-  return new AgentJournal({ baseDir, wikiDir });
+  // 해석 출처는 baseDir/wikiDir 계산과 동일한 우선순위로 판정해 status 로 노출한다.
+  const dirSource: JournalDirSource = firstNonEmpty(process.env.ROCKY_JOURNAL_DIR)
+    ? 'env'
+    : firstNonEmpty(config.dir)
+      ? 'config'
+      : 'default';
+  const wikiDirSource: JournalWikiDirSource = firstNonEmpty(process.env.ROCKY_JOURNAL_WIKI_DIR)
+    ? 'env'
+    : firstNonEmpty(config.wikiDir)
+      ? 'config'
+      : 'unset';
+  return new AgentJournal({ baseDir, wikiDir, dirSource, wikiDirSource });
 }
 
 function firstNonEmpty(...values: Array<string | undefined>): string | undefined {

--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -554,19 +554,19 @@ export interface JournalEnvOptions {
  * 저널 인스턴스를 만든다. env 가 명시적 per-process override 라 config 를 이긴다.
  */
 export function createJournalFromEnv(config: JournalEnvOptions = {}): AgentJournal {
-  const baseDir = firstNonEmpty(process.env.ROCKY_JOURNAL_DIR, config.dir);
-  const wikiDir = firstNonEmpty(process.env.ROCKY_JOURNAL_WIKI_DIR, config.wikiDir);
-  // 해석 출처는 baseDir/wikiDir 계산과 동일한 우선순위로 판정해 status 로 노출한다.
-  const dirSource: JournalDirSource = firstNonEmpty(process.env.ROCKY_JOURNAL_DIR)
-    ? 'env'
-    : firstNonEmpty(config.dir)
-      ? 'config'
-      : 'default';
-  const wikiDirSource: JournalWikiDirSource = firstNonEmpty(process.env.ROCKY_JOURNAL_WIKI_DIR)
-    ? 'env'
-    : firstNonEmpty(config.wikiDir)
-      ? 'config'
-      : 'unset';
+  // 소스별 값을 한 번만 추출해 baseDir/dirSource, wikiDir/wikiDirSource 를 파생한다.
+  // firstNonEmpty 가 trim + 빈문자 처리를 하므로 `envDir ?? configDir` 는 기존
+  // `firstNonEmpty(env, config)` 와 동치 — env 우선, 없으면 config, 둘 다 없으면 undefined.
+  const envDir = firstNonEmpty(process.env.ROCKY_JOURNAL_DIR);
+  const configDir = firstNonEmpty(config.dir);
+  const baseDir = envDir ?? configDir;
+  const dirSource: JournalDirSource = envDir ? 'env' : configDir ? 'config' : 'default';
+
+  const envWiki = firstNonEmpty(process.env.ROCKY_JOURNAL_WIKI_DIR);
+  const configWiki = firstNonEmpty(config.wikiDir);
+  const wikiDir = envWiki ?? configWiki;
+  const wikiDirSource: JournalWikiDirSource = envWiki ? 'env' : configWiki ? 'config' : 'unset';
+
   return new AgentJournal({ baseDir, wikiDir, dirSource, wikiDirSource });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ export async function buildServer(options: BuildServerOptions = {}) {
     'journal_append',
     {
       description:
-        '에이전트 저널에 한 줄을 append-only 로 기록한다. 다음 turn 에 인용할 결정 / blocker / 사용자 답변 / 메모를 남길 때 사용. remote 호출 없음. (content: 필수 본문, kind?: decision/blocker/answer/note 등 기본 note, tags?: 문자열 배열, pageId?: 연결할 Notion page id 또는 URL)',
+        '에이전트 저널에 한 줄을 append-only 로 기록한다. 다음 turn 에 인용할 결정 / blocker / 사용자 답변 / 메모를 남길 때 사용. remote 호출 없음. 저장 위치는 `journal.dir`(rocky.json) 또는 `ROCKY_JOURNAL_DIR`(env 우선)로 변경 가능(journal_status 로 확인). (content: 필수 본문, kind?: decision/blocker/answer/note 등 기본 note, tags?: 문자열 배열, pageId?: 연결할 Notion page id 또는 URL)',
       inputSchema: {
         content: z.string(),
         kind: z.string().optional(),
@@ -298,7 +298,7 @@ export async function buildServer(options: BuildServerOptions = {}) {
     'journal_status',
     {
       description:
-        '저널 메타(파일 경로, 존재 여부, 유효 항목 수 — 손상 라인 skip, 바이트 크기, 마지막 항목 시각) + 정리 대상 wikiDir + 마지막 curate watermark 를 조회한다. `/rocky:curate` 가 정리 시작 시 이걸로 wikiDir 과 증분 기준점을 확인한다. remote 호출 없음.',
+        '저널 메타(파일 경로, 존재 여부, 유효 항목 수 — 손상 라인 skip, 바이트 크기, 마지막 항목 시각) + 정리 대상 wikiDir + 마지막 curate watermark + 경로 출처(dirSource / wikiDirSource)를 조회한다. `/rocky:curate` 가 정리 시작 시 이걸로 wikiDir 과 증분 기준점을 확인한다. remote 호출 없음. 저널 저장 위치는 `journal.dir`(rocky.json) 또는 `ROCKY_JOURNAL_DIR`(env 우선)로, curate 정리 위치는 `journal.wikiDir` 또는 `ROCKY_JOURNAL_WIKI_DIR`(env 우선)로 변경 가능하다 — 현재 어디서 왔는지는 dirSource / wikiDirSource 로 확인.',
       inputSchema: {},
     },
     async () => jsonResult(await handleJournalStatus(journal)),


### PR DESCRIPTION
## 배경

`journal.dir` / `ROCKY_JOURNAL_DIR`(저널 JSONL 위치)와 `journal.wikiDir` / `ROCKY_JOURNAL_WIKI_DIR`(curate 정리 위치)가 이미 config·env 로 변경 가능한데, 소스를 읽지 않으면 그 사실을 알 수 없었다 (도구 description·`journal_status` 출력 어디에도 힌트 없음). 이걸 사용처(플러그인 도구 표면)에서 발견 가능하게 만든다. **동작·기본 경로 불변, 순수 additive.**

## 변경

- **`journal_status` 구조화 출력** (`src/core/journal.ts`): `JournalStatus` 에 경로 출처 힌트 두 개 추가.
  - `dirSource: 'env' | 'config' | 'default'` — 저널 저장 dir 이 어디서 왔는지.
  - `wikiDirSource: 'env' | 'config' | 'unset'` — curate 대상 wikiDir 의 출처. `'unset'` 이면 미설정이라 `wikiDir` 필드도 없다 → 미설정일 때도 설정 가능 여부를 발견 가능.
  - 판정은 `createJournalFromEnv` 의 `firstNonEmpty(env, config)` 우선순위와 1:1 대응 (env → config → default/unset).
  - `AgentJournal` 생성자에 `dirSource` / `wikiDirSource` 옵션 추가 — 미지정 시 `baseDir` / `wikiDir` 유무로 추정, `createJournalFromEnv` 는 명시적으로 전달.
- **도구 description** (`src/index.ts`): `journal_status` · `journal_append` 에 저장/정리 위치가 config·env 로 설정 가능함을 안내.
- **문서** (`FEATURES.md`): `journal_status` What 필드 목록에 새 필드 반영.
- **테스트** (`src/core/journal.test.ts`): 새 필드 케이스 추가/갱신.

## 제약 준수

- 기존 필드명·의미·기본 경로·config 키 불변. 새 config 키 없음 → `rocky.schema.json` 변경 없음.

## 게이트

- `bun run check` ✅ / `bun run typecheck` ✅ / `bun test` ✅ (207 pass)

모든 리뷰 코멘트는 한국어로 작성해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)