### PR TITLE
chore(release): 버전 0.10.0 범프

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "rocky",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "rocky Claude Code plugin (Bun runtime). 7 openapi_* tools (cache-first OpenAPI / Swagger spec inspection, endpoint search, tag list) + seo_validate (OG / Twitter Card / JSON-LD / favicon meta validation via ogpeek) + notion_* tools (cache-first Notion page read + refresh diff, delegated to the ntn CLI, registered only when ntn is detected) + worklog_* tools (append-only local JSONL agent journal — the record layer; always registered; formerly journal_*). A Stop hook auto-captures each turn as a kind:\"turn\" worklog entry. Slash commands: /finish (gh CLI), /recall (distills the worklog into an anchored history digest — the organize layer, replacing /curate). Bundled skills: writing-cc-plugin (Claude Code plugin authoring guide + reference) and delegating-to-codex (canonical pattern + guardrails for delegating a self-contained task to a headless OpenAI model via the codex CLI; the /codex command layers a worktree+supervise+merge workflow on top). PR watching is delegated to Claude Code's built-in /autofix-pr. Archived domains (mysql / spec-pact / pr-watch tools) re-enter as separate PRs. 소울(페르소나) 선택: souls/*.md 프리셋 + ~/.config/rocky/souls 커스텀, rocky.json 의 soul 필드로 고정, SessionStart 훅이 매 세션 자동 주입. /rocky:soul 커맨드로 전환.",
   "author": {
     "name": "Minjun Kim"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minjun0219/rocky",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "rocky (named after Project Hail Mary) — a single Bun package shipping a Claude Code plugin (marketplace) plus a host-agnostic openapi-mcp stdio CLI (npm), sharing one OpenAPI / Swagger core. 7 openapi_* tools (cache-first spec inspection, endpoint search, tag list) + 1 seo_validate tool (OG / Twitter Card / JSON-LD / favicon meta validation via ogpeek) + 4 notion_* tools (cache-first Notion page read + refresh diff, delegated to the ntn CLI, plugin-only and registered only when ntn is detected) + 4 worklog_* tools (append-only local JSONL agent journal — the record layer, plugin-only, always registered; formerly journal_*), with a Stop hook auto-capturing each turn and a /recall command distilling the worklog into an anchored history digest. mysql / spec-pact / pr-watch domains live on archive/pre-openapi-only-slim; the opencode plugin is archived in-tree under .archive/agent-toolkit-opencode/.",
   "license": "MIT",
   "author": "Minjun Kim",


### PR DESCRIPTION
## 요약
`0.9.0` → `0.10.0` minor 범프. `package.json` + `.claude-plugin/plugin.json` 두 곳 lockstep 갱신.

## 0.9.0 이후 누적된 신규 feat
- soul(페르소나) 기능 전체 — 프리셋 3종 + `/soul` 커맨드 + SessionStart 자동 주입
- `/issue` — 다른 레포에서 rocky 개선 아이디어를 GitHub Issue 로 캡처
- opencode 호스트 통합 (#80) — `/opencode` 위임 커맨드 + MCP 호스트 문서
- delegating-to-codex 스킬 (#83)

breaking 없음 → minor.

## 게이트
- `bun run check` ✓
- `bun run typecheck` ✓
- `bun test` — 246 pass / 0 fail ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)